### PR TITLE
[codex] Encrypt local batch fallback files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ This is the desktop component of the work tracked in
   (default 4096) with `ocrTextTruncated` set when the cap applies.
 - Batches every 30s or 24 frames, whichever first.
 - Local-only mode persists batches under `~/.evalops/agentd/batches/` as
-  `0o600` JSON and sweeps old or over-budget batches; HTTP mode `POST`s a
-  Connect/proto JSON `SubmitBatchRequest` to
+  `0o600` JSON by default and sweeps old or over-budget batches; HTTP mode
+  `POST`s a Connect/proto JSON `SubmitBatchRequest` to
   `chronicle.v1.ChronicleService.SubmitBatch` and falls back to local on
   failure. Remote HTTP is allowed only for loopback development; non-loopback
   remote endpoints must use HTTPS and configured client auth.
+- Remote and Secret Broker modes encrypt local fallback batches at rest by
+  default using a per-device Keychain-backed AES-GCM key. Local-only mode can
+  opt in with `encryptLocalBatches: true`.
 - Optional Secret Broker mode wraps the frame batch into a broker artifact
   (`chronicle_frame_batch_json`) first, then sends only the artifact/session
   reference to Chronicle so Platform can unwrap, meter, and revoke through ASB.
@@ -97,6 +100,8 @@ agentd reads and writes `~/.evalops/agentd/config.json`. Important defaults:
 - `maxOcrTextChars: 4096`
 - `maxBatchAgeDays: 7`
 - `maxBatchBytes: 536870912`
+- `encryptLocalBatches: false` in local-only mode, `true` in remote or Secret
+  Broker mode when omitted
 - `auth: { "mode": "none" }`
 
 Remote mode requires `localOnly: false`, an HTTPS or loopback endpoint, and an
@@ -165,6 +170,12 @@ batch interval, and max-frame settings at runtime. Server `PAUSED` capture mode
 stops capture until a later policy resumes it, while manual user pause still
 wins locally.
 
+Encrypted local batches use the `.agentdbatch` extension. The encryption key is
+created or loaded from Keychain service `dev.evalops.agentd.local-batch-key`,
+accounted by `deviceId`, and is never written to `config.json` or the batch
+directory. Retention sweeps apply to both plaintext `.json` batches and
+encrypted `.agentdbatch` batches.
+
 ## What's next
 
 - Consume generated `chronicle.v1` Swift types when the platform SDK publishes
