### PR TITLE
[codex] Add managed Chronicle heartbeat policy sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ This is the desktop component of the work tracked in
 - Optional Secret Broker mode wraps the frame batch into a broker artifact
   (`chronicle_frame_batch_json`) first, then sends only the artifact/session
   reference to Chronicle so Platform can unwrap, meter, and revoke through ASB.
+- Remote mode registers the device with Chronicle, sends periodic heartbeats
+  with pending local queue pressure, and applies server-returned capture policy
+  without requiring an app restart. Local hard-deny safety rails remain
+  fail-closed even when a remote policy allows a bundle or path.
 - Menu-bar UI: pause/resume (`⌃⌥⌘P`), flush now (`⌃⌥⌘F`), reveal batches dir,
   quit.
 
@@ -137,6 +141,30 @@ session token reference. The endpoint is the Secret Broker HTTP
 If wrapping fails, agentd persists the original inline `SubmitBatchRequest`
 locally and does not write the broker session token to disk.
 
+When `localOnly` is `false`, agentd derives the other Chronicle control-plane
+RPC URLs from `endpoint`. For example:
+
+```json
+{
+  "endpoint": "https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch",
+  "localOnly": false,
+  "auth": {
+    "mode": "bearer",
+    "keychainService": "dev.evalops.agentd",
+    "keychainAccount": "chronicle"
+  }
+}
+```
+
+On boot, agentd calls `RegisterDevice` with app version, hostname, capture mode,
+Secret Broker mode, and local permission preflight metadata. Every 30 seconds it
+calls `Heartbeat` with pending in-memory frames plus local fallback batch count
+and bytes. `RegisterDevice` and `Heartbeat` responses may include a
+`CapturePolicy`; agentd applies allowlist, denylist, path-deny, pause-window,
+batch interval, and max-frame settings at runtime. Server `PAUSED` capture mode
+stops capture until a later policy resumes it, while manual user pause still
+wins locally.
+
 ## What's next
 
 - Consume generated `chronicle.v1` Swift types when the platform SDK publishes
