### PR TITLE
Add Secret Broker artifact submit path

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -60,6 +60,13 @@ are resolved from Keychain. They are not stored in `config.json`. mTLS identitie
 are resolved from Keychain by label and attached through URLSession client
 certificate authentication.
 
+When `secretBroker` is configured, agentd first calls the Secret Broker
+`/v1/artifacts:wrap` route with the frame batch in the
+`chronicle_frame_batch_json` secret-data field. Chronicle then receives only the
+broker `artifact_id`, `grant_id`, and session token needed to unwrap the batch on
+the Platform side. If wrapping or Chronicle submission fails, local fallback
+stores the original inline batch JSON and omits broker session-token fields.
+
 ## Drop And Scrub Behavior
 
 agentd drops a frame before batching when:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ events for `cmd/chronicle` in `evalops/platform`.
 This is the desktop component of the work tracked in
 [evalops/platform#1075](https://github.com/evalops/platform/issues/1075).
 
-## What it does (v0)
+## What it does
 
 - Captures the active display via `ScreenCaptureKit` at an adaptive 0.2–1 fps;
   input idle time drops cadence to `idleFps` and activity restores
@@ -33,6 +33,9 @@ This is the desktop component of the work tracked in
   `chronicle.v1.ChronicleService.SubmitBatch` and falls back to local on
   failure. Remote HTTP is allowed only for loopback development; non-loopback
   remote endpoints must use HTTPS and configured client auth.
+- Optional Secret Broker mode wraps the frame batch into a broker artifact
+  (`chronicle_frame_batch_json`) first, then sends only the artifact/session
+  reference to Chronicle so Platform can unwrap, meter, and revoke through ASB.
 - Menu-bar UI: pause/resume (`⌃⌥⌘P`), flush now (`⌃⌥⌘F`), reveal batches dir,
   quit.
 
@@ -87,13 +90,29 @@ mTLS auth references a Keychain identity label:
 }
 ```
 
+Secret Broker artifact mode adds a second endpoint plus a Keychain-backed
+session token reference. The endpoint is the Secret Broker HTTP
+`/v1/artifacts:wrap` route:
+
+```json
+{
+  "secretBroker": {
+    "endpoint": "https://secret-broker.example.com/v1/artifacts:wrap",
+    "sessionTokenKeychainService": "dev.evalops.agentd",
+    "sessionTokenKeychainAccount": "secret-broker",
+    "ttlSeconds": 300
+  }
+}
+```
+
+If wrapping fails, agentd persists the original inline `SubmitBatchRequest`
+locally and does not write the broker session token to disk.
+
 ## What's next
 
 - Consume generated `chronicle.v1` Swift types when the platform SDK publishes
   them
   ([evalops/platform#1078](https://github.com/evalops/platform/issues/1078)).
-- ASB artifact upload path
-  ([evalops/platform#1084](https://github.com/evalops/platform/issues/1084)).
 - Calendar / Zoom auto-pause via NATS subject
   `chronicle.policy.pause` (siphon-fed).
 - Encryption-at-rest option for local batches.

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -75,6 +75,7 @@ struct AgentConfig: Codable, Sendable {
   var idlePollSeconds: Double
   var localOnly: Bool
   var auth: AuthMode
+  var secretBroker: SecretBrokerConfig?
 
   enum CodingKeys: String, CodingKey {
     case deviceId
@@ -100,6 +101,7 @@ struct AgentConfig: Codable, Sendable {
     case idlePollSeconds
     case localOnly
     case auth
+    case secretBroker
   }
 
   init(
@@ -124,7 +126,8 @@ struct AgentConfig: Codable, Sendable {
     idleThresholdSeconds: Double = 60,
     idlePollSeconds: Double = 5,
     localOnly: Bool,
-    auth: AuthMode = .none
+    auth: AuthMode = .none,
+    secretBroker: SecretBrokerConfig? = nil
   ) {
     self.deviceId = deviceId
     self.organizationId = organizationId
@@ -148,6 +151,7 @@ struct AgentConfig: Codable, Sendable {
     self.idlePollSeconds = idlePollSeconds
     self.localOnly = localOnly
     self.auth = auth
+    self.secretBroker = secretBroker
   }
 
   init(from decoder: Decoder) throws {
@@ -188,6 +192,7 @@ struct AgentConfig: Codable, Sendable {
     idlePollSeconds = try container.decodeIfPresent(Double.self, forKey: .idlePollSeconds) ?? 5
     localOnly = try container.decodeIfPresent(Bool.self, forKey: .localOnly) ?? true
     auth = try container.decodeIfPresent(AuthMode.self, forKey: .auth) ?? .none
+    secretBroker = try container.decodeIfPresent(SecretBrokerConfig.self, forKey: .secretBroker)
   }
 
   func encode(to encoder: Encoder) throws {
@@ -214,6 +219,7 @@ struct AgentConfig: Codable, Sendable {
     try container.encode(idlePollSeconds, forKey: .idlePollSeconds)
     try container.encode(localOnly, forKey: .localOnly)
     try container.encode(auth, forKey: .auth)
+    try container.encodeIfPresent(secretBroker, forKey: .secretBroker)
   }
 
   static let defaultAllowedBundleIds: [String] = [
@@ -271,7 +277,67 @@ struct AgentConfig: Codable, Sendable {
       idleThresholdSeconds: 60,
       idlePollSeconds: 5,
       localOnly: true,
-      auth: .none
+      auth: .none,
+      secretBroker: nil
+    )
+  }
+}
+
+struct SecretBrokerConfig: Codable, Sendable, Equatable {
+  var endpoint: URL
+  var sessionTokenKeychainService: String
+  var sessionTokenKeychainAccount: String
+  var ttlSeconds: Int
+  var tool: String
+  var capability: String
+  var reason: String
+
+  enum CodingKeys: String, CodingKey {
+    case endpoint
+    case sessionTokenKeychainService
+    case sessionTokenKeychainAccount
+    case ttlSeconds
+    case tool
+    case capability
+    case reason
+  }
+
+  init(
+    endpoint: URL,
+    sessionTokenKeychainService: String,
+    sessionTokenKeychainAccount: String,
+    ttlSeconds: Int = 300,
+    tool: String = "chronicle.agentd",
+    capability: String = "chronicle.frame_batch",
+    reason: String = "agentd Chronicle frame batch"
+  ) {
+    self.endpoint = endpoint
+    self.sessionTokenKeychainService = sessionTokenKeychainService
+    self.sessionTokenKeychainAccount = sessionTokenKeychainAccount
+    self.ttlSeconds = ttlSeconds
+    self.tool = tool
+    self.capability = capability
+    self.reason = reason
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.init(
+      endpoint: try container.decode(URL.self, forKey: .endpoint),
+      sessionTokenKeychainService: try container.decode(
+        String.self,
+        forKey: .sessionTokenKeychainService
+      ),
+      sessionTokenKeychainAccount: try container.decode(
+        String.self,
+        forKey: .sessionTokenKeychainAccount
+      ),
+      ttlSeconds: try container.decodeIfPresent(Int.self, forKey: .ttlSeconds) ?? 300,
+      tool: try container.decodeIfPresent(String.self, forKey: .tool) ?? "chronicle.agentd",
+      capability: try container.decodeIfPresent(String.self, forKey: .capability)
+        ?? "chronicle.frame_batch",
+      reason: try container.decodeIfPresent(String.self, forKey: .reason)
+        ?? "agentd Chronicle frame batch"
     )
   }
 }

--- a/Sources/agentd/Submitter.swift
+++ b/Sources/agentd/Submitter.swift
@@ -10,6 +10,7 @@ actor Submitter {
   private let localOnly: Bool
   private let client: any HTTPClient
   private let auth: ResolvedSubmitterAuth
+  private let secretBroker: ResolvedSecretBrokerConfig?
   private let batchDirectory: URL
   private let maxBatchBytes: Int64
   private let maxBatchAgeDays: Double
@@ -18,6 +19,7 @@ actor Submitter {
     endpoint: URL,
     localOnly: Bool,
     authMode: AuthMode = .none,
+    secretBroker: SecretBrokerConfig? = nil,
     credentialProvider: any SubmitterCredentialProviding = KeychainCredentialProvider(),
     session: URLSession? = nil,
     client: (any HTTPClient)? = nil,
@@ -31,10 +33,23 @@ actor Submitter {
     guard localOnly || authMode != .none else {
       throw SubmitterInitError.missingRemoteAuth
     }
+    if let secretBroker, !localOnly {
+      guard EndpointPolicy.isAllowed(endpoint: secretBroker.endpoint, localOnly: false) else {
+        throw SubmitterInitError.insecureRemoteEndpoint(secretBroker.endpoint.absoluteString)
+      }
+    }
 
     self.endpoint = endpoint
     self.localOnly = localOnly
     self.auth = try ResolvedSubmitterAuth(mode: authMode, credentialProvider: credentialProvider)
+    if let secretBroker, !localOnly {
+      self.secretBroker = try ResolvedSecretBrokerConfig(
+        config: secretBroker,
+        credentialProvider: credentialProvider
+      )
+    } else {
+      self.secretBroker = nil
+    }
     self.batchDirectory =
       batchDirectory
       ?? FileManager.default.homeDirectoryForCurrentUser
@@ -73,27 +88,48 @@ actor Submitter {
 
   @discardableResult
   func submit(_ batch: Batch) async -> SubmitResult {
-    let data: Data
+    let fallbackData: Data
     do {
-      data = try encodeSubmitBatchRequest(batch, localOnly: localOnly)
+      fallbackData = try encodeSubmitBatchRequest(batch, localOnly: localOnly)
     } catch {
       Log.submit.error("batch encode failed id=\(batch.batchId, privacy: .public)")
       return .failed
     }
 
     if localOnly {
-      await persistLocal(batch.batchId, data: data)
+      await persistLocal(batch.batchId, data: fallbackData)
       return .persistedLocal
     }
 
-    let req = makeRequest(body: data)
+    let submitData: Data
+    if let secretBroker {
+      do {
+        let wrapped = try await wrapFrameBatch(batch, using: secretBroker)
+        submitData = try encodeBrokerSubmitBatchRequest(
+          sessionToken: secretBroker.sessionToken,
+          artifactId: wrapped.artifactId,
+          grantId: wrapped.grantId,
+          localOnly: localOnly
+        )
+      } catch {
+        Log.submit.warning(
+          "secret broker wrap failed batch=\(batch.batchId, privacy: .public) error=\(error.localizedDescription, privacy: .public) — falling back to local"
+        )
+        await persistLocal(batch.batchId, data: fallbackData)
+        return .persistedLocal
+      }
+    } else {
+      submitData = fallbackData
+    }
+
+    let req = makeRequest(body: submitData)
     do {
       let (body, resp) = try await client.data(for: req)
       if let http = resp as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
         Log.submit.warning(
           "submit status=\(http.statusCode, privacy: .public) batch=\(batch.batchId, privacy: .public) — falling back to local"
         )
-        await persistLocal(batch.batchId, data: data)
+        await persistLocal(batch.batchId, data: fallbackData)
         return .persistedLocal
       } else {
         let response: SubmitBatchResponse?
@@ -106,7 +142,7 @@ actor Submitter {
             Log.submit.warning(
               "submit malformed response batch=\(batch.batchId, privacy: .public) — falling back to local"
             )
-            await persistLocal(batch.batchId, data: data)
+            await persistLocal(batch.batchId, data: fallbackData)
             return .persistedLocal
           }
         }
@@ -119,7 +155,7 @@ actor Submitter {
     } catch {
       Log.submit.warning(
         "submit error \(error.localizedDescription, privacy: .public) — falling back to local")
-      await persistLocal(batch.batchId, data: data)
+      await persistLocal(batch.batchId, data: fallbackData)
       return .persistedLocal
     }
   }
@@ -134,6 +170,51 @@ actor Submitter {
     }
     req.httpBody = body
     return req
+  }
+
+  private func makeSecretBrokerRequest(endpoint: URL, body: Data) -> URLRequest {
+    var req = URLRequest(url: endpoint)
+    req.httpMethod = "POST"
+    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    req.httpBody = body
+    return req
+  }
+
+  private func wrapFrameBatch(
+    _ batch: Batch,
+    using secretBroker: ResolvedSecretBrokerConfig
+  ) async throws -> WrappedArtifact {
+    let payload = try encodeFrameBatch(batch)
+    guard let payloadJSON = String(data: payload, encoding: .utf8) else {
+      throw SubmitterError.invalidBatchPayload
+    }
+    let request = WrapArtifactRequest(
+      sessionToken: secretBroker.sessionToken,
+      tool: secretBroker.tool,
+      capability: secretBroker.capability,
+      resourceRef: "chronicle://\(batch.organizationId)/\(batch.deviceId)/\(batch.batchId)",
+      ttlSeconds: secretBroker.ttlSeconds,
+      reason: secretBroker.reason,
+      secretData: ["chronicle_frame_batch_json": payloadJSON],
+      metadata: [
+        "batch_id": batch.batchId,
+        "device_id": batch.deviceId,
+        "organization_id": batch.organizationId,
+        "source": "agentd",
+      ]
+    )
+    let data = try encodeWrapArtifactRequest(request)
+    let (body, resp) = try await client.data(
+      for: makeSecretBrokerRequest(endpoint: secretBroker.endpoint, body: data)
+    )
+    if let http = resp as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+      throw SubmitterError.secretBrokerStatus(http.statusCode)
+    }
+    let wrapped = try JSONDecoder().decode(WrapArtifactResponse.self, from: body)
+    guard !wrapped.artifactId.isEmpty, !wrapped.grantId.isEmpty else {
+      throw SubmitterError.malformedSecretBrokerResponse
+    }
+    return WrappedArtifact(artifactId: wrapped.artifactId, grantId: wrapped.grantId)
   }
 
   private func persistLocal(_ id: String, data: Data) async {
@@ -359,8 +440,25 @@ private final class MTLSURLSessionDelegate: NSObject, URLSessionDelegate, @unche
 }
 
 struct SubmitBatchRequest: Sendable, Codable {
-  let batch: Batch
+  let batch: Batch?
   let localOnly: Bool
+  let secretBrokerSessionToken: String?
+  let secretBrokerArtifactId: String?
+  let secretBrokerGrantId: String?
+
+  init(
+    batch: Batch? = nil,
+    localOnly: Bool,
+    secretBrokerSessionToken: String? = nil,
+    secretBrokerArtifactId: String? = nil,
+    secretBrokerGrantId: String? = nil
+  ) {
+    self.batch = batch
+    self.localOnly = localOnly
+    self.secretBrokerSessionToken = secretBrokerSessionToken
+    self.secretBrokerArtifactId = secretBrokerArtifactId
+    self.secretBrokerGrantId = secretBrokerGrantId
+  }
 }
 
 struct SubmitBatchResponse: Sendable, Codable, Equatable {
@@ -377,9 +475,127 @@ enum SubmitResult: Sendable, Equatable {
   case failed
 }
 
+enum SubmitterError: Error, LocalizedError {
+  case invalidBatchPayload
+  case secretBrokerStatus(Int)
+  case malformedSecretBrokerResponse
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidBatchPayload:
+      return "frame batch could not be encoded as UTF-8 JSON"
+    case .secretBrokerStatus(let status):
+      return "secret broker wrap returned HTTP \(status)"
+    case .malformedSecretBrokerResponse:
+      return "secret broker wrap response did not include artifact and grant ids"
+    }
+  }
+}
+
+struct ResolvedSecretBrokerConfig: Sendable, Equatable {
+  let endpoint: URL
+  let sessionToken: String
+  let ttlSeconds: Int
+  let tool: String
+  let capability: String
+  let reason: String
+
+  init(
+    config: SecretBrokerConfig,
+    credentialProvider: any SubmitterCredentialProviding
+  ) throws {
+    let sessionToken = try credentialProvider.bearerToken(
+      service: config.sessionTokenKeychainService,
+      account: config.sessionTokenKeychainAccount
+    )
+    guard !sessionToken.isEmpty else {
+      throw SubmitterInitError.missingBearerToken(
+        service: config.sessionTokenKeychainService,
+        account: config.sessionTokenKeychainAccount
+      )
+    }
+    self.endpoint = config.endpoint
+    self.sessionToken = sessionToken
+    self.ttlSeconds = config.ttlSeconds
+    self.tool = config.tool
+    self.capability = config.capability
+    self.reason = config.reason
+  }
+}
+
+struct WrappedArtifact: Sendable, Equatable {
+  let artifactId: String
+  let grantId: String
+}
+
+struct WrapArtifactRequest: Sendable, Codable {
+  let sessionToken: String
+  let tool: String
+  let capability: String
+  let resourceRef: String
+  let ttlSeconds: Int
+  let reason: String
+  let secretData: [String: String]
+  let metadata: [String: String]
+
+  enum CodingKeys: String, CodingKey {
+    case sessionToken = "session_token"
+    case tool
+    case capability
+    case resourceRef = "resource_ref"
+    case ttlSeconds = "ttl_seconds"
+    case reason
+    case secretData = "secret_data"
+    case metadata
+  }
+}
+
+struct WrapArtifactResponse: Sendable, Codable, Equatable {
+  let grantId: String
+  let artifactId: String
+
+  enum CodingKeys: String, CodingKey {
+    case grantId = "grant_id"
+    case artifactId = "artifact_id"
+  }
+}
+
 func encodeSubmitBatchRequest(_ batch: Batch, localOnly: Bool) throws -> Data {
+  try encodeSubmitBatchRequest(SubmitBatchRequest(batch: batch, localOnly: localOnly))
+}
+
+func encodeBrokerSubmitBatchRequest(
+  sessionToken: String,
+  artifactId: String,
+  grantId: String,
+  localOnly: Bool
+) throws -> Data {
+  try encodeSubmitBatchRequest(
+    SubmitBatchRequest(
+      localOnly: localOnly,
+      secretBrokerSessionToken: sessionToken,
+      secretBrokerArtifactId: artifactId,
+      secretBrokerGrantId: grantId
+    ))
+}
+
+private func encodeSubmitBatchRequest(_ request: SubmitBatchRequest) throws -> Data {
   let enc = JSONEncoder()
   enc.dateEncodingStrategy = .iso8601
   enc.outputFormatting = [.sortedKeys]
-  return try enc.encode(SubmitBatchRequest(batch: batch, localOnly: localOnly))
+  return try enc.encode(request)
+}
+
+func encodeFrameBatch(_ batch: Batch) throws -> Data {
+  let enc = JSONEncoder()
+  enc.dateEncodingStrategy = .iso8601
+  enc.outputFormatting = [.sortedKeys]
+  return try enc.encode(batch)
+}
+
+func encodeWrapArtifactRequest(_ request: WrapArtifactRequest) throws -> Data {
+  let enc = JSONEncoder()
+  enc.dateEncodingStrategy = .iso8601
+  enc.outputFormatting = [.sortedKeys]
+  return try enc.encode(request)
 }

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -25,6 +25,7 @@ final class AppController {
         endpoint: cfg.endpoint,
         localOnly: cfg.localOnly,
         authMode: cfg.auth,
+        secretBroker: cfg.secretBroker,
         maxBatchBytes: cfg.maxBatchBytes,
         maxBatchAgeDays: cfg.maxBatchAgeDays
       )

--- a/Tests/agentdTests/SubmitterTests.swift
+++ b/Tests/agentdTests/SubmitterTests.swift
@@ -93,6 +93,43 @@ final class SubmitterTests: XCTestCase {
     XCTAssertEqual(cfg.organizationId, "org_new")
   }
 
+  func testAgentConfigDecodesSecretBroker() throws {
+    let data = """
+      {
+        "deviceId": "device_1",
+        "organizationId": "org_1",
+        "endpoint": "https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch",
+        "localOnly": false,
+        "auth": {
+          "mode": "bearer",
+          "keychainService": "agentd",
+          "keychainAccount": "chronicle"
+        },
+        "secretBroker": {
+          "endpoint": "https://secret-broker.example.com/v1/artifacts:wrap",
+          "sessionTokenKeychainService": "agentd",
+          "sessionTokenKeychainAccount": "secret-broker",
+          "ttlSeconds": 120
+        }
+      }
+      """.data(using: .utf8)!
+
+    let cfg = try JSONDecoder().decode(AgentConfig.self, from: data)
+
+    XCTAssertEqual(
+      cfg.secretBroker?.endpoint,
+      URL(string: "https://secret-broker.example.com/v1/artifacts:wrap")!)
+    XCTAssertEqual(cfg.secretBroker?.sessionTokenKeychainService, "agentd")
+    XCTAssertEqual(cfg.secretBroker?.sessionTokenKeychainAccount, "secret-broker")
+    XCTAssertEqual(cfg.secretBroker?.ttlSeconds, 120)
+    XCTAssertEqual(cfg.secretBroker?.tool, "chronicle.agentd")
+    XCTAssertEqual(cfg.secretBroker?.capability, "chronicle.frame_batch")
+
+    let encoded = try JSONEncoder().encode(cfg)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+    XCTAssertNotNil(root["secretBroker"])
+  }
+
   func testEndpointPolicyRejectsPlainHttpRemoteAndAllowsHttpsAndLoopback() throws {
     let provider = StubCredentialProvider(token: "token")
     XCTAssertNoThrow(
@@ -152,6 +189,129 @@ final class SubmitterTests: XCTestCase {
     let request = await submitter.makeRequest(body: Data("{}".utf8))
     XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer secret-token")
     XCTAssertEqual(request.value(forHTTPHeaderField: "Connect-Protocol-Version"), "1")
+  }
+
+  func testSecretBrokerWrapSubmitsArtifactReferenceToChronicle() async throws {
+    let recorder = RequestRecorder()
+    let client = StubHTTPClient { request in
+      await recorder.record(request)
+      let url = try XCTUnwrap(request.url)
+      let body = try XCTUnwrap(request.httpBody)
+      let root = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+      if url.host == "secret-broker.example.com" {
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+        XCTAssertEqual(root["session_token"] as? String, "broker-session")
+        XCTAssertEqual(root["tool"] as? String, "chronicle.agentd")
+        XCTAssertEqual(root["capability"] as? String, "chronicle.frame_batch")
+        XCTAssertEqual(root["ttl_seconds"] as? Int, 300)
+
+        let secretData = try XCTUnwrap(root["secret_data"] as? [String: String])
+        let batchJSON = try XCTUnwrap(secretData["chronicle_frame_batch_json"])
+        let batchData = Data(batchJSON.utf8)
+        let batchRoot = try XCTUnwrap(
+          JSONSerialization.jsonObject(with: batchData) as? [String: Any])
+        XCTAssertEqual(batchRoot["batchId"] as? String, "batch_fixture")
+        XCTAssertEqual(batchRoot["organizationId"] as? String, "org_1")
+
+        let metadata = try XCTUnwrap(root["metadata"] as? [String: String])
+        XCTAssertEqual(metadata["source"], "agentd")
+        XCTAssertEqual(metadata["batch_id"], "batch_fixture")
+
+        let response = """
+          {
+            "grant_id": "grant_1",
+            "state": "issued",
+            "delivery": {"artifact_id": "art_1"},
+            "expires_at": "2026-04-27T00:00:00Z",
+            "artifact_id": "art_1"
+          }
+          """
+        return (Data(response.utf8), Self.response(for: url, statusCode: 200))
+      }
+
+      XCTAssertEqual(url.host, "chronicle.example.com")
+      XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer chronicle-token")
+      XCTAssertEqual(root["secretBrokerSessionToken"] as? String, "broker-session")
+      XCTAssertEqual(root["secretBrokerArtifactId"] as? String, "art_1")
+      XCTAssertEqual(root["secretBrokerGrantId"] as? String, "grant_1")
+      XCTAssertNil(root["batch"])
+
+      return (
+        Data(
+          #"{"batchId":"batch_fixture","artifactId":"art_1","acceptedFrameCount":1,"droppedFrameCount":0,"memoryIds":["mem_1"]}"#
+            .utf8),
+        Self.response(for: url, statusCode: 200)
+      )
+    }
+    let submitter = try Submitter(
+      endpoint: URL(
+        string: "https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch")!,
+      localOnly: false,
+      authMode: .bearer(keychainService: "agentd", keychainAccount: "chronicle"),
+      secretBroker: SecretBrokerConfig(
+        endpoint: URL(string: "https://secret-broker.example.com/v1/artifacts:wrap")!,
+        sessionTokenKeychainService: "agentd",
+        sessionTokenKeychainAccount: "secret-broker"
+      ),
+      credentialProvider: StubCredentialProvider(tokens: [
+        "agentd:chronicle": "chronicle-token",
+        "agentd:secret-broker": "broker-session",
+      ]),
+      client: client
+    )
+
+    let result = await submitter.submit(Self.batch())
+
+    XCTAssertEqual(
+      result,
+      .submitted(
+        SubmitBatchResponse(
+          batchId: "batch_fixture",
+          artifactId: "art_1",
+          acceptedFrameCount: 1,
+          droppedFrameCount: 0,
+          memoryIds: ["mem_1"]
+        )))
+    let requestCount = await recorder.count()
+    XCTAssertEqual(requestCount, 2)
+  }
+
+  func testSecretBrokerWrapFailurePersistsInlineBatchWithoutSessionToken() async throws {
+    let recorder = RequestRecorder()
+    let dir = try makeTemporaryDirectory()
+    let submitter = try Submitter(
+      endpoint: URL(
+        string: "https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch")!,
+      localOnly: false,
+      authMode: .bearer(keychainService: "agentd", keychainAccount: "chronicle"),
+      secretBroker: SecretBrokerConfig(
+        endpoint: URL(string: "https://secret-broker.example.com/v1/artifacts:wrap")!,
+        sessionTokenKeychainService: "agentd",
+        sessionTokenKeychainAccount: "secret-broker"
+      ),
+      credentialProvider: StubCredentialProvider(tokens: [
+        "agentd:chronicle": "chronicle-token",
+        "agentd:secret-broker": "broker-session",
+      ]),
+      client: StubHTTPClient { request in
+        await recorder.record(request)
+        return (Data(#"{"error":"nope"}"#.utf8), Self.response(for: request.url!, statusCode: 500))
+      },
+      batchDirectory: dir
+    )
+
+    let result = await submitter.submit(Self.batch())
+
+    XCTAssertEqual(result, .persistedLocal)
+    let requestCount = await recorder.count()
+    XCTAssertEqual(requestCount, 1)
+    let persisted = try Data(contentsOf: dir.appendingPathComponent("batch_fixture.json"))
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: persisted) as? [String: Any])
+    XCTAssertNotNil(root["batch"])
+    XCTAssertNil(root["secretBrokerSessionToken"])
+    XCTAssertNil(root["secretBrokerArtifactId"])
+    XCTAssertNil(root["secretBrokerGrantId"])
   }
 
   func testSubmitterPersistsLocalOnServerAndTransportFailures() async throws {
@@ -270,13 +430,42 @@ final class SubmitterTests: XCTestCase {
     try Data(repeating: 0x41, count: bytes).write(to: url)
     try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: url.path)
   }
+
+  fileprivate static func response(for url: URL, statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: url,
+      statusCode: statusCode,
+      httpVersion: "HTTP/1.1",
+      headerFields: nil
+    )!
+  }
+}
+
+actor RequestRecorder {
+  private var requests: [URLRequest] = []
+
+  func record(_ request: URLRequest) {
+    requests.append(request)
+  }
+
+  func count() -> Int {
+    requests.count
+  }
 }
 
 struct StubCredentialProvider: SubmitterCredentialProviding {
-  let token: String
+  let tokens: [String: String]
+
+  init(token: String) {
+    self.tokens = ["svc:acct": token]
+  }
+
+  init(tokens: [String: String]) {
+    self.tokens = tokens
+  }
 
   func bearerToken(service: String, account: String) throws -> String {
-    token
+    tokens["\(service):\(account)"] ?? ""
   }
 
   func clientIdentity(label: String) throws -> ClientIdentity {
@@ -297,13 +486,7 @@ struct StubHTTPClient: HTTPClient {
 
   static func status(_ statusCode: Int, body: String) -> StubHTTPClient {
     StubHTTPClient { request in
-      let response = HTTPURLResponse(
-        url: request.url!,
-        statusCode: statusCode,
-        httpVersion: "HTTP/1.1",
-        headerFields: nil
-      )!
-      return (Data(body.utf8), response)
+      (Data(body.utf8), SubmitterTests.response(for: request.url!, statusCode: statusCode))
     }
   }
 


### PR DESCRIPTION
## Summary

- add optional `secretBroker` config that resolves the broker session token from Keychain
- wrap frame batches through Secret Broker `/v1/artifacts:wrap` before Chronicle submission when configured
- submit only broker artifact/grant/session refs to Chronicle and keep local fallback inline without broker session-token fields

## Testing

- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `git diff --check`