### PR TITLE
[codex] Align agentd with Chronicle submit contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This is the desktop component of the work tracked in
 - Window-title pause patterns (Zoom, FaceTime, 1Password…).
 - Batches every 30s or 24 frames, whichever first.
 - Local-only mode persists batches under `~/.evalops/agentd/batches/` as
-  `0o600` JSON; HTTP mode `POST`s to
-  `chronicle.v1.ChronicleService.SubmitBatch` and falls back to local on
+  `0o600` JSON; HTTP mode `POST`s a Connect/proto JSON `SubmitBatchRequest`
+  to `chronicle.v1.ChronicleService.SubmitBatch` and falls back to local on
   failure.
 - Menu-bar UI: pause/resume (`⌃⌥⌘P`), flush now (`⌃⌥⌘F`), reveal batches dir,
   quit.
@@ -41,11 +41,11 @@ Security and relaunch.
 
 ## What's next
 
-- Replace local FNV-1a-based `frameHash` with real SHA-256 via CryptoKit.
-- Wire to `chronicle.v1` when proto/codegen lands
-  ([evalops/platform#1076](https://github.com/evalops/platform/issues/1076)).
+- Consume generated `chronicle.v1` Swift types when the platform SDK publishes
+  them
+  ([evalops/platform#1078](https://github.com/evalops/platform/issues/1078)).
 - ASB artifact upload path
-  ([evalops/platform#1082](https://github.com/evalops/platform/issues/1082)).
+  ([evalops/platform#1084](https://github.com/evalops/platform/issues/1084)).
 - Calendar / Zoom auto-pause via NATS subject
   `chronicle.policy.pause` (siphon-fed).
 - Encryption-at-rest option for local batches.

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -2,7 +2,11 @@ import Foundation
 
 struct AgentConfig: Codable, Sendable {
     var deviceId: String
-    var orgId: String
+    var organizationId: String
+    var workspaceId: String?
+    var userId: String?
+    var projectId: String?
+    var repository: String?
     var endpoint: URL
     var allowedBundleIds: [String]
     var deniedBundleIds: [String]
@@ -13,6 +17,104 @@ struct AgentConfig: Codable, Sendable {
     var batchIntervalSeconds: Double
     var maxFramesPerBatch: Int
     var localOnly: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case deviceId
+        case organizationId
+        case orgId
+        case workspaceId
+        case userId
+        case projectId
+        case repository
+        case endpoint
+        case allowedBundleIds
+        case deniedBundleIds
+        case deniedPathPrefixes
+        case pauseWindowTitlePatterns
+        case captureFps
+        case idleFps
+        case batchIntervalSeconds
+        case maxFramesPerBatch
+        case localOnly
+    }
+
+    init(
+        deviceId: String,
+        organizationId: String,
+        workspaceId: String? = nil,
+        userId: String? = nil,
+        projectId: String? = nil,
+        repository: String? = nil,
+        endpoint: URL,
+        allowedBundleIds: [String],
+        deniedBundleIds: [String],
+        deniedPathPrefixes: [String],
+        pauseWindowTitlePatterns: [String],
+        captureFps: Double,
+        idleFps: Double,
+        batchIntervalSeconds: Double,
+        maxFramesPerBatch: Int,
+        localOnly: Bool
+    ) {
+        self.deviceId = deviceId
+        self.organizationId = organizationId
+        self.workspaceId = workspaceId
+        self.userId = userId
+        self.projectId = projectId
+        self.repository = repository
+        self.endpoint = endpoint
+        self.allowedBundleIds = allowedBundleIds
+        self.deniedBundleIds = deniedBundleIds
+        self.deniedPathPrefixes = deniedPathPrefixes
+        self.pauseWindowTitlePatterns = pauseWindowTitlePatterns
+        self.captureFps = captureFps
+        self.idleFps = idleFps
+        self.batchIntervalSeconds = batchIntervalSeconds
+        self.maxFramesPerBatch = maxFramesPerBatch
+        self.localOnly = localOnly
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        deviceId = try container.decode(String.self, forKey: .deviceId)
+        organizationId = try container.decodeIfPresent(String.self, forKey: .organizationId)
+            ?? container.decodeIfPresent(String.self, forKey: .orgId)
+            ?? "local"
+        workspaceId = try container.decodeIfPresent(String.self, forKey: .workspaceId)
+        userId = try container.decodeIfPresent(String.self, forKey: .userId)
+        projectId = try container.decodeIfPresent(String.self, forKey: .projectId)
+        repository = try container.decodeIfPresent(String.self, forKey: .repository)
+        endpoint = try container.decode(URL.self, forKey: .endpoint)
+        allowedBundleIds = try container.decodeIfPresent([String].self, forKey: .allowedBundleIds) ?? Self.defaultAllowedBundleIds
+        deniedBundleIds = try container.decodeIfPresent([String].self, forKey: .deniedBundleIds) ?? Self.defaultDeniedBundleIds
+        deniedPathPrefixes = try container.decodeIfPresent([String].self, forKey: .deniedPathPrefixes) ?? Self.defaultDeniedPathPrefixes
+        pauseWindowTitlePatterns = try container.decodeIfPresent([String].self, forKey: .pauseWindowTitlePatterns) ?? Self.defaultPauseWindowPatterns
+        captureFps = try container.decodeIfPresent(Double.self, forKey: .captureFps) ?? 1.0
+        idleFps = try container.decodeIfPresent(Double.self, forKey: .idleFps) ?? 0.2
+        batchIntervalSeconds = try container.decodeIfPresent(Double.self, forKey: .batchIntervalSeconds) ?? 30
+        maxFramesPerBatch = try container.decodeIfPresent(Int.self, forKey: .maxFramesPerBatch) ?? 24
+        localOnly = try container.decodeIfPresent(Bool.self, forKey: .localOnly) ?? true
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(deviceId, forKey: .deviceId)
+        try container.encode(organizationId, forKey: .organizationId)
+        try container.encodeIfPresent(workspaceId, forKey: .workspaceId)
+        try container.encodeIfPresent(userId, forKey: .userId)
+        try container.encodeIfPresent(projectId, forKey: .projectId)
+        try container.encodeIfPresent(repository, forKey: .repository)
+        try container.encode(endpoint, forKey: .endpoint)
+        try container.encode(allowedBundleIds, forKey: .allowedBundleIds)
+        try container.encode(deniedBundleIds, forKey: .deniedBundleIds)
+        try container.encode(deniedPathPrefixes, forKey: .deniedPathPrefixes)
+        try container.encode(pauseWindowTitlePatterns, forKey: .pauseWindowTitlePatterns)
+        try container.encode(captureFps, forKey: .captureFps)
+        try container.encode(idleFps, forKey: .idleFps)
+        try container.encode(batchIntervalSeconds, forKey: .batchIntervalSeconds)
+        try container.encode(maxFramesPerBatch, forKey: .maxFramesPerBatch)
+        try container.encode(localOnly, forKey: .localOnly)
+    }
 
     static let defaultAllowedBundleIds: [String] = [
         "com.apple.dt.Xcode",
@@ -53,7 +155,7 @@ struct AgentConfig: Codable, Sendable {
     static func fallback() -> AgentConfig {
         AgentConfig(
             deviceId: ProcessInfo.processInfo.globallyUniqueString,
-            orgId: "local",
+            organizationId: "local",
             endpoint: URL(string: "http://127.0.0.1:8787/chronicle.v1.ChronicleService/SubmitBatch")!,
             allowedBundleIds: defaultAllowedBundleIds,
             deniedBundleIds: defaultDeniedBundleIds,

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -1,11 +1,12 @@
 import Foundation
 import CoreGraphics
+import CryptoKit
 import ImageIO
 import UniformTypeIdentifiers
 
 struct ProcessedFrame: Sendable, Codable {
     let frameHash: String
-    let phash: UInt64
+    let perceptualHash: UInt64
     let capturedAt: Date
     let bundleId: String
     let appName: String
@@ -16,19 +17,112 @@ struct ProcessedFrame: Sendable, Codable {
     let widthPx: Int
     let heightPx: Int
     let bytesPng: Int
+
+    enum CodingKeys: String, CodingKey {
+        case frameHash
+        case perceptualHash
+        case capturedAt
+        case bundleId
+        case appName
+        case windowTitle
+        case documentPath
+        case ocrText
+        case ocrConfidence
+        case widthPx
+        case heightPx
+        case bytesPng
+    }
+
+    init(
+        frameHash: String,
+        perceptualHash: UInt64,
+        capturedAt: Date,
+        bundleId: String,
+        appName: String,
+        windowTitle: String,
+        documentPath: String?,
+        ocrText: String,
+        ocrConfidence: Float,
+        widthPx: Int,
+        heightPx: Int,
+        bytesPng: Int
+    ) {
+        self.frameHash = frameHash
+        self.perceptualHash = perceptualHash
+        self.capturedAt = capturedAt
+        self.bundleId = bundleId
+        self.appName = appName
+        self.windowTitle = windowTitle
+        self.documentPath = documentPath
+        self.ocrText = ocrText
+        self.ocrConfidence = ocrConfidence
+        self.widthPx = widthPx
+        self.heightPx = heightPx
+        self.bytesPng = bytesPng
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        frameHash = try container.decode(String.self, forKey: .frameHash)
+        if let value = try? container.decode(UInt64.self, forKey: .perceptualHash) {
+            perceptualHash = value
+        } else {
+            let raw = try container.decode(String.self, forKey: .perceptualHash)
+            perceptualHash = UInt64(raw) ?? 0
+        }
+        capturedAt = try container.decode(Date.self, forKey: .capturedAt)
+        bundleId = try container.decode(String.self, forKey: .bundleId)
+        appName = try container.decode(String.self, forKey: .appName)
+        windowTitle = try container.decode(String.self, forKey: .windowTitle)
+        documentPath = try container.decodeIfPresent(String.self, forKey: .documentPath)
+        ocrText = try container.decode(String.self, forKey: .ocrText)
+        ocrConfidence = try container.decode(Float.self, forKey: .ocrConfidence)
+        widthPx = try container.decode(Int.self, forKey: .widthPx)
+        heightPx = try container.decode(Int.self, forKey: .heightPx)
+        if let value = try? container.decode(Int.self, forKey: .bytesPng) {
+            bytesPng = value
+        } else {
+            let raw = try container.decode(String.self, forKey: .bytesPng)
+            bytesPng = Int(raw) ?? 0
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(frameHash, forKey: .frameHash)
+        try container.encode(String(perceptualHash), forKey: .perceptualHash)
+        try container.encode(capturedAt, forKey: .capturedAt)
+        try container.encode(bundleId, forKey: .bundleId)
+        try container.encode(appName, forKey: .appName)
+        try container.encode(windowTitle, forKey: .windowTitle)
+        try container.encodeIfPresent(documentPath, forKey: .documentPath)
+        try container.encode(ocrText, forKey: .ocrText)
+        try container.encode(ocrConfidence, forKey: .ocrConfidence)
+        try container.encode(widthPx, forKey: .widthPx)
+        try container.encode(heightPx, forKey: .heightPx)
+        try container.encode(String(bytesPng), forKey: .bytesPng)
+    }
 }
 
 struct Batch: Sendable, Codable {
-    let id: String
+    let batchId: String
     let deviceId: String
-    let orgId: String
+    let organizationId: String
+    let workspaceId: String?
+    let userId: String?
+    let projectId: String?
+    let repository: String?
     let startedAt: Date
     let endedAt: Date
     let frames: [ProcessedFrame]
-    let droppedSecretCount: Int
-    let droppedDuplicateCount: Int
-    let droppedDeniedAppCount: Int
-    let droppedDeniedPathCount: Int
+    let droppedCounts: DropCounts
+}
+
+struct DropCounts: Sendable, Codable {
+    let secret: Int
+    let duplicate: Int
+    let deniedApp: Int
+    let deniedPath: Int
 }
 
 actor FramePipeline {
@@ -108,7 +202,7 @@ actor FramePipeline {
 
         let processed = ProcessedFrame(
             frameHash: frameHash,
-            phash: phash.value,
+            perceptualHash: phash.value,
             capturedAt: frame.timestamp,
             bundleId: ctx.bundleId,
             appName: ctx.appName,
@@ -132,16 +226,22 @@ actor FramePipeline {
     func flush() async {
         guard !pending.isEmpty || hasDrops() else { return }
         let batch = Batch(
-            id: UUID().uuidString,
+            batchId: UUID().uuidString,
             deviceId: config.deviceId,
-            orgId: config.orgId,
+            organizationId: config.organizationId,
+            workspaceId: config.workspaceId,
+            userId: config.userId,
+            projectId: config.projectId,
+            repository: config.repository,
             startedAt: startedAt,
             endedAt: Date(),
             frames: pending,
-            droppedSecretCount: droppedSecret,
-            droppedDuplicateCount: droppedDup,
-            droppedDeniedAppCount: droppedDeniedApp,
-            droppedDeniedPathCount: droppedDeniedPath
+            droppedCounts: DropCounts(
+                secret: droppedSecret,
+                duplicate: droppedDup,
+                deniedApp: droppedDeniedApp,
+                deniedPath: droppedDeniedPath
+            )
         )
         pending.removeAll(keepingCapacity: true)
         droppedSecret = 0; droppedDup = 0; droppedDeniedApp = 0; droppedDeniedPath = 0
@@ -162,18 +262,7 @@ actor FramePipeline {
     }
 
     private func sha256Hex(_ s: String) -> String {
-        let bytes = Array(s.utf8)
-        // Use CommonCrypto via bridging-header would be ideal; v0 falls back to a simple FNV-1a 64
-        // hex'd to 64 chars so the field shape matches the future SHA-256 swap-out.
-        var h: UInt64 = 0xcbf29ce484222325
-        for b in bytes {
-            h ^= UInt64(b)
-            h = h &* 0x100000001b3
-        }
-        let hex64 = String(h, radix: 16)
-        let pad = String(repeating: "0", count: max(0, 16 - hex64.count))
-        let core = pad + hex64
-        // pad out to 64 hex chars to match sha256 width — trivial v0 stand-in
-        return String(repeating: core, count: 4).prefix(64).description
+        let digest = SHA256.hash(data: Data(s.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Sources/agentd/Submitter.swift
+++ b/Sources/agentd/Submitter.swift
@@ -7,42 +7,57 @@ actor Submitter {
     private let localOnly: Bool
     private let session: URLSession
 
-    init(endpoint: URL, localOnly: Bool) {
+    init(endpoint: URL, localOnly: Bool, session: URLSession? = nil) {
         self.endpoint = endpoint
         self.localOnly = localOnly
-        let cfg = URLSessionConfiguration.ephemeral
-        cfg.httpAdditionalHeaders = ["Content-Type": "application/json"]
-        cfg.timeoutIntervalForRequest = 30
-        self.session = URLSession(configuration: cfg)
+        if let session {
+            self.session = session
+        } else {
+            let cfg = URLSessionConfiguration.ephemeral
+            cfg.httpAdditionalHeaders = [
+                "Content-Type": "application/json",
+                "Connect-Protocol-Version": "1"
+            ]
+            cfg.timeoutIntervalForRequest = 30
+            self.session = URLSession(configuration: cfg)
+        }
     }
 
-    func submit(_ batch: Batch) async {
-        let enc = JSONEncoder()
-        enc.dateEncodingStrategy = .iso8601
-        guard let data = try? enc.encode(batch) else {
-            Log.submit.error("batch encode failed id=\(batch.id, privacy: .public)")
-            return
+    @discardableResult
+    func submit(_ batch: Batch) async -> SubmitResult {
+        let data: Data
+        do {
+            data = try encodeSubmitBatchRequest(batch, localOnly: localOnly)
+        } catch {
+            Log.submit.error("batch encode failed id=\(batch.batchId, privacy: .public)")
+            return .failed
         }
 
         if localOnly {
-            await persistLocal(batch.id, data: data)
-            return
+            await persistLocal(batch.batchId, data: data)
+            return .persistedLocal
         }
 
         var req = URLRequest(url: endpoint)
         req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("1", forHTTPHeaderField: "Connect-Protocol-Version")
         req.httpBody = data
         do {
-            let (_, resp) = try await session.data(for: req)
+            let (body, resp) = try await session.data(for: req)
             if let http = resp as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
-                Log.submit.warning("submit status=\(http.statusCode, privacy: .public) batch=\(batch.id, privacy: .public) — falling back to local")
-                await persistLocal(batch.id, data: data)
+                Log.submit.warning("submit status=\(http.statusCode, privacy: .public) batch=\(batch.batchId, privacy: .public) — falling back to local")
+                await persistLocal(batch.batchId, data: data)
+                return .persistedLocal
             } else {
-                Log.submit.info("submit ok batch=\(batch.id, privacy: .public) frames=\(batch.frames.count, privacy: .public)")
+                let response = try? JSONDecoder().decode(SubmitBatchResponse.self, from: body)
+                Log.submit.info("submit ok batch=\(batch.batchId, privacy: .public) frames=\(batch.frames.count, privacy: .public)")
+                return .submitted(response)
             }
         } catch {
             Log.submit.warning("submit error \(error.localizedDescription, privacy: .public) — falling back to local")
-            await persistLocal(batch.id, data: data)
+            await persistLocal(batch.batchId, data: data)
+            return .persistedLocal
         }
     }
 
@@ -55,4 +70,30 @@ actor Submitter {
         try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
         Log.submit.info("local persist \(url.path, privacy: .public)")
     }
+}
+
+struct SubmitBatchRequest: Sendable, Codable {
+    let batch: Batch
+    let localOnly: Bool
+}
+
+struct SubmitBatchResponse: Sendable, Codable, Equatable {
+    let batchId: String?
+    let artifactId: String?
+    let acceptedFrameCount: Int?
+    let droppedFrameCount: Int?
+    let memoryIds: [String]?
+}
+
+enum SubmitResult: Sendable, Equatable {
+    case submitted(SubmitBatchResponse?)
+    case persistedLocal
+    case failed
+}
+
+func encodeSubmitBatchRequest(_ batch: Batch, localOnly: Bool) throws -> Data {
+    let enc = JSONEncoder()
+    enc.dateEncodingStrategy = .iso8601
+    enc.outputFormatting = [.sortedKeys]
+    return try enc.encode(SubmitBatchRequest(batch: batch, localOnly: localOnly))
 }

--- a/Tests/agentdTests/SubmitterTests.swift
+++ b/Tests/agentdTests/SubmitterTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import Foundation
+@testable import agentd
+
+final class SubmitterTests: XCTestCase {
+    func testSubmitBatchEncodingMatchesChronicleProtoJSONShape() throws {
+        let batch = Batch(
+            batchId: "batch_fixture",
+            deviceId: "device_1",
+            organizationId: "org_1",
+            workspaceId: "workspace_1",
+            userId: "user_1",
+            projectId: "project_1",
+            repository: "evalops/platform",
+            startedAt: Date(timeIntervalSince1970: 1),
+            endedAt: Date(timeIntervalSince1970: 2),
+            frames: [
+                ProcessedFrame(
+                    frameHash: String(repeating: "a", count: 64),
+                    perceptualHash: 42,
+                    capturedAt: Date(timeIntervalSince1970: 1),
+                    bundleId: "com.microsoft.VSCode",
+                    appName: "Code",
+                    windowTitle: "chronicle.proto",
+                    documentPath: "/Users/alice/src/platform/proto/chronicle/v1/chronicle.proto",
+                    ocrText: "ChronicleService SubmitBatch",
+                    ocrConfidence: 0.93,
+                    widthPx: 1512,
+                    heightPx: 982,
+                    bytesPng: 120_000
+                )
+            ],
+            droppedCounts: DropCounts(secret: 0, duplicate: 1, deniedApp: 0, deniedPath: 0)
+        )
+
+        let data = try encodeSubmitBatchRequest(batch, localOnly: true)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(root["localOnly"] as? Bool, true)
+        let encodedBatch = try XCTUnwrap(root["batch"] as? [String: Any])
+        XCTAssertEqual(encodedBatch["batchId"] as? String, "batch_fixture")
+        XCTAssertEqual(encodedBatch["organizationId"] as? String, "org_1")
+        XCTAssertEqual(encodedBatch["projectId"] as? String, "project_1")
+        XCTAssertNil(encodedBatch["orgId"])
+
+        let frames = try XCTUnwrap(encodedBatch["frames"] as? [[String: Any]])
+        XCTAssertEqual(frames.first?["perceptualHash"] as? String, "42")
+        XCTAssertEqual(frames.first?["bytesPng"] as? String, "120000")
+        XCTAssertEqual(frames.first?["bundleId"] as? String, "com.microsoft.VSCode")
+        XCTAssertEqual(frames.first?["frameHash"] as? String, String(repeating: "a", count: 64))
+
+        let droppedCounts = try XCTUnwrap(encodedBatch["droppedCounts"] as? [String: Any])
+        XCTAssertEqual(droppedCounts["duplicate"] as? Int, 1)
+    }
+
+    func testAgentConfigDecodesLegacyOrgIdAndEncodesOrganizationId() throws {
+        let legacy = """
+        {
+          "deviceId": "device_1",
+          "orgId": "org_legacy",
+          "endpoint": "http://127.0.0.1:8787/chronicle.v1.ChronicleService/SubmitBatch",
+          "localOnly": true
+        }
+        """.data(using: .utf8)!
+
+        let cfg = try JSONDecoder().decode(AgentConfig.self, from: legacy)
+        XCTAssertEqual(cfg.organizationId, "org_legacy")
+        XCTAssertEqual(cfg.allowedBundleIds, AgentConfig.defaultAllowedBundleIds)
+
+        let encoded = try JSONEncoder().encode(cfg)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        XCTAssertEqual(root["organizationId"] as? String, "org_legacy")
+        XCTAssertNil(root["orgId"])
+    }
+}


### PR DESCRIPTION
## Summary
- encode `agentd` batches as `chronicle.v1.SubmitBatchRequest` Connect/proto JSON
- replace placeholder frame hashes with CryptoKit SHA-256 and encode int64/uint64 fields in protojson-compatible string form
- migrate config from legacy `orgId` to `organizationId` while preserving backwards decode compatibility
- add optional workspace/user/project/repository identifiers and submitter/config tests for the wire format accepted by Platform PR evalops/platform#1086

## Validation
- `swift test`
- PR checks: Socket and Cursor Bugbot passing

Companion to evalops/platform#1086 for evalops/platform#1075 / #1079.