@@ -153,6 +181,7 @@ locally and does not write the broker session token to disk.
 ```
 Sources/agentd/
   main.swift              # NSApplication + AppController boot
+  ChronicleControl.swift  # RegisterDevice/Heartbeat + policy response client
   Config.swift            # ~/.evalops/agentd/config.json
   CaptureService.swift    # SCStream pipeline
   WindowContext.swift     # AX + NSWorkspace probe

--- a/Sources/agentd/ChronicleControl.swift
+++ b/Sources/agentd/ChronicleControl.swift
@@ -116,6 +116,30 @@ struct ChronicleDevice: Sendable, Codable, Equatable {
   var paused: Bool?
   var pauseReason: String?
   var metadata: [String: String]?
+
+  init(
+    deviceId: String,
+    organizationId: String,
+    workspaceId: String? = nil,
+    userId: String? = nil,
+    hostname: String? = nil,
+    appVersion: String? = nil,
+    captureMode: CaptureMode? = nil,
+    paused: Bool? = nil,
+    pauseReason: String? = nil,
+    metadata: [String: String]? = nil
+  ) {
+    self.deviceId = deviceId
+    self.organizationId = organizationId
+    self.workspaceId = workspaceId
+    self.userId = userId
+    self.hostname = hostname
+    self.appVersion = appVersion
+    self.captureMode = captureMode
+    self.paused = paused
+    self.pauseReason = pauseReason
+    self.metadata = metadata
+  }
 }
 
 struct RegisterDeviceRequest: Sendable, Codable, Equatable {
@@ -166,6 +190,14 @@ struct ChronicleControlState: Sendable, Equatable {
   var serverPaused: Bool = false
   var serverPauseReason: String?
   var lastError: String?
+
+  mutating func apply(device: ChronicleDevice) -> Bool {
+    let previousPaused = serverPaused
+    let previousReason = serverPauseReason
+    serverPaused = device.paused ?? false
+    serverPauseReason = device.pauseReason
+    return previousPaused != serverPaused || previousReason != serverPauseReason
+  }
 }
 
 actor ChronicleControlClient {

--- a/Sources/agentd/ChronicleControl.swift
+++ b/Sources/agentd/ChronicleControl.swift
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import Foundation
+
+enum CaptureMode: String, Sendable, Codable, Equatable {
+  case unspecified = "CAPTURE_MODE_UNSPECIFIED"
+  case localOnly = "CAPTURE_MODE_LOCAL_ONLY"
+  case hybrid = "CAPTURE_MODE_HYBRID"
+  case cloud = "CAPTURE_MODE_CLOUD"
+  case paused = "CAPTURE_MODE_PAUSED"
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let raw = try? container.decode(String.self),
+      let value = CaptureMode(rawValue: raw)
+    {
+      self = value
+    } else {
+      self = .unspecified
+    }
+  }
+}
+
+struct CapturePolicy: Sendable, Codable, Equatable {
+  var policyVersion: String
+  var captureMode: CaptureMode
+  var allowedBundleIds: [String]
+  var deniedBundleIds: [String]
+  var deniedPathPrefixes: [String]
+  var pauseWindowTitlePatterns: [String]
+  var secretPatterns: [String]
+  var cloudConsolidationTier: String
+  var minBatchIntervalSeconds: Int
+  var maxFramesPerBatch: Int
+  var sourcePolicyRef: String
+
+  init(
+    policyVersion: String = "",
+    captureMode: CaptureMode = .unspecified,
+    allowedBundleIds: [String] = [],
+    deniedBundleIds: [String] = [],
+    deniedPathPrefixes: [String] = [],
+    pauseWindowTitlePatterns: [String] = [],
+    secretPatterns: [String] = [],
+    cloudConsolidationTier: String = "",
+    minBatchIntervalSeconds: Int = 0,
+    maxFramesPerBatch: Int = 0,
+    sourcePolicyRef: String = ""
+  ) {
+    self.policyVersion = policyVersion
+    self.captureMode = captureMode
+    self.allowedBundleIds = allowedBundleIds
+    self.deniedBundleIds = deniedBundleIds
+    self.deniedPathPrefixes = deniedPathPrefixes
+    self.pauseWindowTitlePatterns = pauseWindowTitlePatterns
+    self.secretPatterns = secretPatterns
+    self.cloudConsolidationTier = cloudConsolidationTier
+    self.minBatchIntervalSeconds = minBatchIntervalSeconds
+    self.maxFramesPerBatch = maxFramesPerBatch
+    self.sourcePolicyRef = sourcePolicyRef
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case policyVersion
+    case captureMode
+    case allowedBundleIds
+    case deniedBundleIds
+    case deniedPathPrefixes
+    case pauseWindowTitlePatterns
+    case secretPatterns
+    case cloudConsolidationTier
+    case minBatchIntervalSeconds
+    case maxFramesPerBatch
+    case sourcePolicyRef
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.init(
+      policyVersion: try container.decodeIfPresent(String.self, forKey: .policyVersion) ?? "",
+      captureMode: try container.decodeIfPresent(CaptureMode.self, forKey: .captureMode)
+        ?? .unspecified,
+      allowedBundleIds: try container.decodeIfPresent([String].self, forKey: .allowedBundleIds)
+        ?? [],
+      deniedBundleIds: try container.decodeIfPresent([String].self, forKey: .deniedBundleIds)
+        ?? [],
+      deniedPathPrefixes: try container.decodeIfPresent([String].self, forKey: .deniedPathPrefixes)
+        ?? [],
+      pauseWindowTitlePatterns: try container.decodeIfPresent(
+        [String].self,
+        forKey: .pauseWindowTitlePatterns
+      ) ?? [],
+      secretPatterns: try container.decodeIfPresent([String].self, forKey: .secretPatterns) ?? [],
+      cloudConsolidationTier: try container.decodeIfPresent(
+        String.self,
+        forKey: .cloudConsolidationTier
+      ) ?? "",
+      minBatchIntervalSeconds: try container.decodeIfPresent(
+        Int.self,
+        forKey: .minBatchIntervalSeconds
+      ) ?? 0,
+      maxFramesPerBatch: try container.decodeIfPresent(Int.self, forKey: .maxFramesPerBatch) ?? 0,
+      sourcePolicyRef: try container.decodeIfPresent(String.self, forKey: .sourcePolicyRef) ?? ""
+    )
+  }
+}
+
+struct ChronicleDevice: Sendable, Codable, Equatable {
+  var deviceId: String
+  var organizationId: String
+  var workspaceId: String?
+  var userId: String?
+  var hostname: String?
+  var appVersion: String?
+  var captureMode: CaptureMode?
+  var paused: Bool?
+  var pauseReason: String?
+  var metadata: [String: String]?
+}
+
+struct RegisterDeviceRequest: Sendable, Codable, Equatable {
+  var deviceId: String
+  var organizationId: String
+  var workspaceId: String?
+  var userId: String?
+  var hostname: String
+  var appVersion: String
+  var metadata: [String: String]
+}
+
+struct RegisterDeviceResponse: Sendable, Codable, Equatable {
+  var device: ChronicleDevice?
+  var policy: CapturePolicy?
+}
+
+struct HeartbeatRequest: Sendable, Codable, Equatable {
+  var deviceId: String
+  var organizationId: String
+  var pendingFrameCount: Int
+  var pendingBytes: Int64
+
+  enum CodingKeys: String, CodingKey {
+    case deviceId
+    case organizationId
+    case pendingFrameCount
+    case pendingBytes
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(deviceId, forKey: .deviceId)
+    try container.encode(organizationId, forKey: .organizationId)
+    try container.encode(pendingFrameCount, forKey: .pendingFrameCount)
+    try container.encode(String(pendingBytes), forKey: .pendingBytes)
+  }
+}
+
+struct HeartbeatResponse: Sendable, Codable, Equatable {
+  var device: ChronicleDevice?
+  var policy: CapturePolicy?
+}
+
+struct ChronicleControlState: Sendable, Equatable {
+  var registered: Bool = false
+  var lastPolicyVersion: String?
+  var serverPaused: Bool = false
+  var serverPauseReason: String?
+  var lastError: String?
+}
+
+actor ChronicleControlClient {
+  private let submitBatchEndpoint: URL
+  private let client: any HTTPClient
+  private let auth: ResolvedSubmitterAuth
+
+  init(
+    submitBatchEndpoint: URL,
+    authMode: AuthMode,
+    credentialProvider: any SubmitterCredentialProviding = KeychainCredentialProvider(),
+    session: URLSession? = nil,
+    client: (any HTTPClient)? = nil
+  ) throws {
+    guard EndpointPolicy.isAllowed(endpoint: submitBatchEndpoint, localOnly: false) else {
+      throw SubmitterInitError.insecureRemoteEndpoint(submitBatchEndpoint.absoluteString)
+    }
+    guard authMode != .none else {
+      throw SubmitterInitError.missingRemoteAuth
+    }
+    self.submitBatchEndpoint = submitBatchEndpoint
+    self.auth = try ResolvedSubmitterAuth(mode: authMode, credentialProvider: credentialProvider)
+
+    if let client {
+      self.client = client
+    } else if let session {
+      self.client = URLSessionHTTPClient(session: session)
+    } else if case .mtls(let identity) = auth {
+      let cfg = URLSessionConfiguration.ephemeral
+      cfg.httpAdditionalHeaders = [
+        "Content-Type": "application/json",
+        "Connect-Protocol-Version": "1",
+      ]
+      cfg.timeoutIntervalForRequest = 30
+      self.client = URLSessionHTTPClient(
+        session: URLSession(
+          configuration: cfg,
+          delegate: MTLSURLSessionDelegate(identity: identity.secIdentity),
+          delegateQueue: nil
+        ))
+    } else {
+      let cfg = URLSessionConfiguration.ephemeral
+      cfg.httpAdditionalHeaders = [
+        "Content-Type": "application/json",
+        "Connect-Protocol-Version": "1",
+      ]
+      cfg.timeoutIntervalForRequest = 30
+      self.client = URLSessionHTTPClient(session: URLSession(configuration: cfg))
+    }
+  }
+
+  func register(_ request: RegisterDeviceRequest) async throws -> RegisterDeviceResponse {
+    try await send(request, method: "RegisterDevice", responseType: RegisterDeviceResponse.self)
+  }
+
+  func heartbeat(_ request: HeartbeatRequest) async throws -> HeartbeatResponse {
+    try await send(request, method: "Heartbeat", responseType: HeartbeatResponse.self)
+  }
+
+  func endpoint(for method: String) -> URL {
+    ChronicleEndpoint.methodURL(fromSubmitBatchEndpoint: submitBatchEndpoint, method: method)
+  }
+
+  private func send<Request: Encodable & Sendable, Response: Decodable & Sendable>(
+    _ body: Request,
+    method: String,
+    responseType: Response.Type
+  ) async throws -> Response {
+    let data = try encodeChronicleControlRequest(body)
+    var req = URLRequest(url: endpoint(for: method))
+    req.httpMethod = "POST"
+    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    req.setValue("1", forHTTPHeaderField: "Connect-Protocol-Version")
+    if case .bearer(let token) = auth {
+      req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    }
+    req.httpBody = data
+
+    let (responseBody, resp) = try await client.data(for: req)
+    if let http = resp as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+      throw ChronicleControlError.status(method: method, statusCode: http.statusCode)
+    }
+    if responseBody.isEmpty {
+      return try JSONDecoder().decode(responseType, from: Data("{}".utf8))
+    }
+    return try JSONDecoder().decode(responseType, from: responseBody)
+  }
+}
+
+enum ChronicleEndpoint {
+  static func methodURL(fromSubmitBatchEndpoint endpoint: URL, method: String) -> URL {
+    var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false)
+    let marker = "/chronicle.v1.ChronicleService/"
+    if let path = components?.path, let range = path.range(of: marker) {
+      components?.path = String(path[..<range.upperBound]) + method
+      return components?.url ?? endpoint
+    }
+    components?.path = endpoint.deletingLastPathComponent().appendingPathComponent(method).path
+    return components?.url ?? endpoint
+  }
+}
+
+enum ChronicleControlError: Error, LocalizedError, Equatable {
+  case status(method: String, statusCode: Int)
+
+  var errorDescription: String? {
+    switch self {
+    case .status(let method, let statusCode):
+      return "Chronicle \(method) returned HTTP \(statusCode)"
+    }
+  }
+}
+
+func encodeChronicleControlRequest<T: Encodable>(_ request: T) throws -> Data {
+  let enc = JSONEncoder()
+  enc.outputFormatting = [.sortedKeys]
+  return try enc.encode(request)
+}

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -154,6 +154,54 @@ struct AgentConfig: Codable, Sendable {
     self.secretBroker = secretBroker
   }
 
+  func applying(policy: CapturePolicy) -> AgentConfig {
+    var next = self
+
+    if !policy.allowedBundleIds.isEmpty {
+      next.allowedBundleIds = policy.allowedBundleIds
+    }
+
+    next.deniedBundleIds = Self.mergePolicyList(
+      defaultValues: Self.defaultDeniedBundleIds,
+      currentValues: deniedBundleIds,
+      policyValues: policy.deniedBundleIds
+    )
+    next.deniedPathPrefixes = Self.mergePolicyList(
+      defaultValues: Self.defaultDeniedPathPrefixes,
+      currentValues: deniedPathPrefixes,
+      policyValues: policy.deniedPathPrefixes
+    )
+    next.pauseWindowTitlePatterns = Self.mergePolicyList(
+      defaultValues: Self.defaultPauseWindowPatterns,
+      currentValues: pauseWindowTitlePatterns,
+      policyValues: policy.pauseWindowTitlePatterns
+    )
+
+    if policy.minBatchIntervalSeconds > 0 {
+      next.batchIntervalSeconds = max(batchIntervalSeconds, Double(policy.minBatchIntervalSeconds))
+    }
+    if policy.maxFramesPerBatch > 0 {
+      next.maxFramesPerBatch = policy.maxFramesPerBatch
+    }
+
+    return next
+  }
+
+  private static func mergePolicyList(
+    defaultValues: [String],
+    currentValues: [String],
+    policyValues: [String]
+  ) -> [String] {
+    var seen = Set<String>()
+    var merged: [String] = []
+    for value in defaultValues + currentValues + policyValues where !value.isEmpty {
+      if seen.insert(value).inserted {
+        merged.append(value)
+      }
+    }
+    return merged
+  }
+
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     deviceId = try container.decode(String.self, forKey: .deviceId)

--- a/Sources/agentd/MenuBarController.swift
+++ b/Sources/agentd/MenuBarController.swift
@@ -7,6 +7,7 @@ import Foundation
 final class MenuBarController: NSObject {
   private let statusItem: NSStatusItem
   private let menu = NSMenu()
+  private var aboutItem: NSMenuItem?
   private var paused: Bool = false
   private let onPauseToggle: @Sendable (Bool) -> Void
   private let onFlushNow: @Sendable () -> Void
@@ -60,6 +61,7 @@ final class MenuBarController: NSObject {
     let about = NSMenuItem(
       title: "agentd \(Bundle.main.appVersion) — local-only", action: nil, keyEquivalent: "")
     about.isEnabled = false
+    aboutItem = about
     menu.addItem(about)
 
     menu.addItem(.separator())
@@ -90,10 +92,28 @@ final class MenuBarController: NSObject {
   @objc private func flush() { onFlushNow() }
   @objc private func reveal() { onOpenBatchesDir() }
   @objc private func quit() { onQuit() }
+
+  func setStatus(paused: Bool, detail: String, localOnly: Bool, policyVersion: String?) {
+    self.paused = paused
+    if let button = statusItem.button {
+      button.image = NSImage(
+        systemSymbolName: paused ? "pause.circle" : "circle.fill",
+        accessibilityDescription: paused ? "agentd paused" : "agentd recording"
+      )
+      button.image?.isTemplate = true
+      button.toolTip = "agentd — \(detail)"
+    }
+    if let item = menu.items.first {
+      item.title = paused ? "Resume Capture" : "Pause Capture"
+    }
+    let mode = localOnly ? "local-only" : "managed"
+    let policy = policyVersion.map { " policy \($0)" } ?? ""
+    aboutItem?.title = "agentd \(Bundle.main.appVersion) — \(mode)\(policy)"
+  }
 }
 
 extension Bundle {
-  fileprivate var appVersion: String {
+  var appVersion: String {
     (infoDictionary?["CFBundleShortVersionString"] as? String) ?? "0.0.0"
   }
 }

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -218,6 +218,11 @@ actor FramePipeline {
     droppedBackpressure += 1
   }
 
+  func pendingStats() -> PendingFrameStats {
+    let pendingBytes = pending.reduce(Int64(0)) { $0 + Int64($1.bytesPng) }
+    return PendingFrameStats(frameCount: pending.count, estimatedBytes: pendingBytes)
+  }
+
   func consume(_ frame: CapturedFrame, context: WindowContext?) async {
     guard let ctx = context else { return }
 
@@ -363,4 +368,9 @@ actor FramePipeline {
     let digest = SHA256.hash(data: Data(s.utf8))
     return digest.map { String(format: "%02x", $0) }.joined()
   }
+}
+
+struct PendingFrameStats: Sendable, Equatable {
+  let frameCount: Int
+  let estimatedBytes: Int64
 }

--- a/Sources/agentd/Submitter.swift
+++ b/Sources/agentd/Submitter.swift
@@ -279,12 +279,55 @@ actor Submitter {
       )
     }
   }
+
+  func localBatchStats() async -> LocalBatchStats {
+    let files = localBatchFiles()
+    return LocalBatchStats(
+      fileCount: files.count,
+      bytes: files.reduce(Int64(0)) { $0 + $1.size }
+    )
+  }
+
+  private func localBatchFiles() -> [LocalBatchFile] {
+    let fm = FileManager.default
+    guard
+      let urls = try? fm.contentsOfDirectory(
+        at: batchDirectory,
+        includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey, .isRegularFileKey],
+        options: [.skipsHiddenFiles]
+      )
+    else { return [] }
+
+    var files: [LocalBatchFile] = []
+    for url in urls where url.pathExtension == "json" {
+      guard
+        let values = try? url.resourceValues(forKeys: [
+          .contentModificationDateKey,
+          .fileSizeKey,
+          .isRegularFileKey,
+        ]),
+        values.isRegularFile == true
+      else { continue }
+      files.append(
+        LocalBatchFile(
+          url: url,
+          modified: values.contentModificationDate ?? .distantPast,
+          size: Int64(values.fileSize ?? 0)
+        ))
+    }
+    return files
+  }
 }
 
 private struct LocalBatchFile {
   let url: URL
   let modified: Date
   let size: Int64
+}
+
+struct LocalBatchStats: Sendable, Equatable {
+  let fileCount: Int
+  let bytes: Int64
 }
 
 protocol HTTPClient: Sendable {
@@ -412,7 +455,7 @@ struct KeychainCredentialProvider: SubmitterCredentialProviding {
   }
 }
 
-private final class MTLSURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
+final class MTLSURLSessionDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
   private let identity: SecIdentity
 
   init(identity: SecIdentity) {

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -174,12 +174,13 @@ final class AppController {
       let response = try await controlClient.heartbeat(await makeHeartbeatRequest())
       controlState.registered = true
       controlState.lastError = nil
+      var devicePauseChanged = false
       if let device = response.device {
-        apply(device: device)
+        devicePauseChanged = apply(device: device)
       }
       if let policy = response.policy {
         await apply(policy: policy)
-      } else {
+      } else if devicePauseChanged {
         await reconcileCaptureState()
       }
     } catch {
@@ -218,9 +219,9 @@ final class AppController {
     )
   }
 
-  private func apply(device: ChronicleDevice) {
-    controlState.serverPaused = device.paused ?? false
-    controlState.serverPauseReason = device.pauseReason
+  @discardableResult
+  private func apply(device: ChronicleDevice) -> Bool {
+    controlState.apply(device: device)
   }
 
   private func apply(policy: CapturePolicy) async {

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -5,14 +5,18 @@ import Foundation
 
 @MainActor
 final class AppController {
-  private let config: AgentConfig
+  private var config: AgentConfig
   private let pipeline: FramePipeline
   private let submitter: Submitter
+  private let controlClient: ChronicleControlClient?
   private var capture: CaptureService!
   private var menuBar: MenuBarController!
-  private var paused = false
+  private var userPaused = false
+  private var captureRunning = false
+  private var controlState = ChronicleControlState()
   private var flushTimer: Timer?
   private var idleTimer: Timer?
+  private var heartbeatTimer: Timer?
   private var idleMode = false
 
   init() {
@@ -46,10 +50,27 @@ final class AppController {
     self.pipeline = FramePipeline(config: cfg) { batch in
       await submitter.submit(batch)
     }
+
+    if cfg.localOnly {
+      self.controlClient = nil
+    } else {
+      do {
+        self.controlClient = try ChronicleControlClient(
+          submitBatchEndpoint: cfg.endpoint,
+          authMode: cfg.auth
+        )
+      } catch {
+        Log.app.error(
+          "chronicle control disabled: \(error.localizedDescription, privacy: .public)"
+        )
+        self.controlClient = nil
+      }
+    }
   }
 
   func boot() async {
-    if !WindowContextProbe.axTrustedPrompt() {
+    let permissions = PermissionSnapshot.current(promptForAccessibility: true)
+    if !permissions.accessibilityTrusted {
       Log.app.warning("Accessibility not granted yet — window-context will be empty until granted")
     }
 
@@ -80,20 +101,19 @@ final class AppController {
       }
     )
 
-    do {
-      try await capture.start(targetFps: config.captureFps)
-    } catch {
-      Log.app.error("capture start failed: \(error.localizedDescription, privacy: .public)")
-    }
+    await registerWithChronicle(permissions: permissions)
+    await reconcileCaptureState()
 
-    let interval = config.batchIntervalSeconds
-    flushTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
-      Task { await pipeline.flush() }
-    }
+    scheduleFlushTimer()
     idleTimer = Timer.scheduledTimer(
       withTimeInterval: max(1, config.idlePollSeconds), repeats: true
     ) { [weak self] _ in
       Task { @MainActor in await self?.pollIdleState() }
+    }
+    if controlClient != nil {
+      heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+        Task { @MainActor in await self?.sendHeartbeat() }
+      }
     }
 
     Log.app.info(
@@ -102,18 +122,12 @@ final class AppController {
   }
 
   private func applyPause(_ paused: Bool) async {
-    guard paused != self.paused else { return }
-    self.paused = paused
-    if paused {
-      await capture.stop()
-    } else {
-      try? await capture.start(targetFps: config.captureFps)
-      idleMode = false
-    }
+    userPaused = paused
+    await reconcileCaptureState()
   }
 
   private func pollIdleState() async {
-    guard !paused else { return }
+    guard captureRunning else { return }
     let idleSeconds = CGEventSource.secondsSinceLastEventType(
       .combinedSessionState,
       eventType: CGEventType(rawValue: ~0)!
@@ -126,6 +140,176 @@ final class AppController {
     await capture.updateFps(fps)
     Log.capture.info(
       "adaptive fps mode=\(shouldIdle ? "idle" : "active", privacy: .public) fps=\(fps, privacy: .public)"
+    )
+  }
+
+  private func registerWithChronicle(permissions: PermissionSnapshot) async {
+    guard let controlClient else {
+      updateMenuStatus()
+      return
+    }
+    do {
+      let response = try await controlClient.register(
+        makeRegisterRequest(permissions: permissions)
+      )
+      controlState.registered = true
+      controlState.lastError = nil
+      if let device = response.device {
+        apply(device: device)
+      }
+      if let policy = response.policy {
+        await apply(policy: policy)
+      }
+      Log.app.info("chronicle device registered")
+    } catch {
+      controlState.lastError = error.localizedDescription
+      Log.app.error("chronicle register failed: \(error.localizedDescription, privacy: .public)")
+    }
+    updateMenuStatus()
+  }
+
+  private func sendHeartbeat() async {
+    guard let controlClient else { return }
+    do {
+      let response = try await controlClient.heartbeat(await makeHeartbeatRequest())
+      controlState.registered = true
+      controlState.lastError = nil
+      if let device = response.device {
+        apply(device: device)
+      }
+      if let policy = response.policy {
+        await apply(policy: policy)
+      }
+    } catch {
+      controlState.lastError = error.localizedDescription
+      Log.app.warning("chronicle heartbeat failed: \(error.localizedDescription, privacy: .public)")
+    }
+    updateMenuStatus()
+  }
+
+  private func makeRegisterRequest(permissions: PermissionSnapshot) -> RegisterDeviceRequest {
+    RegisterDeviceRequest(
+      deviceId: config.deviceId,
+      organizationId: config.organizationId,
+      workspaceId: config.workspaceId,
+      userId: config.userId,
+      hostname: Host.current().localizedName ?? "unknown",
+      appVersion: Bundle.main.appVersion,
+      metadata: [
+        "capture_state": captureRunning ? "capturing" : "stopped",
+        "local_only": String(config.localOnly),
+        "secret_broker_enabled": String(config.secretBroker != nil),
+        "accessibility_trusted": String(permissions.accessibilityTrusted),
+        "screen_capture_preflight": String(permissions.screenCaptureTrusted),
+      ]
+    )
+  }
+
+  private func makeHeartbeatRequest() async -> HeartbeatRequest {
+    let pending = await pipeline.pendingStats()
+    let local = await submitter.localBatchStats()
+    return HeartbeatRequest(
+      deviceId: config.deviceId,
+      organizationId: config.organizationId,
+      pendingFrameCount: pending.frameCount + local.fileCount,
+      pendingBytes: pending.estimatedBytes + local.bytes
+    )
+  }
+
+  private func apply(device: ChronicleDevice) {
+    controlState.serverPaused = device.paused ?? false
+    controlState.serverPauseReason = device.pauseReason
+  }
+
+  private func apply(policy: CapturePolicy) async {
+    if !policy.policyVersion.isEmpty {
+      controlState.lastPolicyVersion = policy.policyVersion
+    }
+    if policy.captureMode == .paused {
+      controlState.serverPaused = true
+      controlState.serverPauseReason =
+        policy.sourcePolicyRef.isEmpty
+        ? "policy"
+        : policy.sourcePolicyRef
+    } else if controlState.serverPaused, policy.captureMode != .unspecified {
+      controlState.serverPaused = false
+      controlState.serverPauseReason = nil
+    }
+
+    let next = config.applying(policy: policy)
+    let intervalChanged = next.batchIntervalSeconds != config.batchIntervalSeconds
+    config = next
+    await pipeline.updateConfig(next)
+    if intervalChanged {
+      scheduleFlushTimer()
+    }
+    if captureRunning {
+      await capture.updateFps(idleMode ? config.idleFps : config.captureFps)
+    }
+    await reconcileCaptureState()
+    updateMenuStatus()
+  }
+
+  private func reconcileCaptureState() async {
+    let shouldPause = userPaused || controlState.serverPaused
+    if shouldPause, captureRunning {
+      await capture.stop()
+      captureRunning = false
+      idleMode = false
+    } else if !shouldPause, !captureRunning {
+      do {
+        try await capture.start(targetFps: config.captureFps)
+        captureRunning = true
+      } catch {
+        controlState.lastError = error.localizedDescription
+        Log.app.error("capture start failed: \(error.localizedDescription, privacy: .public)")
+      }
+    }
+    updateMenuStatus()
+  }
+
+  private func scheduleFlushTimer() {
+    flushTimer?.invalidate()
+    let interval = max(1, config.batchIntervalSeconds)
+    let pipeline = pipeline
+    flushTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
+      Task { await pipeline.flush() }
+    }
+  }
+
+  private func updateMenuStatus() {
+    let detail: String
+    if userPaused {
+      detail = "paused by user"
+    } else if controlState.serverPaused {
+      detail = "paused by policy"
+    } else if captureRunning {
+      detail = controlState.registered ? "capturing, registered" : "capturing"
+    } else if let error = controlState.lastError {
+      detail = "stopped: \(error)"
+    } else {
+      detail = "stopped"
+    }
+    menuBar?.setStatus(
+      paused: userPaused || controlState.serverPaused || !captureRunning,
+      detail: detail,
+      localOnly: config.localOnly,
+      policyVersion: controlState.lastPolicyVersion
+    )
+  }
+}
+
+struct PermissionSnapshot: Sendable, Equatable {
+  let accessibilityTrusted: Bool
+  let screenCaptureTrusted: Bool
+
+  @MainActor
+  static func current(promptForAccessibility: Bool) -> PermissionSnapshot {
+    PermissionSnapshot(
+      accessibilityTrusted: promptForAccessibility
+        ? WindowContextProbe.axTrustedPrompt()
+        : AXIsProcessTrusted(),
+      screenCaptureTrusted: CGPreflightScreenCaptureAccess()
     )
   }
 }

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -5,6 +5,7 @@ import Foundation
 
 @MainActor
 final class AppController {
+  private let policyBaseConfig: AgentConfig
   private var config: AgentConfig
   private let pipeline: FramePipeline
   private let submitter: Submitter
@@ -21,6 +22,7 @@ final class AppController {
 
   init() {
     let cfg = ConfigStore.load()
+    self.policyBaseConfig = cfg
     self.config = cfg
 
     let submitter: Submitter
@@ -239,7 +241,7 @@ final class AppController {
       controlState.serverPauseReason = nil
     }
 
-    let next = config.applying(policy: policy)
+    let next = policyBaseConfig.applying(policy: policy)
     let intervalChanged = next.batchIntervalSeconds != config.batchIntervalSeconds
     config = next
     await pipeline.updateConfig(next)

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -179,6 +179,8 @@ final class AppController {
       }
       if let policy = response.policy {
         await apply(policy: policy)
+      } else {
+        await reconcileCaptureState()
       }
     } catch {
       controlState.lastError = error.localizedDescription

--- a/Tests/agentdTests/ChronicleControlTests.swift
+++ b/Tests/agentdTests/ChronicleControlTests.swift
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import Foundation
+import XCTest
+
+@testable import agentd
+
+final class ChronicleControlTests: XCTestCase {
+  func testEndpointDerivesControlMethodsFromSubmitBatchURL() {
+    let endpoint = URL(
+      string: "https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch")!
+
+    XCTAssertEqual(
+      ChronicleEndpoint.methodURL(fromSubmitBatchEndpoint: endpoint, method: "Heartbeat")
+        .absoluteString,
+      "https://chronicle.example.com/chronicle.v1.ChronicleService/Heartbeat"
+    )
+  }
+
+  func testHeartbeatEncodesProtoJSONInt64AsString() throws {
+    let request = HeartbeatRequest(
+      deviceId: "device_1",
+      organizationId: "org_1",
+      pendingFrameCount: 2,
+      pendingBytes: 123_456
+    )
+
+    let data = try encodeChronicleControlRequest(request)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+    XCTAssertEqual(root["deviceId"] as? String, "device_1")
+    XCTAssertEqual(root["organizationId"] as? String, "org_1")
+    XCTAssertEqual(root["pendingFrameCount"] as? Int, 2)
+    XCTAssertEqual(root["pendingBytes"] as? String, "123456")
+  }
+
+  func testControlClientRegistersAndHeartbeatsWithBearerAuth() async throws {
+    let recorder = ChronicleRequestRecorder()
+    let client = StubHTTPClient { request in
+      await recorder.record(request)
+      let url = try XCTUnwrap(request.url)
+      let body = try XCTUnwrap(request.httpBody)
+      let root = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+      XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer chronicle-token")
+      XCTAssertEqual(request.value(forHTTPHeaderField: "Connect-Protocol-Version"), "1")
+
+      if url.path.hasSuffix("/RegisterDevice") {
+        XCTAssertEqual(root["deviceId"] as? String, "device_1")
+        XCTAssertEqual(root["organizationId"] as? String, "org_1")
+        let metadata = try XCTUnwrap(root["metadata"] as? [String: String])
+        XCTAssertEqual(metadata["capture_state"], "stopped")
+        return (
+          Data(
+            #"{"device":{"deviceId":"device_1","organizationId":"org_1","paused":false},"policy":{"policyVersion":"p1","captureMode":"CAPTURE_MODE_HYBRID","allowedBundleIds":["com.test.App"],"maxFramesPerBatch":4}}"#
+              .utf8),
+          Self.response(for: url, statusCode: 200)
+        )
+      }
+
+      XCTAssertTrue(url.path.hasSuffix("/Heartbeat"))
+      XCTAssertEqual(root["pendingFrameCount"] as? Int, 3)
+      XCTAssertEqual(root["pendingBytes"] as? String, "4096")
+      return (
+        Data(
+          #"{"device":{"deviceId":"device_1","organizationId":"org_1","paused":true,"pauseReason":"policy"},"policy":{"policyVersion":"p2","captureMode":"CAPTURE_MODE_PAUSED"}}"#
+            .utf8),
+        Self.response(for: url, statusCode: 200)
+      )
+    }
+
+    let control = try ChronicleControlClient(
+      submitBatchEndpoint: URL(
+        string: "https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch")!,
+      authMode: .bearer(keychainService: "agentd", keychainAccount: "chronicle"),
+      credentialProvider: StubCredentialProvider(tokens: ["agentd:chronicle": "chronicle-token"]),
+      client: client
+    )
+
+    let register = try await control.register(
+      RegisterDeviceRequest(
+        deviceId: "device_1",
+        organizationId: "org_1",
+        workspaceId: nil,
+        userId: nil,
+        hostname: "host",
+        appVersion: "1.0.0",
+        metadata: ["capture_state": "stopped"]
+      ))
+    let heartbeat = try await control.heartbeat(
+      HeartbeatRequest(
+        deviceId: "device_1",
+        organizationId: "org_1",
+        pendingFrameCount: 3,
+        pendingBytes: 4096
+      ))
+
+    XCTAssertEqual(register.policy?.policyVersion, "p1")
+    XCTAssertEqual(register.policy?.maxFramesPerBatch, 4)
+    XCTAssertEqual(heartbeat.device?.paused, true)
+    XCTAssertEqual(heartbeat.policy?.captureMode, .paused)
+    let requestCount = await recorder.count()
+    XCTAssertEqual(requestCount, 2)
+  }
+
+  func testCapturePolicyOverlayPreservesLocalHardDenies() {
+    var cfg = PipelineTests.config(maxFramesPerBatch: 24)
+    cfg.deniedBundleIds = ["com.local.Secret"]
+    cfg.deniedPathPrefixes = [".ssh"]
+    cfg.pauseWindowTitlePatterns = ["1Password"]
+    cfg.batchIntervalSeconds = 30
+
+    let policy = CapturePolicy(
+      policyVersion: "policy_1",
+      captureMode: .hybrid,
+      allowedBundleIds: ["com.remote.Allowed"],
+      deniedBundleIds: ["com.remote.Secret"],
+      deniedPathPrefixes: [".aws"],
+      pauseWindowTitlePatterns: ["Zoom Meeting"],
+      minBatchIntervalSeconds: 60,
+      maxFramesPerBatch: 8,
+      sourcePolicyRef: "chronicle.default"
+    )
+
+    let next = cfg.applying(policy: policy)
+
+    XCTAssertEqual(next.allowedBundleIds, ["com.remote.Allowed"])
+    XCTAssertTrue(next.deniedBundleIds.contains("com.agilebits.onepassword7"))
+    XCTAssertTrue(next.deniedBundleIds.contains("com.local.Secret"))
+    XCTAssertTrue(next.deniedBundleIds.contains("com.remote.Secret"))
+    XCTAssertTrue(next.deniedPathPrefixes.contains(".ssh"))
+    XCTAssertTrue(next.deniedPathPrefixes.contains(".aws"))
+    XCTAssertTrue(next.pauseWindowTitlePatterns.contains("1Password"))
+    XCTAssertTrue(next.pauseWindowTitlePatterns.contains("Zoom Meeting"))
+    XCTAssertEqual(next.batchIntervalSeconds, 60)
+    XCTAssertEqual(next.maxFramesPerBatch, 8)
+  }
+
+  fileprivate static func response(for url: URL, statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: url,
+      statusCode: statusCode,
+      httpVersion: "HTTP/1.1",
+      headerFields: nil
+    )!
+  }
+}
+
+actor ChronicleRequestRecorder {
+  private var requests: [URLRequest] = []
+
+  func record(_ request: URLRequest) {
+    requests.append(request)
+  }
+
+  func count() -> Int {
+    requests.count
+  }
+}

--- a/Tests/agentdTests/ChronicleControlTests.swift
+++ b/Tests/agentdTests/ChronicleControlTests.swift
@@ -136,6 +136,34 @@ final class ChronicleControlTests: XCTestCase {
     XCTAssertEqual(next.maxFramesPerBatch, 8)
   }
 
+  func testPolicyReapplyFromLocalBaselineAllowsServerPolicyToShrink() {
+    var base = PipelineTests.config(maxFramesPerBatch: 24)
+    base.deniedBundleIds = ["com.local.Secret"]
+    base.batchIntervalSeconds = 30
+
+    let first = base.applying(
+      policy: CapturePolicy(
+        policyVersion: "policy_1",
+        deniedBundleIds: ["com.remote.Secret"],
+        minBatchIntervalSeconds: 120
+      ))
+    let second = base.applying(
+      policy: CapturePolicy(
+        policyVersion: "policy_2",
+        deniedBundleIds: ["com.remote.NewSecret"],
+        minBatchIntervalSeconds: 45
+      ))
+
+    XCTAssertTrue(first.deniedBundleIds.contains("com.local.Secret"))
+    XCTAssertTrue(first.deniedBundleIds.contains("com.remote.Secret"))
+    XCTAssertEqual(first.batchIntervalSeconds, 120)
+
+    XCTAssertTrue(second.deniedBundleIds.contains("com.local.Secret"))
+    XCTAssertFalse(second.deniedBundleIds.contains("com.remote.Secret"))
+    XCTAssertTrue(second.deniedBundleIds.contains("com.remote.NewSecret"))
+    XCTAssertEqual(second.batchIntervalSeconds, 45)
+  }
+
   func testControlStateReportsDevicePauseChangesWithoutPolicy() {
     var state = ChronicleControlState()
 

--- a/Tests/agentdTests/ChronicleControlTests.swift
+++ b/Tests/agentdTests/ChronicleControlTests.swift
@@ -136,6 +136,41 @@ final class ChronicleControlTests: XCTestCase {
     XCTAssertEqual(next.maxFramesPerBatch, 8)
   }
 
+  func testControlStateReportsDevicePauseChangesWithoutPolicy() {
+    var state = ChronicleControlState()
+
+    XCTAssertTrue(
+      state.apply(
+        device: ChronicleDevice(
+          deviceId: "device_1",
+          organizationId: "org_1",
+          paused: true,
+          pauseReason: "policy"
+        )))
+    XCTAssertEqual(state.serverPaused, true)
+    XCTAssertEqual(state.serverPauseReason, "policy")
+
+    XCTAssertFalse(
+      state.apply(
+        device: ChronicleDevice(
+          deviceId: "device_1",
+          organizationId: "org_1",
+          paused: true,
+          pauseReason: "policy"
+        )))
+
+    XCTAssertTrue(
+      state.apply(
+        device: ChronicleDevice(
+          deviceId: "device_1",
+          organizationId: "org_1",
+          paused: false,
+          pauseReason: nil
+        )))
+    XCTAssertEqual(state.serverPaused, false)
+    XCTAssertNil(state.serverPauseReason)
+  }
+
   fileprivate static func response(for url: URL, statusCode: Int) -> HTTPURLResponse {
     HTTPURLResponse(
       url: url,


### PR DESCRIPTION
## Summary

- add a Chronicle control client for `RegisterDevice` and `Heartbeat`, deriving control RPC URLs from the configured `SubmitBatch` endpoint
- register remote-mode devices with app/host/permission metadata and send heartbeat queue pressure from pending frames plus local fallback batches
- apply server-returned capture policy at runtime while preserving local hard-deny safety rails, and surface managed/policy status in the menu bar
- document managed mode and add control/policy tests for protojson encoding, auth, policy overlay precedence, and the register -> heartbeat loop

## Issues

Refs #28.
Refs #29.

## Validation

- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `scripts/package_app.sh`
- `git diff --check`
