### PR TITLE
docs: add agentd workflow rails

### DIFF
--- a/.agents/skills/agentd-chronicle-privacy-pr/SKILL.md
+++ b/.agents/skills/agentd-chronicle-privacy-pr/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: agentd-chronicle-privacy-pr
+description: Use when changing agentd Chronicle capture, privacy, local storage, permissions, policy sync, Secret Broker, or Platform contract behavior.
+---
+
+# agentd Chronicle Privacy PR
+
+Use this workflow for agentd changes that touch capture, privacy, storage, transport, policy, or Chronicle contracts.
+
+## Start
+
+1. Check live state:
+   - `gh issue list --repo evalops/agentd --limit 20`
+   - `gh pr list --repo evalops/agentd --limit 20`
+   - `gh issue list --repo evalops/platform --search Chronicle --limit 20`
+2. Identify whether the change affects:
+   - Screen Recording or Accessibility permissions
+   - OCR, pHash, secret scanning, or frame dropping
+   - local fallback batches or encryption
+   - Chronicle RegisterDevice, Heartbeat, or SubmitBatch shape
+   - Secret Broker artifact wrapping
+   - policy pause precedence
+
+## Implementation Rules
+
+- Preserve fail-closed secret scanning and pause precedence unless the issue explicitly asks for a behavior change.
+- Do not log OCR text, raw frame payloads, secrets, Keychain values, or unredacted document paths.
+- Keep request fixtures and the strict mock Chronicle harness aligned with any request-shape change.
+- If generated Swift Chronicle types become available, prefer them over handwritten request structs and add an explicit drift gate.
+
+## Verification
+
+Run the narrow checks that match the touched surface:
+
+```bash
+swift test
+python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
+```
+
+For packaging or permission work:
+
+```bash
+scripts/package_app.sh
+scripts/permission_smoke.sh --no-launch
+```
+
+If hardware-backed macOS permission prompts cannot be verified in the current environment, say that clearly.
+
+## PR Body Checklist
+
+- Privacy/security impact.
+- Chronicle or Platform contract impact.
+- Commands run and result.
+- Any manual hardware, signing, notarization, or Platform follow-up.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Repository Instructions
+
+## Scope
+
+agentd is the macOS desktop capture client for the EvalOps Chronicle pipeline. Treat privacy, local data handling, permissions, and Platform contract drift as first-class product behavior.
+
+## Codex App Operating Rails
+
+- Prefer Codex App Worktree mode for changes in this repository so packaging, permission-smoke, and Chronicle contract experiments stay isolated.
+- Before changing Chronicle request shape, policy handling, or Secret Broker behavior, check related live issues/PRs in `evalops/agentd` and `evalops/platform` with `gh`.
+- Keep local-only behavior safe by default. Do not weaken fail-closed secret scanning, pause precedence, local file permissions, HTTPS/client-auth requirements, or encrypted fallback behavior without an explicit issue.
+- Do not commit local batch data, diagnostics output, packaged apps, archives, signing identities, notarization credentials, or Keychain-derived material.
+
+## Verification Defaults
+
+- Run `swift test` for code changes.
+- Run `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle` for Chronicle contract or fixture changes.
+- Run `scripts/package_app.sh` when changing packaging, entitlements, launch-at-login, or notarization paths.
+- Run `scripts/permission_smoke.sh --no-launch` when changing Screen Recording or Accessibility permission flows and note that hardware-backed prompts still need manual verification.
+
+## PR Expectations
+
+- Include privacy/security impact in the PR body for capture, storage, policy, or transport changes.
+- Include the exact Platform contract, issue, or fixture touched when request/response shapes change.
+- Keep app behavior, fixtures, and README updates together when a user-visible safety property changes.


### PR DESCRIPTION
## Summary
- add repository AGENTS.md guidance for Chronicle privacy, permissions, local storage, and contract-safe work
- add agentd-chronicle-privacy-pr skill for capture, privacy, Secret Broker, and Platform contract changes

## Test plan
- inspected git diff and skill frontmatter locally
- docs/workflow-only change; runtime tests not run