### PR TITLE
ci: sync shared GitHub Actions rails

### DIFF
--- a/.github/workflows/codex-rails-check.yml
+++ b/.github/workflows/codex-rails-check.yml
@@ -15,6 +15,6 @@ permissions:
 
 jobs:
   validate:
-    uses: evalops/.github/.github/workflows/codex-rails-check.yml@0944b072407d5cdd9447e8262661e5929bc1a4d4
+    uses: evalops/.github/.github/workflows/codex-rails-check.yml@ec91f80b667b8b672f5db3f2300d05c30475dfc4
     with:
       require_agents: true


### PR DESCRIPTION
## Summary
- repin Codex Rails to evalops/.github@ec91f80 so this repo gets the shared timeout, Blacksmith runner, and Ruby-test rails

## Verification
- actionlint .github/workflows/codex-rails-check.yml
- git diff --check