### PR TITLE
Carry Chronicle correlation metadata from agentd

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ agentd reads and writes `~/.evalops/agentd/config.json`. Important defaults:
   Broker mode when omitted
 - `auth: { "mode": "none" }`
 
+Optional `metadata` entries are copied into every Chronicle `FrameBatch` and
+Secret Broker wrap request. Use this for non-secret correlation IDs such as
+`maestro_session_id`, `agent_run_id`, `tool_execution_id`, `trace_id`,
+`task_id`, and `source_issue`; Platform preserves these as receipt evidence and
+Cerebro indexes them as Chronicle graph labels.
+
 Remote mode requires `localOnly: false`, an HTTPS or loopback endpoint, and an
 auth mode. Bearer auth references a Keychain item:
 

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -59,6 +59,7 @@ struct AgentConfig: Codable, Sendable {
   var userId: String?
   var projectId: String?
   var repository: String?
+  var metadata: [String: String]
   var endpoint: URL
   var allowedBundleIds: [String]
   var deniedBundleIds: [String]
@@ -89,6 +90,7 @@ struct AgentConfig: Codable, Sendable {
     case userId
     case projectId
     case repository
+    case metadata
     case endpoint
     case allowedBundleIds
     case deniedBundleIds
@@ -119,6 +121,7 @@ struct AgentConfig: Codable, Sendable {
     userId: String? = nil,
     projectId: String? = nil,
     repository: String? = nil,
+    metadata: [String: String] = [:],
     endpoint: URL,
     allowedBundleIds: [String],
     deniedBundleIds: [String],
@@ -147,6 +150,7 @@ struct AgentConfig: Codable, Sendable {
     self.userId = userId
     self.projectId = projectId
     self.repository = repository
+    self.metadata = Self.cleanMetadata(metadata)
     self.endpoint = endpoint
     self.allowedBundleIds = allowedBundleIds
     self.deniedBundleIds = deniedBundleIds
@@ -218,6 +222,19 @@ struct AgentConfig: Codable, Sendable {
     return merged
   }
 
+  private static func cleanMetadata(_ metadata: [String: String]) -> [String: String] {
+    var cleaned: [String: String] = [:]
+    for (rawKey, rawValue) in metadata {
+      let key = rawKey.trimmingCharacters(in: .whitespacesAndNewlines)
+      let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+      if key.isEmpty || value.isEmpty {
+        continue
+      }
+      cleaned[key] = value
+    }
+    return cleaned
+  }
+
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     deviceId = try container.decode(String.self, forKey: .deviceId)
@@ -229,6 +246,9 @@ struct AgentConfig: Codable, Sendable {
     userId = try container.decodeIfPresent(String.self, forKey: .userId)
     projectId = try container.decodeIfPresent(String.self, forKey: .projectId)
     repository = try container.decodeIfPresent(String.self, forKey: .repository)
+    metadata = Self.cleanMetadata(
+      try container.decodeIfPresent([String: String].self, forKey: .metadata) ?? [:]
+    )
     endpoint = try container.decode(URL.self, forKey: .endpoint)
     allowedBundleIds =
       try container.decodeIfPresent([String].self, forKey: .allowedBundleIds)
@@ -277,6 +297,9 @@ struct AgentConfig: Codable, Sendable {
     try container.encodeIfPresent(userId, forKey: .userId)
     try container.encodeIfPresent(projectId, forKey: .projectId)
     try container.encodeIfPresent(repository, forKey: .repository)
+    if !metadata.isEmpty {
+      try container.encode(metadata, forKey: .metadata)
+    }
     try container.encode(endpoint, forKey: .endpoint)
     try container.encode(allowedBundleIds, forKey: .allowedBundleIds)
     try container.encode(deniedBundleIds, forKey: .deniedBundleIds)

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -148,6 +148,7 @@ struct Batch: Sendable, Codable {
   let userId: String?
   let projectId: String?
   let repository: String?
+  let metadata: [String: String]
   let startedAt: Date
   let endedAt: Date
   let captureWindow: CaptureWindow
@@ -162,6 +163,7 @@ struct Batch: Sendable, Codable {
     userId: String?,
     projectId: String?,
     repository: String?,
+    metadata: [String: String] = [:],
     startedAt: Date,
     endedAt: Date,
     captureWindow: CaptureWindow? = nil,
@@ -175,6 +177,7 @@ struct Batch: Sendable, Codable {
     self.userId = userId
     self.projectId = projectId
     self.repository = repository
+    self.metadata = metadata
     self.startedAt = startedAt
     self.endedAt = endedAt
     self.captureWindow = captureWindow ?? CaptureWindow(startedAt: startedAt, endedAt: endedAt)
@@ -190,6 +193,7 @@ struct Batch: Sendable, Codable {
     case userId
     case projectId
     case repository
+    case metadata
     case startedAt
     case endedAt
     case captureWindow
@@ -209,6 +213,7 @@ struct Batch: Sendable, Codable {
       userId: try container.decodeIfPresent(String.self, forKey: .userId),
       projectId: try container.decodeIfPresent(String.self, forKey: .projectId),
       repository: try container.decodeIfPresent(String.self, forKey: .repository),
+      metadata: try container.decodeIfPresent([String: String].self, forKey: .metadata) ?? [:],
       startedAt: startedAt,
       endedAt: endedAt,
       captureWindow: try container.decodeIfPresent(CaptureWindow.self, forKey: .captureWindow),
@@ -435,6 +440,7 @@ actor FramePipeline {
       userId: config.userId,
       projectId: config.projectId,
       repository: config.repository,
+      metadata: config.metadata,
       startedAt: startedAt,
       endedAt: Date(),
       frames: pending,

--- a/Sources/agentd/Submitter.swift
+++ b/Sources/agentd/Submitter.swift
@@ -223,6 +223,18 @@ actor Submitter {
       throw SubmitterError.invalidBatchPayload
     }
     var metadata = batch.metadata
+    for reservedKey in [
+      "batch_id",
+      "device_id",
+      "organization_id",
+      "workspace_id",
+      "user_id",
+      "project_id",
+      "repository",
+      "source",
+    ] {
+      metadata.removeValue(forKey: reservedKey)
+    }
     metadata["batch_id"] = batch.batchId
     metadata["device_id"] = batch.deviceId
     metadata["organization_id"] = batch.organizationId

--- a/Sources/agentd/Submitter.swift
+++ b/Sources/agentd/Submitter.swift
@@ -222,6 +222,24 @@ actor Submitter {
     guard let payloadJSON = String(data: payload, encoding: .utf8) else {
       throw SubmitterError.invalidBatchPayload
     }
+    var metadata = batch.metadata
+    metadata["batch_id"] = batch.batchId
+    metadata["device_id"] = batch.deviceId
+    metadata["organization_id"] = batch.organizationId
+    if let workspaceId = batch.workspaceId {
+      metadata["workspace_id"] = workspaceId
+    }
+    if let userId = batch.userId {
+      metadata["user_id"] = userId
+    }
+    if let projectId = batch.projectId {
+      metadata["project_id"] = projectId
+    }
+    if let repository = batch.repository {
+      metadata["repository"] = repository
+    }
+    metadata["source"] = "agentd"
+
     let request = WrapArtifactRequest(
       sessionToken: secretBroker.sessionToken,
       tool: secretBroker.tool,
@@ -230,12 +248,7 @@ actor Submitter {
       ttlSeconds: secretBroker.ttlSeconds,
       reason: secretBroker.reason,
       secretData: ["chronicle_frame_batch_json": payloadJSON],
-      metadata: [
-        "batch_id": batch.batchId,
-        "device_id": batch.deviceId,
-        "organization_id": batch.organizationId,
-        "source": "agentd",
-      ]
+      metadata: metadata
     )
     let data = try encodeWrapArtifactRequest(request)
     let (body, resp) = try await client.data(

--- a/Tests/agentdTests/SubmitterTests.swift
+++ b/Tests/agentdTests/SubmitterTests.swift
@@ -16,6 +16,10 @@ final class SubmitterTests: XCTestCase {
       userId: "user_1",
       projectId: "project_1",
       repository: "evalops/platform",
+      metadata: [
+        "maestro_session_id": "session_1",
+        "agent_run_id": "run_1",
+      ],
       startedAt: Date(timeIntervalSince1970: 1),
       endedAt: Date(timeIntervalSince1970: 2),
       frames: [
@@ -46,6 +50,9 @@ final class SubmitterTests: XCTestCase {
     XCTAssertEqual(encodedBatch["projectId"] as? String, "project_1")
     XCTAssertNil(encodedBatch["orgId"])
     XCTAssertNotNil(encodedBatch["captureWindow"])
+    let metadata = try XCTUnwrap(encodedBatch["metadata"] as? [String: String])
+    XCTAssertEqual(metadata["maestro_session_id"], "session_1")
+    XCTAssertEqual(metadata["agent_run_id"], "run_1")
 
     let frames = try XCTUnwrap(encodedBatch["frames"] as? [[String: Any]])
     XCTAssertEqual(frames.first?["perceptualHash"] as? String, "42")
@@ -94,6 +101,32 @@ final class SubmitterTests: XCTestCase {
 
     let cfg = try JSONDecoder().decode(AgentConfig.self, from: data)
     XCTAssertEqual(cfg.organizationId, "org_new")
+  }
+
+  func testAgentConfigDecodesAndCleansMetadata() throws {
+    let data = """
+      {
+        "deviceId": "device_1",
+        "organizationId": "org_1",
+        "endpoint": "http://127.0.0.1:8787/chronicle.v1.ChronicleService/SubmitBatch",
+        "localOnly": true,
+        "metadata": {
+          " maestro_session_id ": " session_1 ",
+          "empty_value": " ",
+          "agent_run_id": "run_1"
+        }
+      }
+      """.data(using: .utf8)!
+
+    let cfg = try JSONDecoder().decode(AgentConfig.self, from: data)
+    XCTAssertEqual(cfg.metadata["maestro_session_id"], "session_1")
+    XCTAssertEqual(cfg.metadata["agent_run_id"], "run_1")
+    XCTAssertNil(cfg.metadata["empty_value"])
+
+    let encoded = try JSONEncoder().encode(cfg)
+    let root = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+    let metadata = try XCTUnwrap(root["metadata"] as? [String: String])
+    XCTAssertEqual(metadata["maestro_session_id"], "session_1")
   }
 
   func testAgentConfigDecodesSecretBroker() throws {

--- a/Tests/agentdTests/SubmitterTests.swift
+++ b/Tests/agentdTests/SubmitterTests.swift
@@ -340,6 +340,97 @@ final class SubmitterTests: XCTestCase {
     XCTAssertEqual(requestCount, 2)
   }
 
+  func testSecretBrokerWrapRemovesSpoofedReservedMetadataWhenBatchFieldMissing() async throws {
+    let client = StubHTTPClient { request in
+      let url = try XCTUnwrap(request.url)
+      let body = try XCTUnwrap(request.httpBody)
+      let root = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+      if url.host == "secret-broker.example.com" {
+        let metadata = try XCTUnwrap(root["metadata"] as? [String: String])
+        XCTAssertEqual(metadata["batch_id"], "batch_fixture")
+        XCTAssertEqual(metadata["device_id"], "device_1")
+        XCTAssertEqual(metadata["organization_id"], "org_1")
+        XCTAssertEqual(metadata["source"], "agentd")
+        XCTAssertEqual(metadata["custom"], "kept")
+        XCTAssertNil(metadata["workspace_id"])
+        XCTAssertNil(metadata["user_id"])
+        XCTAssertNil(metadata["project_id"])
+        XCTAssertNil(metadata["repository"])
+
+        let response = """
+          {
+            "grant_id": "grant_1",
+            "artifact_id": "art_1"
+          }
+          """
+        return (Data(response.utf8), Self.response(for: url, statusCode: 200))
+      }
+
+      return (Data(), Self.response(for: url, statusCode: 200))
+    }
+
+    let batch = Batch(
+      batchId: "batch_fixture",
+      deviceId: "device_1",
+      organizationId: "org_1",
+      workspaceId: nil,
+      userId: nil,
+      projectId: nil,
+      repository: nil,
+      metadata: [
+        "batch_id": "spoofed-batch",
+        "device_id": "spoofed-device",
+        "organization_id": "spoofed-org",
+        "workspace_id": "spoofed-workspace",
+        "user_id": "spoofed-user",
+        "project_id": "spoofed-project",
+        "repository": "spoofed/repo",
+        "source": "spoofed-source",
+        "custom": "kept",
+      ],
+      startedAt: Date(timeIntervalSince1970: 1),
+      endedAt: Date(timeIntervalSince1970: 2),
+      frames: [
+        ProcessedFrame(
+          frameHash: String(repeating: "a", count: 64),
+          perceptualHash: 42,
+          capturedAt: Date(timeIntervalSince1970: 1),
+          bundleId: "com.microsoft.VSCode",
+          appName: "Code",
+          windowTitle: "chronicle.proto",
+          documentPath: nil,
+          ocrText: "ChronicleService SubmitBatch",
+          ocrConfidence: 0.93,
+          widthPx: 10,
+          heightPx: 10,
+          bytesPng: 400
+        )
+      ],
+      droppedCounts: DropCounts(secret: 0, duplicate: 0, deniedApp: 0, deniedPath: 0)
+    )
+
+    let submitter = try Submitter(
+      endpoint: URL(
+        string: "https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch")!,
+      localOnly: false,
+      authMode: .bearer(keychainService: "agentd", keychainAccount: "chronicle"),
+      secretBroker: SecretBrokerConfig(
+        endpoint: URL(string: "https://secret-broker.example.com/v1/artifacts:wrap")!,
+        sessionTokenKeychainService: "agentd",
+        sessionTokenKeychainAccount: "secret-broker"
+      ),
+      credentialProvider: StubCredentialProvider(tokens: [
+        "agentd:chronicle": "chronicle-token",
+        "agentd:secret-broker": "broker-session",
+      ]),
+      client: client
+    )
+
+    let result = await submitter.submit(batch)
+    XCTAssertEqual(result, .submitted(nil))
+  }
+
   func testSecretBrokerWrapFailurePersistsInlineBatchWithoutSessionToken() async throws {
     let recorder = RequestRecorder()
     let dir = try makeTemporaryDirectory()


### PR DESCRIPTION
## Summary
- add optional non-secret `metadata` to agentd config and every Chronicle `FrameBatch`
- pass the same metadata into Secret Broker wrap requests alongside batch/device/org fields
- document the Maestro/Chronicle correlation keys and cover config/batch encoding in tests

## Validation
- `swift test`

Part of evalops/platform#1075.