@@ -172,7 +183,6 @@ wins locally.
   ([evalops/platform#1078](https://github.com/evalops/platform/issues/1078)).
 - Calendar / Zoom auto-pause via NATS subject
   `chronicle.policy.pause` (siphon-fed).
-- Encryption-at-rest option for local batches.
 - Hardware-backed permission-flow smoke test for Screen Recording and
   Accessibility prompts.
 

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -74,6 +74,7 @@ struct AgentConfig: Codable, Sendable {
   var idleThresholdSeconds: Double
   var idlePollSeconds: Double
   var localOnly: Bool
+  var encryptLocalBatches: Bool
   var auth: AuthMode
   var secretBroker: SecretBrokerConfig?
 
@@ -100,6 +101,7 @@ struct AgentConfig: Codable, Sendable {
     case idleThresholdSeconds
     case idlePollSeconds
     case localOnly
+    case encryptLocalBatches
     case auth
     case secretBroker
   }
@@ -126,6 +128,7 @@ struct AgentConfig: Codable, Sendable {
     idleThresholdSeconds: Double = 60,
     idlePollSeconds: Double = 5,
     localOnly: Bool,
+    encryptLocalBatches: Bool? = nil,
     auth: AuthMode = .none,
     secretBroker: SecretBrokerConfig? = nil
   ) {
@@ -150,6 +153,7 @@ struct AgentConfig: Codable, Sendable {
     self.idleThresholdSeconds = idleThresholdSeconds
     self.idlePollSeconds = idlePollSeconds
     self.localOnly = localOnly
+    self.encryptLocalBatches = encryptLocalBatches ?? (!localOnly || secretBroker != nil)
     self.auth = auth
     self.secretBroker = secretBroker
   }
@@ -241,6 +245,9 @@ struct AgentConfig: Codable, Sendable {
     localOnly = try container.decodeIfPresent(Bool.self, forKey: .localOnly) ?? true
     auth = try container.decodeIfPresent(AuthMode.self, forKey: .auth) ?? .none
     secretBroker = try container.decodeIfPresent(SecretBrokerConfig.self, forKey: .secretBroker)
+    encryptLocalBatches =
+      try container.decodeIfPresent(Bool.self, forKey: .encryptLocalBatches)
+      ?? (!localOnly || secretBroker != nil)
   }
 
   func encode(to encoder: Encoder) throws {
@@ -266,6 +273,7 @@ struct AgentConfig: Codable, Sendable {
     try container.encode(idleThresholdSeconds, forKey: .idleThresholdSeconds)
     try container.encode(idlePollSeconds, forKey: .idlePollSeconds)
     try container.encode(localOnly, forKey: .localOnly)
+    try container.encode(encryptLocalBatches, forKey: .encryptLocalBatches)
     try container.encode(auth, forKey: .auth)
     try container.encodeIfPresent(secretBroker, forKey: .secretBroker)
   }
@@ -325,6 +333,7 @@ struct AgentConfig: Codable, Sendable {
       idleThresholdSeconds: 60,
       idlePollSeconds: 5,
       localOnly: true,
+      encryptLocalBatches: false,
       auth: .none,
       secretBroker: nil
     )

--- a/Sources/agentd/LocalBatchCrypto.swift
+++ b/Sources/agentd/LocalBatchCrypto.swift
@@ -9,13 +9,48 @@ protocol LocalBatchKeyProviding: Sendable {
 }
 
 struct KeychainLocalBatchKeyProvider: LocalBatchKeyProviding {
-  private let service = "dev.evalops.agentd.local-batch-key"
+  private let service: String
+  private let readKeyData: @Sendable (String, String) throws -> Data?
+  private let storeKeyData: @Sendable (String, String, Data) throws -> Bool
+  private let generateRandomKeyData: @Sendable () throws -> Data
+
+  init(
+    service: String = "dev.evalops.agentd.local-batch-key",
+    readKeyData: @escaping @Sendable (String, String) throws -> Data? = Self.readKeyData,
+    storeKeyData: @escaping @Sendable (String, String, Data) throws -> Bool = Self.storeKeyData,
+    generateRandomKeyData: @escaping @Sendable () throws -> Data = Self.generateRandomKeyData
+  ) {
+    self.service = service
+    self.readKeyData = readKeyData
+    self.storeKeyData = storeKeyData
+    self.generateRandomKeyData = generateRandomKeyData
+  }
 
   func localBatchKey(deviceId: String) throws -> SymmetricKey {
     if let existing = try readKey(deviceId: deviceId) {
       return SymmetricKey(data: existing)
     }
 
+    let bytes = try generateRandomKeyData()
+    if try storeKey(bytes, deviceId: deviceId) {
+      return SymmetricKey(data: bytes)
+    }
+
+    guard let existing = try readKey(deviceId: deviceId) else {
+      throw LocalBatchCryptoError.keychainReadFailed(errSecItemNotFound)
+    }
+    return SymmetricKey(data: existing)
+  }
+
+  private func readKey(deviceId: String) throws -> Data? {
+    try readKeyData(service, deviceId)
+  }
+
+  private func storeKey(_ key: Data, deviceId: String) throws -> Bool {
+    try storeKeyData(service, deviceId, key)
+  }
+
+  private static func generateRandomKeyData() throws -> Data {
     var bytes = Data(count: 32)
     let status = bytes.withUnsafeMutableBytes { buffer in
       SecRandomCopyBytes(kSecRandomDefault, buffer.count, buffer.baseAddress!)
@@ -23,11 +58,10 @@ struct KeychainLocalBatchKeyProvider: LocalBatchKeyProviding {
     guard status == errSecSuccess else {
       throw LocalBatchCryptoError.keyGenerationFailed(status)
     }
-    try storeKey(bytes, deviceId: deviceId)
-    return SymmetricKey(data: bytes)
+    return bytes
   }
 
-  private func readKey(deviceId: String) throws -> Data? {
+  private static func readKeyData(service: String, deviceId: String) throws -> Data? {
     let query: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: service,
@@ -46,7 +80,7 @@ struct KeychainLocalBatchKeyProvider: LocalBatchKeyProviding {
     return data
   }
 
-  private func storeKey(_ key: Data, deviceId: String) throws {
+  private static func storeKeyData(service: String, deviceId: String, key: Data) throws -> Bool {
     let attributes: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: service,
@@ -55,7 +89,12 @@ struct KeychainLocalBatchKeyProvider: LocalBatchKeyProviding {
       kSecValueData as String: key,
     ]
     let status = SecItemAdd(attributes as CFDictionary, nil)
-    guard status == errSecSuccess || status == errSecDuplicateItem else {
+    switch status {
+    case errSecSuccess:
+      return true
+    case errSecDuplicateItem:
+      return false
+    default:
       throw LocalBatchCryptoError.keychainWriteFailed(status)
     }
   }

--- a/Sources/agentd/LocalBatchCrypto.swift
+++ b/Sources/agentd/LocalBatchCrypto.swift
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+@preconcurrency import CryptoKit
+import Foundation
+import Security
+
+protocol LocalBatchKeyProviding: Sendable {
+  func localBatchKey(deviceId: String) throws -> SymmetricKey
+}
+
+struct KeychainLocalBatchKeyProvider: LocalBatchKeyProviding {
+  private let service = "dev.evalops.agentd.local-batch-key"
+
+  func localBatchKey(deviceId: String) throws -> SymmetricKey {
+    if let existing = try readKey(deviceId: deviceId) {
+      return SymmetricKey(data: existing)
+    }
+
+    var bytes = Data(count: 32)
+    let status = bytes.withUnsafeMutableBytes { buffer in
+      SecRandomCopyBytes(kSecRandomDefault, buffer.count, buffer.baseAddress!)
+    }
+    guard status == errSecSuccess else {
+      throw LocalBatchCryptoError.keyGenerationFailed(status)
+    }
+    try storeKey(bytes, deviceId: deviceId)
+    return SymmetricKey(data: bytes)
+  }
+
+  private func readKey(deviceId: String) throws -> Data? {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: deviceId,
+      kSecReturnData as String: true,
+      kSecMatchLimit as String: kSecMatchLimitOne,
+    ]
+    var item: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &item)
+    if status == errSecItemNotFound {
+      return nil
+    }
+    guard status == errSecSuccess, let data = item as? Data else {
+      throw LocalBatchCryptoError.keychainReadFailed(status)
+    }
+    return data
+  }
+
+  private func storeKey(_ key: Data, deviceId: String) throws {
+    let attributes: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: deviceId,
+      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+      kSecValueData as String: key,
+    ]
+    let status = SecItemAdd(attributes as CFDictionary, nil)
+    guard status == errSecSuccess || status == errSecDuplicateItem else {
+      throw LocalBatchCryptoError.keychainWriteFailed(status)
+    }
+  }
+}
+
+struct LocalBatchCryptor: @unchecked Sendable {
+  static let encryptedExtension = "agentdbatch"
+  private static let magic = Data("AGENTD-BATCH-AESGCM-v1\n".utf8)
+
+  let key: SymmetricKey
+
+  func encrypt(_ plaintext: Data) throws -> Data {
+    let sealed = try AES.GCM.seal(plaintext, using: key)
+    guard let combined = sealed.combined else {
+      throw LocalBatchCryptoError.invalidCiphertext
+    }
+    return Self.magic + combined
+  }
+
+  func decrypt(_ ciphertext: Data) throws -> Data {
+    guard ciphertext.starts(with: Self.magic) else {
+      throw LocalBatchCryptoError.invalidCiphertext
+    }
+    let combined = ciphertext.dropFirst(Self.magic.count)
+    let box = try AES.GCM.SealedBox(combined: Data(combined))
+    return try AES.GCM.open(box, using: key)
+  }
+}
+
+enum LocalBatchCryptoError: Error, LocalizedError, Equatable {
+  case keyGenerationFailed(OSStatus)
+  case keychainReadFailed(OSStatus)
+  case keychainWriteFailed(OSStatus)
+  case invalidCiphertext
+
+  var errorDescription: String? {
+    switch self {
+    case .keyGenerationFailed(let status):
+      return "failed to generate local batch key: \(status)"
+    case .keychainReadFailed(let status):
+      return "failed to read local batch key from Keychain: \(status)"
+    case .keychainWriteFailed(let status):
+      return "failed to store local batch key in Keychain: \(status)"
+    case .invalidCiphertext:
+      return "local batch ciphertext is invalid"
+    }
+  }
+}

--- a/Sources/agentd/Submitter.swift
+++ b/Sources/agentd/Submitter.swift
@@ -14,6 +14,7 @@ actor Submitter {
   private let batchDirectory: URL
   private let maxBatchBytes: Int64
   private let maxBatchAgeDays: Double
+  private let localBatchCryptor: LocalBatchCryptor?
 
   init(
     endpoint: URL,
@@ -25,7 +26,10 @@ actor Submitter {
     client: (any HTTPClient)? = nil,
     batchDirectory: URL? = nil,
     maxBatchBytes: Int64 = 512 * 1024 * 1024,
-    maxBatchAgeDays: Double = 7
+    maxBatchAgeDays: Double = 7,
+    deviceId: String = "default",
+    encryptLocalBatches: Bool = false,
+    localBatchKeyProvider: any LocalBatchKeyProviding = KeychainLocalBatchKeyProvider()
   ) throws {
     guard EndpointPolicy.isAllowed(endpoint: endpoint, localOnly: localOnly) else {
       throw SubmitterInitError.insecureRemoteEndpoint(endpoint.absoluteString)
@@ -56,6 +60,13 @@ actor Submitter {
       .appendingPathComponent(".evalops/agentd/batches")
     self.maxBatchBytes = maxBatchBytes
     self.maxBatchAgeDays = maxBatchAgeDays
+    if encryptLocalBatches {
+      self.localBatchCryptor = try LocalBatchCryptor(
+        key: localBatchKeyProvider.localBatchKey(deviceId: deviceId)
+      )
+    } else {
+      self.localBatchCryptor = nil
+    }
 
     if let client {
       self.client = client
@@ -219,54 +230,92 @@ actor Submitter {
 
   private func persistLocal(_ id: String, data: Data) async {
     try? FileManager.default.createDirectory(at: batchDirectory, withIntermediateDirectories: true)
-    let url = batchDirectory.appendingPathComponent("\(id).json")
-    try? data.write(to: url, options: .atomic)
+    let url: URL
+    let dataToWrite: Data
+    if let localBatchCryptor {
+      do {
+        dataToWrite = try localBatchCryptor.encrypt(data)
+        url = batchDirectory.appendingPathComponent(
+          "\(id).\(LocalBatchCryptor.encryptedExtension)"
+        )
+      } catch {
+        Log.submit.error(
+          "local batch encrypt failed id=\(id, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+        )
+        return
+      }
+    } else {
+      dataToWrite = data
+      url = batchDirectory.appendingPathComponent("\(id).json")
+    }
+    try? dataToWrite.write(to: url, options: .atomic)
     try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
     Log.submit.info("local persist \(url.path, privacy: .public)")
     await sweepLocalBatches()
   }
 
-  func sweepLocalBatches() async {
-    let fm = FileManager.default
-    guard
-      let urls = try? fm.contentsOfDirectory(
-        at: batchDirectory,
-        includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey, .isRegularFileKey],
-        options: [.skipsHiddenFiles]
-      )
-    else { return }
+  func retryLocalBatches() async -> LocalBatchReplayResult {
+    guard !localOnly else {
+      return LocalBatchReplayResult(submitted: 0, failed: 0)
+    }
 
-    var files: [LocalBatchFile] = []
+    var submitted = 0
+    var failed = 0
+    for file in localBatchFiles().sorted(by: { $0.modified < $1.modified }) {
+      let data: Data
+      do {
+        data = try readLocalBatch(file)
+      } catch {
+        failed += 1
+        Log.submit.warning(
+          "local batch replay read failed file=\(file.url.lastPathComponent, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+        )
+        continue
+      }
+
+      do {
+        let (_, resp) = try await client.data(for: makeRequest(body: data))
+        if let http = resp as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+          failed += 1
+          Log.submit.warning(
+            "local batch replay status=\(http.statusCode, privacy: .public) file=\(file.url.lastPathComponent, privacy: .public)"
+          )
+          continue
+        }
+        try? FileManager.default.removeItem(at: file.url)
+        submitted += 1
+      } catch {
+        failed += 1
+        Log.submit.warning(
+          "local batch replay failed file=\(file.url.lastPathComponent, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+        )
+      }
+    }
+    await sweepLocalBatches()
+    return LocalBatchReplayResult(submitted: submitted, failed: failed)
+  }
+
+  func sweepLocalBatches() async {
     let now = Date()
     let cutoff = now.addingTimeInterval(-maxBatchAgeDays * 24 * 60 * 60)
     var removedCount = 0
     var removedBytes: Int64 = 0
 
-    for url in urls where url.pathExtension == "json" {
-      guard
-        let values = try? url.resourceValues(forKeys: [
-          .contentModificationDateKey,
-          .fileSizeKey,
-          .isRegularFileKey,
-        ]),
-        values.isRegularFile == true
-      else { continue }
-
-      let modified = values.contentModificationDate ?? .distantPast
-      let size = Int64(values.fileSize ?? 0)
-      if modified < cutoff {
-        if (try? fm.removeItem(at: url)) != nil {
+    var files: [LocalBatchFile] = []
+    for file in localBatchFiles() {
+      if file.modified < cutoff {
+        if (try? FileManager.default.removeItem(at: file.url)) != nil {
           removedCount += 1
-          removedBytes += size
+          removedBytes += file.size
         }
-        continue
+      } else {
+        files.append(file)
       }
-      files.append(LocalBatchFile(url: url, modified: modified, size: size))
     }
 
     var totalBytes = files.reduce(Int64(0)) { $0 + $1.size }
     for file in files.sorted(by: { $0.modified < $1.modified }) where totalBytes > maxBatchBytes {
-      if (try? fm.removeItem(at: file.url)) != nil {
+      if (try? FileManager.default.removeItem(at: file.url)) != nil {
         totalBytes -= file.size
         removedCount += 1
         removedBytes += file.size
@@ -289,9 +338,8 @@ actor Submitter {
   }
 
   private func localBatchFiles() -> [LocalBatchFile] {
-    let fm = FileManager.default
     guard
-      let urls = try? fm.contentsOfDirectory(
+      let urls = try? FileManager.default.contentsOfDirectory(
         at: batchDirectory,
         includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey, .isRegularFileKey],
         options: [.skipsHiddenFiles]
@@ -299,7 +347,8 @@ actor Submitter {
     else { return [] }
 
     var files: [LocalBatchFile] = []
-    for url in urls where url.pathExtension == "json" {
+    for url in urls
+    where url.pathExtension == "json" || url.pathExtension == LocalBatchCryptor.encryptedExtension {
       guard
         let values = try? url.resourceValues(forKeys: [
           .contentModificationDateKey,
@@ -312,10 +361,22 @@ actor Submitter {
         LocalBatchFile(
           url: url,
           modified: values.contentModificationDate ?? .distantPast,
-          size: Int64(values.fileSize ?? 0)
+          size: Int64(values.fileSize ?? 0),
+          encrypted: url.pathExtension == LocalBatchCryptor.encryptedExtension
         ))
     }
     return files
+  }
+
+  private func readLocalBatch(_ file: LocalBatchFile) throws -> Data {
+    let data = try Data(contentsOf: file.url)
+    guard file.encrypted else {
+      return data
+    }
+    guard let localBatchCryptor else {
+      throw LocalBatchCryptoError.invalidCiphertext
+    }
+    return try localBatchCryptor.decrypt(data)
   }
 }
 
@@ -323,6 +384,12 @@ private struct LocalBatchFile {
   let url: URL
   let modified: Date
   let size: Int64
+  let encrypted: Bool
+}
+
+struct LocalBatchReplayResult: Sendable, Equatable {
+  let submitted: Int
+  let failed: Int
 }
 
 struct LocalBatchStats: Sendable, Equatable {

--- a/Sources/agentd/Submitter.swift
+++ b/Sources/agentd/Submitter.swift
@@ -113,35 +113,53 @@ actor Submitter {
     }
 
     let submitData: Data
-    if let secretBroker {
-      do {
-        let wrapped = try await wrapFrameBatch(batch, using: secretBroker)
-        submitData = try encodeBrokerSubmitBatchRequest(
-          sessionToken: secretBroker.sessionToken,
-          artifactId: wrapped.artifactId,
-          grantId: wrapped.grantId,
-          localOnly: localOnly
-        )
-      } catch {
-        Log.submit.warning(
-          "secret broker wrap failed batch=\(batch.batchId, privacy: .public) error=\(error.localizedDescription, privacy: .public) — falling back to local"
-        )
-        await persistLocal(batch.batchId, data: fallbackData)
-        return .persistedLocal
-      }
-    } else {
-      submitData = fallbackData
+    do {
+      submitData = try await makeRemoteSubmitData(for: batch, fallbackData: fallbackData)
+    } catch {
+      Log.submit.warning(
+        "remote submit prepare failed batch=\(batch.batchId, privacy: .public) error=\(error.localizedDescription, privacy: .public) — falling back to local"
+      )
+      await persistLocal(batch.batchId, data: fallbackData)
+      return .persistedLocal
     }
 
-    let req = makeRequest(body: submitData)
+    let result = await submitRemoteData(submitData, batchId: batch.batchId)
+    if case .submitted = result {
+      let replay = await retryLocalBatches()
+      if replay.submitted > 0 || replay.failed > 0 {
+        Log.submit.info(
+          "local batch replay submitted=\(replay.submitted, privacy: .public) failed=\(replay.failed, privacy: .public)"
+        )
+      }
+      return result
+    }
+
+    await persistLocal(batch.batchId, data: fallbackData)
+    return .persistedLocal
+  }
+
+  private func makeRemoteSubmitData(for batch: Batch, fallbackData: Data) async throws -> Data {
+    guard let secretBroker else {
+      return fallbackData
+    }
+    let wrapped = try await wrapFrameBatch(batch, using: secretBroker)
+    return try encodeBrokerSubmitBatchRequest(
+      sessionToken: secretBroker.sessionToken,
+      artifactId: wrapped.artifactId,
+      grantId: wrapped.grantId,
+      localOnly: localOnly
+    )
+  }
+
+  private func submitRemoteData(_ data: Data, batchId: String) async -> SubmitResult {
+    let req = makeRequest(body: data)
     do {
       let (body, resp) = try await client.data(for: req)
       if let http = resp as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
         Log.submit.warning(
-          "submit status=\(http.statusCode, privacy: .public) batch=\(batch.batchId, privacy: .public) — falling back to local"
+          "submit status=\(http.statusCode, privacy: .public) batch=\(batchId, privacy: .public)"
         )
-        await persistLocal(batch.batchId, data: fallbackData)
-        return .persistedLocal
+        return .failed
       } else {
         let response: SubmitBatchResponse?
         if body.isEmpty {
@@ -151,14 +169,13 @@ actor Submitter {
             response = try JSONDecoder().decode(SubmitBatchResponse.self, from: body)
           } catch {
             Log.submit.warning(
-              "submit malformed response batch=\(batch.batchId, privacy: .public) — falling back to local"
+              "submit malformed response batch=\(batchId, privacy: .public)"
             )
-            await persistLocal(batch.batchId, data: fallbackData)
-            return .persistedLocal
+            return .failed
           }
         }
         Log.submit.info(
-          "submit ok batch=\(batch.batchId, privacy: .public) frames=\(batch.frames.count, privacy: .public)"
+          "submit ok batch=\(batchId, privacy: .public)"
         )
         await sweepLocalBatches()
         return .submitted(response)
@@ -166,8 +183,7 @@ actor Submitter {
     } catch {
       Log.submit.warning(
         "submit error \(error.localizedDescription, privacy: .public) — falling back to local")
-      await persistLocal(batch.batchId, data: fallbackData)
-      return .persistedLocal
+      return .failed
     }
   }
 
@@ -273,26 +289,39 @@ actor Submitter {
         continue
       }
 
+      let submitData: Data
       do {
-        let (_, resp) = try await client.data(for: makeRequest(body: data))
-        if let http = resp as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
-          failed += 1
-          Log.submit.warning(
-            "local batch replay status=\(http.statusCode, privacy: .public) file=\(file.url.lastPathComponent, privacy: .public)"
-          )
-          continue
-        }
-        try? FileManager.default.removeItem(at: file.url)
-        submitted += 1
+        submitData = try await makeReplaySubmitData(from: data)
       } catch {
         failed += 1
         Log.submit.warning(
-          "local batch replay failed file=\(file.url.lastPathComponent, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+          "local batch replay prepare failed file=\(file.url.lastPathComponent, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
         )
+        continue
+      }
+
+      let result = await submitRemoteData(submitData, batchId: file.batchId)
+      switch result {
+      case .submitted:
+        try? FileManager.default.removeItem(at: file.url)
+        submitted += 1
+      case .failed, .persistedLocal:
+        failed += 1
       }
     }
     await sweepLocalBatches()
     return LocalBatchReplayResult(submitted: submitted, failed: failed)
+  }
+
+  private func makeReplaySubmitData(from persistedData: Data) async throws -> Data {
+    guard secretBroker != nil else {
+      return persistedData
+    }
+    let request = try decodeSubmitBatchRequest(persistedData)
+    guard let batch = request.batch else {
+      throw SubmitterError.missingPersistedBatch
+    }
+    return try await makeRemoteSubmitData(for: batch, fallbackData: persistedData)
   }
 
   func sweepLocalBatches() async {
@@ -385,6 +414,10 @@ private struct LocalBatchFile {
   let modified: Date
   let size: Int64
   let encrypted: Bool
+
+  var batchId: String {
+    url.deletingPathExtension().lastPathComponent
+  }
 }
 
 struct LocalBatchReplayResult: Sendable, Equatable {
@@ -589,6 +622,7 @@ enum SubmitterError: Error, LocalizedError {
   case invalidBatchPayload
   case secretBrokerStatus(Int)
   case malformedSecretBrokerResponse
+  case missingPersistedBatch
 
   var errorDescription: String? {
     switch self {
@@ -598,6 +632,8 @@ enum SubmitterError: Error, LocalizedError {
       return "secret broker wrap returned HTTP \(status)"
     case .malformedSecretBrokerResponse:
       return "secret broker wrap response did not include artifact and grant ids"
+    case .missingPersistedBatch:
+      return "persisted local batch did not include an inline batch payload"
     }
   }
 }
@@ -694,6 +730,12 @@ private func encodeSubmitBatchRequest(_ request: SubmitBatchRequest) throws -> D
   enc.dateEncodingStrategy = .iso8601
   enc.outputFormatting = [.sortedKeys]
   return try enc.encode(request)
+}
+
+private func decodeSubmitBatchRequest(_ data: Data) throws -> SubmitBatchRequest {
+  let dec = JSONDecoder()
+  dec.dateDecodingStrategy = .iso8601
+  return try dec.decode(SubmitBatchRequest.self, from: data)
 }
 
 func encodeFrameBatch(_ batch: Batch) throws -> Data {

--- a/Sources/agentd/Submitter.swift
+++ b/Sources/agentd/Submitter.swift
@@ -15,6 +15,8 @@ actor Submitter {
   private let maxBatchBytes: Int64
   private let maxBatchAgeDays: Double
   private let localBatchCryptor: LocalBatchCryptor?
+  private var isRetryingLocalBatches = false
+  private var retryLocalBatchesNeedsRerun = false
 
   init(
     endpoint: URL,
@@ -275,6 +277,25 @@ actor Submitter {
       return LocalBatchReplayResult(submitted: 0, failed: 0)
     }
 
+    if isRetryingLocalBatches {
+      retryLocalBatchesNeedsRerun = true
+      return LocalBatchReplayResult(submitted: 0, failed: 0)
+    }
+
+    isRetryingLocalBatches = true
+    defer { isRetryingLocalBatches = false }
+    var submitted = 0
+    var failed = 0
+    repeat {
+      retryLocalBatchesNeedsRerun = false
+      let result = await retryLocalBatchesPass()
+      submitted += result.submitted
+      failed += result.failed
+    } while retryLocalBatchesNeedsRerun
+    return LocalBatchReplayResult(submitted: submitted, failed: failed)
+  }
+
+  private func retryLocalBatchesPass() async -> LocalBatchReplayResult {
     var submitted = 0
     var failed = 0
     for file in localBatchFiles().sorted(by: { $0.modified < $1.modified }) {

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -281,8 +281,12 @@ final class AppController {
     flushTimer?.invalidate()
     let interval = max(1, config.batchIntervalSeconds)
     let pipeline = pipeline
+    let submitter = submitter
     flushTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
-      Task { await pipeline.flush() }
+      Task {
+        await pipeline.flush()
+        _ = await submitter.retryLocalBatches()
+      }
     }
   }
 

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -33,7 +33,9 @@ final class AppController {
         authMode: cfg.auth,
         secretBroker: cfg.secretBroker,
         maxBatchBytes: cfg.maxBatchBytes,
-        maxBatchAgeDays: cfg.maxBatchAgeDays
+        maxBatchAgeDays: cfg.maxBatchAgeDays,
+        deviceId: cfg.deviceId,
+        encryptLocalBatches: cfg.encryptLocalBatches
       )
     } catch {
       Log.submit.fault(
@@ -44,7 +46,9 @@ final class AppController {
         localOnly: true,
         authMode: .none,
         maxBatchBytes: cfg.maxBatchBytes,
-        maxBatchAgeDays: cfg.maxBatchAgeDays
+        maxBatchAgeDays: cfg.maxBatchAgeDays,
+        deviceId: cfg.deviceId,
+        encryptLocalBatches: false
       )
     }
     self.submitter = submitter

--- a/Tests/agentdTests/SubmitterTests.swift
+++ b/Tests/agentdTests/SubmitterTests.swift
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+@preconcurrency import CryptoKit
 import Foundation
 import XCTest
 
@@ -128,6 +129,33 @@ final class SubmitterTests: XCTestCase {
     let encoded = try JSONEncoder().encode(cfg)
     let root = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
     XCTAssertNotNil(root["secretBroker"])
+  }
+
+  func testAgentConfigDefaultsEncryptedBatchesForRemoteMode() throws {
+    let remote = """
+      {
+        "deviceId": "device_1",
+        "organizationId": "org_1",
+        "endpoint": "https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch",
+        "localOnly": false,
+        "auth": {
+          "mode": "bearer",
+          "keychainService": "agentd",
+          "keychainAccount": "chronicle"
+        }
+      }
+      """.data(using: .utf8)!
+    let local = """
+      {
+        "deviceId": "device_1",
+        "organizationId": "org_1",
+        "endpoint": "http://127.0.0.1:8787/chronicle.v1.ChronicleService/SubmitBatch",
+        "localOnly": true
+      }
+      """.data(using: .utf8)!
+
+    XCTAssertTrue(try JSONDecoder().decode(AgentConfig.self, from: remote).encryptLocalBatches)
+    XCTAssertFalse(try JSONDecoder().decode(AgentConfig.self, from: local).encryptLocalBatches)
   }
 
   func testEndpointPolicyRejectsPlainHttpRemoteAndAllowsHttpsAndLoopback() throws {
@@ -340,10 +368,114 @@ final class SubmitterTests: XCTestCase {
     }
   }
 
+  func testEncryptedLocalBatchPersistenceDoesNotWritePlaintext() async throws {
+    let dir = try makeTemporaryDirectory()
+    let submitter = try Submitter(
+      endpoint: URL(string: "http://127.0.0.1:8787/submit")!,
+      localOnly: true,
+      batchDirectory: dir,
+      deviceId: "device_1",
+      encryptLocalBatches: true,
+      localBatchKeyProvider: StaticLocalBatchKeyProvider.one
+    )
+
+    let result = await submitter.submit(Self.batch())
+
+    XCTAssertEqual(result, .persistedLocal)
+    let files = try FileManager.default.contentsOfDirectory(
+      at: dir,
+      includingPropertiesForKeys: nil
+    )
+    let file = try XCTUnwrap(files.first)
+    XCTAssertEqual(file.pathExtension, LocalBatchCryptor.encryptedExtension)
+    let stored = try Data(contentsOf: file)
+    XCTAssertFalse(String(data: stored, encoding: .utf8)?.contains("ChronicleService") ?? false)
+    let plaintext = try LocalBatchCryptor(key: StaticLocalBatchKeyProvider.one.key).decrypt(stored)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: plaintext) as? [String: Any])
+    XCTAssertNotNil(root["batch"])
+  }
+
+  func testEncryptedLocalBatchFailsClosedWithWrongKey() async throws {
+    let dir = try makeTemporaryDirectory()
+    let submitter = try Submitter(
+      endpoint: URL(string: "http://127.0.0.1:8787/submit")!,
+      localOnly: true,
+      batchDirectory: dir,
+      deviceId: "device_1",
+      encryptLocalBatches: true,
+      localBatchKeyProvider: StaticLocalBatchKeyProvider.one
+    )
+    _ = await submitter.submit(Self.batch())
+
+    let file = try XCTUnwrap(
+      FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil).first)
+    let stored = try Data(contentsOf: file)
+    XCTAssertThrowsError(
+      try LocalBatchCryptor(key: StaticLocalBatchKeyProvider.two.key).decrypt(stored)
+    )
+  }
+
+  func testEncryptedLocalBatchReplaySubmitsAndRemovesQueuedFile() async throws {
+    let dir = try makeTemporaryDirectory()
+    let failing = try Submitter(
+      endpoint: URL(string: "https://chronicle.example.com/submit")!,
+      localOnly: false,
+      authMode: .bearer(keychainService: "svc", keychainAccount: "acct"),
+      credentialProvider: StubCredentialProvider(token: "token"),
+      client: StubHTTPClient.status(503, body: #"{"error":"down"}"#),
+      batchDirectory: dir,
+      deviceId: "device_1",
+      encryptLocalBatches: true,
+      localBatchKeyProvider: StaticLocalBatchKeyProvider.one
+    )
+
+    let persistedResult = await failing.submit(Self.batch())
+    XCTAssertEqual(persistedResult, .persistedLocal)
+    let encrypted = try XCTUnwrap(
+      FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil).first)
+    XCTAssertEqual(encrypted.pathExtension, LocalBatchCryptor.encryptedExtension)
+
+    let recorder = RequestRecorder()
+    let replaying = try Submitter(
+      endpoint: URL(string: "https://chronicle.example.com/submit")!,
+      localOnly: false,
+      authMode: .bearer(keychainService: "svc", keychainAccount: "acct"),
+      credentialProvider: StubCredentialProvider(token: "token"),
+      client: StubHTTPClient { request in
+        await recorder.record(request)
+        let body = try XCTUnwrap(request.httpBody)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertNotNil(root["batch"])
+        return (
+          Data(#"{"batchId":"batch_fixture"}"#.utf8),
+          Self.response(for: request.url!, statusCode: 200)
+        )
+      },
+      batchDirectory: dir,
+      deviceId: "device_1",
+      encryptLocalBatches: true,
+      localBatchKeyProvider: StaticLocalBatchKeyProvider.one
+    )
+
+    let replay = await replaying.retryLocalBatches()
+
+    XCTAssertEqual(replay, LocalBatchReplayResult(submitted: 1, failed: 0))
+    let requestCount = await recorder.count()
+    XCTAssertEqual(requestCount, 1)
+    let remaining = try FileManager.default.contentsOfDirectory(
+      at: dir,
+      includingPropertiesForKeys: nil
+    )
+    XCTAssertTrue(remaining.isEmpty)
+  }
+
   func testLocalBatchSweepRemovesOldFiles() async throws {
     let dir = try makeTemporaryDirectory()
     try writeBatchFile(
       dir.appendingPathComponent("old.json"), bytes: 10,
+      modified: Date(timeIntervalSinceNow: -8 * 24 * 60 * 60))
+    try writeBatchFile(
+      dir.appendingPathComponent("old.\(LocalBatchCryptor.encryptedExtension)"), bytes: 10,
       modified: Date(timeIntervalSinceNow: -8 * 24 * 60 * 60))
     try writeBatchFile(dir.appendingPathComponent("new.json"), bytes: 10, modified: Date())
     let submitter = try Submitter(
@@ -356,6 +488,9 @@ final class SubmitterTests: XCTestCase {
     await submitter.sweepLocalBatches()
     XCTAssertFalse(
       FileManager.default.fileExists(atPath: dir.appendingPathComponent("old.json").path))
+    XCTAssertFalse(
+      FileManager.default.fileExists(
+        atPath: dir.appendingPathComponent("old.\(LocalBatchCryptor.encryptedExtension)").path))
     XCTAssertTrue(
       FileManager.default.fileExists(atPath: dir.appendingPathComponent("new.json").path))
   }
@@ -492,5 +627,20 @@ struct StubHTTPClient: HTTPClient {
 
   static func failure(_ error: Error) -> StubHTTPClient {
     StubHTTPClient { _ in throw error }
+  }
+}
+
+struct StaticLocalBatchKeyProvider: @unchecked Sendable, LocalBatchKeyProviding {
+  static let one = StaticLocalBatchKeyProvider(seed: 0x11)
+  static let two = StaticLocalBatchKeyProvider(seed: 0x22)
+
+  let key: SymmetricKey
+
+  init(seed: UInt8) {
+    key = SymmetricKey(data: Data(repeating: seed, count: 32))
+  }
+
+  func localBatchKey(deviceId: String) throws -> SymmetricKey {
+    key
   }
 }

--- a/Tests/agentdTests/SubmitterTests.swift
+++ b/Tests/agentdTests/SubmitterTests.swift
@@ -469,6 +469,90 @@ final class SubmitterTests: XCTestCase {
     XCTAssertTrue(remaining.isEmpty)
   }
 
+  func testEncryptedReplayUsesSecretBrokerWrapping() async throws {
+    let dir = try makeTemporaryDirectory()
+    let failing = try Submitter(
+      endpoint: URL(
+        string: "https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch")!,
+      localOnly: false,
+      authMode: .bearer(keychainService: "agentd", keychainAccount: "chronicle"),
+      secretBroker: SecretBrokerConfig(
+        endpoint: URL(string: "https://secret-broker.example.com/v1/artifacts:wrap")!,
+        sessionTokenKeychainService: "agentd",
+        sessionTokenKeychainAccount: "secret-broker"
+      ),
+      credentialProvider: StubCredentialProvider(tokens: [
+        "agentd:chronicle": "chronicle-token",
+        "agentd:secret-broker": "broker-session",
+      ]),
+      client: StubHTTPClient.status(503, body: #"{"error":"down"}"#),
+      batchDirectory: dir,
+      deviceId: "device_1",
+      encryptLocalBatches: true,
+      localBatchKeyProvider: StaticLocalBatchKeyProvider.one
+    )
+
+    let persistedResult = await failing.submit(Self.batch())
+    XCTAssertEqual(persistedResult, .persistedLocal)
+
+    let recorder = RequestRecorder()
+    let replaying = try Submitter(
+      endpoint: URL(
+        string: "https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch")!,
+      localOnly: false,
+      authMode: .bearer(keychainService: "agentd", keychainAccount: "chronicle"),
+      secretBroker: SecretBrokerConfig(
+        endpoint: URL(string: "https://secret-broker.example.com/v1/artifacts:wrap")!,
+        sessionTokenKeychainService: "agentd",
+        sessionTokenKeychainAccount: "secret-broker"
+      ),
+      credentialProvider: StubCredentialProvider(tokens: [
+        "agentd:chronicle": "chronicle-token",
+        "agentd:secret-broker": "broker-session",
+      ]),
+      client: StubHTTPClient { request in
+        await recorder.record(request)
+        let url = try XCTUnwrap(request.url)
+        let body = try XCTUnwrap(request.httpBody)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        if url.host == "secret-broker.example.com" {
+          let secretData = try XCTUnwrap(root["secret_data"] as? [String: String])
+          XCTAssertNotNil(secretData["chronicle_frame_batch_json"])
+          return (
+            Data(#"{"grant_id":"grant_1","artifact_id":"art_1"}"#.utf8),
+            Self.response(for: url, statusCode: 200)
+          )
+        }
+
+        XCTAssertEqual(url.host, "chronicle.example.com")
+        XCTAssertNil(root["batch"])
+        XCTAssertEqual(root["secretBrokerSessionToken"] as? String, "broker-session")
+        XCTAssertEqual(root["secretBrokerArtifactId"] as? String, "art_1")
+        XCTAssertEqual(root["secretBrokerGrantId"] as? String, "grant_1")
+        return (
+          Data(#"{"batchId":"batch_fixture","artifactId":"art_1"}"#.utf8),
+          Self.response(for: url, statusCode: 200)
+        )
+      },
+      batchDirectory: dir,
+      deviceId: "device_1",
+      encryptLocalBatches: true,
+      localBatchKeyProvider: StaticLocalBatchKeyProvider.one
+    )
+
+    let replay = await replaying.retryLocalBatches()
+
+    XCTAssertEqual(replay, LocalBatchReplayResult(submitted: 1, failed: 0))
+    let requestCount = await recorder.count()
+    XCTAssertEqual(requestCount, 2)
+    let remaining = try FileManager.default.contentsOfDirectory(
+      at: dir,
+      includingPropertiesForKeys: nil
+    )
+    XCTAssertTrue(remaining.isEmpty)
+  }
+
   func testLocalBatchSweepRemovesOldFiles() async throws {
     let dir = try makeTemporaryDirectory()
     try writeBatchFile(

--- a/Tests/agentdTests/SubmitterTests.swift
+++ b/Tests/agentdTests/SubmitterTests.swift
@@ -469,6 +469,61 @@ final class SubmitterTests: XCTestCase {
     XCTAssertTrue(remaining.isEmpty)
   }
 
+  func testConcurrentReplayRequestsDoNotResubmitQueuedBatch() async throws {
+    let dir = try makeTemporaryDirectory()
+    let failing = try Submitter(
+      endpoint: URL(string: "https://chronicle.example.com/submit")!,
+      localOnly: false,
+      authMode: .bearer(keychainService: "svc", keychainAccount: "acct"),
+      credentialProvider: StubCredentialProvider(token: "token"),
+      client: StubHTTPClient.status(503, body: #"{"error":"down"}"#),
+      batchDirectory: dir
+    )
+
+    let persistedResult = await failing.submit(Self.batch(id: "queued_batch"))
+    XCTAssertEqual(persistedResult, .persistedLocal)
+
+    let replayStarted = AsyncSignal()
+    let releaseReplay = AsyncGate()
+    let recorder = StringRecorder()
+    let replaying = try Submitter(
+      endpoint: URL(string: "https://chronicle.example.com/submit")!,
+      localOnly: false,
+      authMode: .bearer(keychainService: "svc", keychainAccount: "acct"),
+      credentialProvider: StubCredentialProvider(token: "token"),
+      client: StubHTTPClient { request in
+        let body = try XCTUnwrap(request.httpBody)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let batch = try XCTUnwrap(root["batch"] as? [String: Any])
+        let batchId = try XCTUnwrap(batch["batchId"] as? String)
+        await recorder.record(batchId)
+        await replayStarted.signal()
+        await releaseReplay.wait()
+        return (Data(), Self.response(for: request.url!, statusCode: 200))
+      },
+      batchDirectory: dir
+    )
+
+    let firstReplay = Task { await replaying.retryLocalBatches() }
+    await replayStarted.wait()
+    let secondReplay = Task { await replaying.retryLocalBatches() }
+    await Task.yield()
+    await releaseReplay.open()
+
+    let firstResult = await firstReplay.value
+    let secondResult = await secondReplay.value
+    let results = [firstResult, secondResult]
+    XCTAssertEqual(secondResult, LocalBatchReplayResult(submitted: 0, failed: 0))
+    XCTAssertEqual(results.reduce(0) { $0 + $1.submitted }, 1)
+    XCTAssertEqual(results.reduce(0) { $0 + $1.failed }, 0)
+    XCTAssertEqual(await recorder.values(), ["queued_batch"])
+    let remaining = try FileManager.default.contentsOfDirectory(
+      at: dir,
+      includingPropertiesForKeys: nil
+    )
+    XCTAssertTrue(remaining.isEmpty)
+  }
+
   func testSuccessfulSubmitRetriesQueuedLocalBatches() async throws {
     let dir = try makeTemporaryDirectory()
     let failing = try Submitter(
@@ -650,6 +705,37 @@ final class SubmitterTests: XCTestCase {
       FileManager.default.fileExists(atPath: dir.appendingPathComponent("newest.json").path))
   }
 
+  func testLocalBatchKeyProviderReadsExistingKeyAfterDuplicateStore() throws {
+    final class DuplicateKeychain: @unchecked Sendable {
+      let persisted = Data(repeating: 0xAA, count: 32)
+      private(set) var readCount = 0
+
+      func read() -> Data? {
+        defer { readCount += 1 }
+        return readCount == 0 ? nil : persisted
+      }
+
+      func store(_ key: Data) -> Bool {
+        XCTAssertEqual(key.count, 32)
+        return false
+      }
+    }
+
+    let keychain = DuplicateKeychain()
+    let provider = KeychainLocalBatchKeyProvider(
+      service: "test.local-batch-key",
+      readKeyData: { _, _ in keychain.read() },
+      storeKeyData: { _, _, key in keychain.store(key) },
+      generateRandomKeyData: { Data(repeating: 0xBB, count: 32) }
+    )
+
+    let key = try provider.localBatchKey(deviceId: "device_1")
+    let keyData = key.withUnsafeBytes { Data($0) }
+
+    XCTAssertEqual(keyData, keychain.persisted)
+    XCTAssertEqual(keychain.readCount, 2)
+  }
+
   static func batch(id: String = "batch_fixture") -> Batch {
     Batch(
       batchId: id,
@@ -724,6 +810,50 @@ actor StringRecorder {
 
   func values() -> [String] {
     recordedValues
+  }
+}
+
+actor AsyncSignal {
+  private var isSignaled = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func wait() async {
+    guard !isSignaled else { return }
+    await withCheckedContinuation { continuation in
+      waiters.append(continuation)
+    }
+  }
+
+  func signal() {
+    guard !isSignaled else { return }
+    isSignaled = true
+    let currentWaiters = waiters
+    waiters.removeAll()
+    for waiter in currentWaiters {
+      waiter.resume()
+    }
+  }
+}
+
+actor AsyncGate {
+  private var isOpen = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func wait() async {
+    guard !isOpen else { return }
+    await withCheckedContinuation { continuation in
+      waiters.append(continuation)
+    }
+  }
+
+  func open() {
+    guard !isOpen else { return }
+    isOpen = true
+    let currentWaiters = waiters
+    waiters.removeAll()
+    for waiter in currentWaiters {
+      waiter.resume()
+    }
   }
 }
 

--- a/Tests/agentdTests/SubmitterTests.swift
+++ b/Tests/agentdTests/SubmitterTests.swift
@@ -469,6 +469,49 @@ final class SubmitterTests: XCTestCase {
     XCTAssertTrue(remaining.isEmpty)
   }
 
+  func testSuccessfulSubmitRetriesQueuedLocalBatches() async throws {
+    let dir = try makeTemporaryDirectory()
+    let failing = try Submitter(
+      endpoint: URL(string: "https://chronicle.example.com/submit")!,
+      localOnly: false,
+      authMode: .bearer(keychainService: "svc", keychainAccount: "acct"),
+      credentialProvider: StubCredentialProvider(token: "token"),
+      client: StubHTTPClient.status(503, body: #"{"error":"down"}"#),
+      batchDirectory: dir
+    )
+
+    let persistedResult = await failing.submit(Self.batch(id: "queued_batch"))
+    XCTAssertEqual(persistedResult, .persistedLocal)
+
+    let recorder = StringRecorder()
+    let replaying = try Submitter(
+      endpoint: URL(string: "https://chronicle.example.com/submit")!,
+      localOnly: false,
+      authMode: .bearer(keychainService: "svc", keychainAccount: "acct"),
+      credentialProvider: StubCredentialProvider(token: "token"),
+      client: StubHTTPClient { request in
+        let body = try XCTUnwrap(request.httpBody)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let batch = try XCTUnwrap(root["batch"] as? [String: Any])
+        let batchId = try XCTUnwrap(batch["batchId"] as? String)
+        await recorder.record(batchId)
+        return (Data(), Self.response(for: request.url!, statusCode: 200))
+      },
+      batchDirectory: dir
+    )
+
+    let result = await replaying.submit(Self.batch(id: "live_batch"))
+
+    XCTAssertEqual(result, .submitted(nil))
+    let submittedBatchIds = await recorder.values()
+    XCTAssertEqual(submittedBatchIds, ["live_batch", "queued_batch"])
+    let remaining = try FileManager.default.contentsOfDirectory(
+      at: dir,
+      includingPropertiesForKeys: nil
+    )
+    XCTAssertTrue(remaining.isEmpty)
+  }
+
   func testEncryptedReplayUsesSecretBrokerWrapping() async throws {
     let dir = try makeTemporaryDirectory()
     let failing = try Submitter(
@@ -669,6 +712,18 @@ actor RequestRecorder {
 
   func count() -> Int {
     requests.count
+  }
+}
+
+actor StringRecorder {
+  private var recordedValues: [String] = []
+
+  func record(_ value: String) {
+    recordedValues.append(value)
+  }
+
+  func values() -> [String] {
+    recordedValues
   }
 }
 

--- a/Tests/agentdTests/SubmitterTests.swift
+++ b/Tests/agentdTests/SubmitterTests.swift
@@ -516,7 +516,8 @@ final class SubmitterTests: XCTestCase {
     XCTAssertEqual(secondResult, LocalBatchReplayResult(submitted: 0, failed: 0))
     XCTAssertEqual(results.reduce(0) { $0 + $1.submitted }, 1)
     XCTAssertEqual(results.reduce(0) { $0 + $1.failed }, 0)
-    XCTAssertEqual(await recorder.values(), ["queued_batch"])
+    let recordedBatchIds = await recorder.values()
+    XCTAssertEqual(recordedBatchIds, ["queued_batch"])
     let remaining = try FileManager.default.contentsOfDirectory(
       at: dir,
       includingPropertiesForKeys: nil


### PR DESCRIPTION
## Summary

- add Keychain-backed AES-GCM encryption for local fallback batches, writing encrypted files as `.agentdbatch`
- default encrypted local fallback on for remote / Secret Broker mode while keeping local-only plaintext unless explicitly enabled
- add replay support that decrypts queued local batches and drains them once Chronicle is reachable again
- extend retention sweeps to cover encrypted files and document the storage/key behavior

## Issues

Refs #30.

## Validation

- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `scripts/package_app.sh`
- `git diff --check`
