### PR TITLE
fix: address agentd backlog feedback

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -98,7 +98,10 @@ jobs:
       - name: Record checksums
         run: |
           set -euo pipefail
-          shasum -a 256 "dist/EvalOps agentd.app/Contents/MacOS/agentd" "dist/agentd.zip" "dist/update-channel.json" | tee dist/SHA256SUMS
+          (
+            cd dist
+            shasum -a 256 "EvalOps agentd.app/Contents/MacOS/agentd" "agentd.zip" "update-channel.json" | tee SHA256SUMS
+          )
           codesign -dvvv --entitlements :- "dist/EvalOps agentd.app" > dist/codesign.txt 2>&1
           spctl -a -t exec -vv "dist/EvalOps agentd.app" > dist/spctl.txt 2>&1
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,11 @@ Secret Broker wrap request. Use this for non-secret correlation IDs such as
 `evalops_context_version`, `maestro_session_id`, `agent_run_id`,
 `tool_execution_id`, `trace_id`, `traceparent`, `task_id`, and `source_issue`;
 Platform preserves these as receipt evidence and Cerebro indexes them as
-Chronicle graph labels.
+Chronicle graph labels. agentd centralizes the `evalops.context.v1` keys in
+`EvalOpsContextMetadata`, preserving unknown keys while dropping malformed
+canonical values such as invalid `traceparent` strings. This mirrors the
+Platform envelope contract and Maestro emitter shape tracked in
+evalops/platform#1201 and evalops/maestro-internal#1538.
 
 Remote mode requires `localOnly: false`, an HTTPS or loopback endpoint, and an
 auth mode. Bearer auth references a Keychain item:

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -150,7 +150,7 @@ struct AgentConfig: Codable, Sendable {
     self.userId = userId
     self.projectId = projectId
     self.repository = repository
-    self.metadata = Self.cleanMetadata(metadata)
+    self.metadata = EvalOpsContextMetadata.clean(metadata)
     self.endpoint = endpoint
     self.allowedBundleIds = allowedBundleIds
     self.deniedBundleIds = deniedBundleIds
@@ -222,19 +222,6 @@ struct AgentConfig: Codable, Sendable {
     return merged
   }
 
-  private static func cleanMetadata(_ metadata: [String: String]) -> [String: String] {
-    var cleaned: [String: String] = [:]
-    for (rawKey, rawValue) in metadata {
-      let key = rawKey.trimmingCharacters(in: .whitespacesAndNewlines)
-      let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-      if key.isEmpty || value.isEmpty {
-        continue
-      }
-      cleaned[key] = value
-    }
-    return cleaned
-  }
-
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     deviceId = try container.decode(String.self, forKey: .deviceId)
@@ -246,7 +233,7 @@ struct AgentConfig: Codable, Sendable {
     userId = try container.decodeIfPresent(String.self, forKey: .userId)
     projectId = try container.decodeIfPresent(String.self, forKey: .projectId)
     repository = try container.decodeIfPresent(String.self, forKey: .repository)
-    metadata = Self.cleanMetadata(
+    metadata = EvalOpsContextMetadata.clean(
       try container.decodeIfPresent([String: String].self, forKey: .metadata) ?? [:]
     )
     endpoint = try container.decode(URL.self, forKey: .endpoint)

--- a/Sources/agentd/EvalOpsContextMetadata.swift
+++ b/Sources/agentd/EvalOpsContextMetadata.swift
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import Foundation
+
+struct EvalOpsContextMetadata: Sendable, Equatable {
+  static let contextVersionKey = "evalops_context_version"
+  static let expectedContextVersion = "evalops.context.v1"
+  static let maestroSessionIdKey = "maestro_session_id"
+  static let agentRunIdKey = "agent_run_id"
+  static let toolExecutionIdKey = "tool_execution_id"
+  static let traceIdKey = "trace_id"
+  static let traceparentKey = "traceparent"
+  static let taskIdKey = "task_id"
+  static let sourceIssueKey = "source_issue"
+
+  private static let traceparentRegex =
+    try! NSRegularExpression(
+      pattern: #"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$"#,
+      options: []
+    )
+
+  let values: [String: String]
+
+  init(_ metadata: [String: String]) {
+    values = Self.clean(metadata)
+  }
+
+  static func clean(_ metadata: [String: String]) -> [String: String] {
+    var cleaned: [String: String] = [:]
+    for (rawKey, rawValue) in metadata {
+      let key = rawKey.trimmingCharacters(in: .whitespacesAndNewlines)
+      let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !key.isEmpty, !value.isEmpty else { continue }
+      guard acceptsCanonicalValue(key: key, value: value) else { continue }
+      cleaned[key] = value
+    }
+    return cleaned
+  }
+
+  static func frameBatchMetadata(
+    base metadata: [String: String],
+    batch: Batch,
+    source: String = "agentd"
+  ) -> [String: String] {
+    var values = clean(metadata)
+    for reservedKey in [
+      "batch_id",
+      "device_id",
+      "organization_id",
+      "workspace_id",
+      "user_id",
+      "project_id",
+      "repository",
+      "source",
+    ] {
+      values.removeValue(forKey: reservedKey)
+    }
+    values["batch_id"] = batch.batchId
+    values["device_id"] = batch.deviceId
+    values["organization_id"] = batch.organizationId
+    if let workspaceId = batch.workspaceId {
+      values["workspace_id"] = workspaceId
+    }
+    if let userId = batch.userId {
+      values["user_id"] = userId
+    }
+    if let projectId = batch.projectId {
+      values["project_id"] = projectId
+    }
+    if let repository = batch.repository {
+      values["repository"] = repository
+    }
+    values["source"] = source
+    return values
+  }
+
+  private static func acceptsCanonicalValue(key: String, value: String) -> Bool {
+    switch key {
+    case contextVersionKey:
+      return value == expectedContextVersion
+    case traceparentKey:
+      let range = NSRange(value.startIndex..<value.endIndex, in: value)
+      return traceparentRegex.firstMatch(in: value, options: [], range: range) != nil
+    default:
+      return true
+    }
+  }
+}

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -316,12 +316,12 @@ actor FramePipeline {
   private var droppedDeniedPath = 0
   private var droppedBackpressure = 0
 
-  private let onBatch: @Sendable (Batch) async -> Void
+  private let onBatch: @Sendable (Batch) async -> SubmitResult
 
   init(
     config: AgentConfig,
     ocr: any OCRRecognizing = VisionOCR(),
-    onBatch: @escaping @Sendable (Batch) async -> Void
+    onBatch: @escaping @Sendable (Batch) async -> SubmitResult
   ) {
     self.config = config
     self.ocr = ocr
@@ -459,7 +459,15 @@ actor FramePipeline {
     droppedDeniedPath = 0
     droppedBackpressure = 0
     startedAt = Date()
-    await onBatch(batch)
+    let result = await onBatch(batch)
+    guard case .failed = result else { return }
+    pending = batch.frames + pending
+    droppedSecret += batch.droppedCounts.secret
+    droppedDup += batch.droppedCounts.duplicate
+    droppedDeniedApp += batch.droppedCounts.deniedApp
+    droppedDeniedPath += batch.droppedCounts.deniedPath
+    droppedBackpressure += batch.droppedCounts.droppedBackpressure
+    startedAt = min(startedAt, batch.startedAt)
   }
 
   private func hasDrops() -> Bool {

--- a/Sources/agentd/SecretScrubber.swift
+++ b/Sources/agentd/SecretScrubber.swift
@@ -30,10 +30,13 @@ struct SecretScrubber: Sendable {
       ("azure_storage_key", #"AccountKey=[A-Za-z0-9+/=]{86,90}"#),
       ("mailgun_key", #"\bkey-[0-9a-f]{32}\b"#),
       ("twilio_api_key", #"\bSK[a-f0-9]{32}\b"#),
-      ("discord_bot_token", #"\b[A-Za-z0-9_-]{24}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}\b"#),
+      (
+        "discord_bot_token",
+        #"(?i)\b(?:discord|bot|token|authorization)[\w\s:="'-]{0,30}[A-Za-z0-9_-]{24}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}\b"#
+      ),
       ("slack_bot", #"\bxox[abprs]-[A-Za-z0-9-]{10,}\b"#),
       ("anthropic_key", #"\bsk-ant-[A-Za-z0-9-_]{20,}\b"#),
-      ("openai_key", #"\bsk-(?:proj-|svcacct-|admin-|None-)?[A-Za-z0-9]{32,}\b"#),
+      ("openai_key", #"\bsk-(?:proj-|svcacct-|admin-|None-)?[A-Za-z0-9_-]{32,}\b"#),
       ("stripe_live", #"\b(?:rk|sk)_live_[A-Za-z0-9]{20,}\b"#),
       ("pem_certreq", #"-----BEGIN\s+CERTIFICATE\s+REQUEST-----"#),
       ("password_field", #"(?i)\b(password|passwd|secret|api[_-]?key)\b\s*[:=]\s*\S{4,}"#),

--- a/Sources/agentd/Submitter.swift
+++ b/Sources/agentd/Submitter.swift
@@ -111,7 +111,10 @@ actor Submitter {
     }
 
     if localOnly {
-      await persistLocal(batch.batchId, data: fallbackData)
+      guard await persistLocal(batch.batchId, data: fallbackData) else {
+        lastResultDescription = "failed to persist local batch \(batch.batchId)"
+        return .failed
+      }
       lastResultDescription = "persisted local batch \(batch.batchId)"
       return .persistedLocal
     }
@@ -123,7 +126,10 @@ actor Submitter {
       Log.submit.warning(
         "remote submit prepare failed batch=\(batch.batchId, privacy: .public) error=\(error.localizedDescription, privacy: .public) — falling back to local"
       )
-      await persistLocal(batch.batchId, data: fallbackData)
+      guard await persistLocal(batch.batchId, data: fallbackData) else {
+        lastResultDescription = "failed to persist local fallback batch \(batch.batchId)"
+        return .failed
+      }
       lastResultDescription = "persisted local fallback batch \(batch.batchId)"
       return .persistedLocal
     }
@@ -140,7 +146,10 @@ actor Submitter {
       return result
     }
 
-    await persistLocal(batch.batchId, data: fallbackData)
+    guard await persistLocal(batch.batchId, data: fallbackData) else {
+      lastResultDescription = "failed to persist local fallback batch \(batch.batchId)"
+      return .failed
+    }
     lastResultDescription = "persisted local fallback batch \(batch.batchId)"
     return .persistedLocal
   }
@@ -158,7 +167,11 @@ actor Submitter {
     )
   }
 
-  private func submitRemoteData(_ data: Data, batchId: String) async -> SubmitResult {
+  private func submitRemoteData(
+    _ data: Data,
+    batchId: String,
+    sweepAfterSuccess: Bool = true
+  ) async -> SubmitResult {
     let req = makeRequest(body: data)
     do {
       let (body, resp) = try await client.data(for: req)
@@ -184,7 +197,9 @@ actor Submitter {
         Log.submit.info(
           "submit ok batch=\(batchId, privacy: .public)"
         )
-        await sweepLocalBatches()
+        if sweepAfterSuccess {
+          await sweepLocalBatches()
+        }
         return .submitted(response)
       }
     } catch {
@@ -222,35 +237,7 @@ actor Submitter {
     guard let payloadJSON = String(data: payload, encoding: .utf8) else {
       throw SubmitterError.invalidBatchPayload
     }
-    var metadata = batch.metadata
-    for reservedKey in [
-      "batch_id",
-      "device_id",
-      "organization_id",
-      "workspace_id",
-      "user_id",
-      "project_id",
-      "repository",
-      "source",
-    ] {
-      metadata.removeValue(forKey: reservedKey)
-    }
-    metadata["batch_id"] = batch.batchId
-    metadata["device_id"] = batch.deviceId
-    metadata["organization_id"] = batch.organizationId
-    if let workspaceId = batch.workspaceId {
-      metadata["workspace_id"] = workspaceId
-    }
-    if let userId = batch.userId {
-      metadata["user_id"] = userId
-    }
-    if let projectId = batch.projectId {
-      metadata["project_id"] = projectId
-    }
-    if let repository = batch.repository {
-      metadata["repository"] = repository
-    }
-    metadata["source"] = "agentd"
+    let metadata = EvalOpsContextMetadata.frameBatchMetadata(base: batch.metadata, batch: batch)
 
     let request = WrapArtifactRequest(
       sessionToken: secretBroker.sessionToken,
@@ -276,8 +263,15 @@ actor Submitter {
     return WrappedArtifact(artifactId: wrapped.artifactId, grantId: wrapped.grantId)
   }
 
-  private func persistLocal(_ id: String, data: Data) async {
-    try? FileManager.default.createDirectory(at: batchDirectory, withIntermediateDirectories: true)
+  private func persistLocal(_ id: String, data: Data) async -> Bool {
+    do {
+      try FileManager.default.createDirectory(at: batchDirectory, withIntermediateDirectories: true)
+    } catch {
+      Log.submit.error(
+        "local batch directory create failed id=\(id, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+      )
+      return false
+    }
     let url: URL
     let dataToWrite: Data
     if let localBatchCryptor {
@@ -290,16 +284,24 @@ actor Submitter {
         Log.submit.error(
           "local batch encrypt failed id=\(id, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
         )
-        return
+        return false
       }
     } else {
       dataToWrite = data
       url = batchDirectory.appendingPathComponent("\(id).json")
     }
-    try? dataToWrite.write(to: url, options: .atomic)
-    try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    do {
+      try dataToWrite.write(to: url, options: .atomic)
+      try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    } catch {
+      Log.submit.error(
+        "local batch write failed id=\(id, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+      )
+      return false
+    }
     Log.submit.info("local persist \(url.path, privacy: .public)")
     await sweepLocalBatches()
+    return true
   }
 
   func retryLocalBatches() async -> LocalBatchReplayResult {
@@ -351,7 +353,11 @@ actor Submitter {
         continue
       }
 
-      let result = await submitRemoteData(submitData, batchId: file.batchId)
+      let result = await submitRemoteData(
+        submitData,
+        batchId: file.batchId,
+        sweepAfterSuccess: false
+      )
       switch result {
       case .submitted:
         try? FileManager.default.removeItem(at: file.url)

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -241,7 +241,7 @@ final class AppController {
     return HeartbeatRequest(
       deviceId: config.deviceId,
       organizationId: config.organizationId,
-      pendingFrameCount: pending.frameCount + local.fileCount,
+      pendingFrameCount: pending.frameCount,
       pendingBytes: pending.estimatedBytes + local.bytes,
       paused: pauseState.paused,
       pauseReason: pauseState.reason
@@ -283,8 +283,6 @@ final class AppController {
       await capture.updateFps(idleMode ? config.idleFps : config.captureFps)
     }
     await reconcileCaptureState()
-    schedulePauseWindowTimer()
-    updateMenuStatus()
   }
 
   private func reconcileCaptureState() async {

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -156,6 +156,27 @@ final class PipelineTests: XCTestCase {
     XCTAssertEqual(batch.frames.count, 1)
   }
 
+  func testFailedSubmitKeepsBatchPendingForRetry() async throws {
+    let recorder = BatchRecorder(result: .failed)
+    let pipeline = FramePipeline(config: Self.config(), ocr: StubOCR(text: "clean")) { batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+    await pipeline.flush()
+    let failedStats = await pipeline.pendingStats()
+    XCTAssertEqual(failedStats.frameCount, 1)
+
+    await recorder.setResult(.submitted(nil))
+    await pipeline.flush()
+
+    let batches = await recorder.snapshot()
+    XCTAssertEqual(batches.count, 2)
+    XCTAssertEqual(batches.last?.frames.count, 1)
+    let succeededStats = await pipeline.pendingStats()
+    XCTAssertEqual(succeededStats.frameCount, 0)
+  }
+
   func testFlushEmitsDropOnlyBatch() async throws {
     let recorder = BatchRecorder()
     let pipeline = FramePipeline(config: Self.config(), ocr: StubOCR(text: "clean")) { batch in
@@ -331,9 +352,20 @@ final class PipelineTests: XCTestCase {
 
 actor BatchRecorder {
   private(set) var batches: [Batch] = []
+  private var result: SubmitResult
 
-  func append(_ batch: Batch) {
+  init(result: SubmitResult = .submitted(nil)) {
+    self.result = result
+  }
+
+  @discardableResult
+  func append(_ batch: Batch) -> SubmitResult {
     batches.append(batch)
+    return result
+  }
+
+  func setResult(_ result: SubmitResult) {
+    self.result = result
   }
 
   func snapshot() -> [Batch] {

--- a/Tests/agentdTests/SecretScrubberTests.swift
+++ b/Tests/agentdTests/SecretScrubberTests.swift
@@ -45,10 +45,11 @@ final class SecretScrubberTests: XCTestCase {
       ("twilio_api_key", "SK" + String(repeating: "a", count: 32)),
       (
         "discord_bot_token",
-        String(repeating: "A", count: 24) + "." + String(repeating: "B", count: 6) + "."
+        "discord_token=" + String(repeating: "A", count: 24) + "."
+          + String(repeating: "B", count: 6) + "."
           + String(repeating: "C", count: 27)
       ),
-      ("openai_key", "sk-proj-" + String(repeating: "A", count: 32)),
+      ("openai_key", "sk-proj-" + String(repeating: "A_", count: 16)),
     ]
 
     for (reason, token) in fixtures {
@@ -58,6 +59,13 @@ final class SecretScrubberTests: XCTestCase {
 
   func testOpenAIKeyPatternAvoidsShortSkNoise() {
     XCTAssertEqual(SecretScrubber.evaluate("not a provider key: sk-demo"), .clean)
+  }
+
+  func testDiscordPatternRequiresProviderContext() {
+    let dotted =
+      String(repeating: "A", count: 24) + "." + String(repeating: "B", count: 6) + "."
+      + String(repeating: "C", count: 27)
+    XCTAssertEqual(SecretScrubber.evaluate("ordinary dotted identifier \(dotted)"), .clean)
   }
 
   func testPathPolicyDeniesSshAndAws() {

--- a/Tests/agentdTests/SubmitterTests.swift
+++ b/Tests/agentdTests/SubmitterTests.swift
@@ -142,6 +142,29 @@ final class SubmitterTests: XCTestCase {
       metadata["traceparent"], "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01")
   }
 
+  func testEvalOpsContextMetadataDropsMalformedCanonicalValuesAndPreservesUnknownKeys() throws {
+    let metadata = EvalOpsContextMetadata.clean([
+      " evalops_context_version ": " evalops.context.v1 ",
+      "traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+      "custom": " kept ",
+      "bad_trace": "ignored",
+    ])
+
+    XCTAssertEqual(metadata["evalops_context_version"], "evalops.context.v1")
+    XCTAssertEqual(
+      metadata["traceparent"], "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01")
+    XCTAssertEqual(metadata["custom"], "kept")
+
+    let malformed = EvalOpsContextMetadata.clean([
+      "evalops_context_version": "evalops.context.v2",
+      "traceparent": "not-a-traceparent",
+      "custom": "kept",
+    ])
+    XCTAssertNil(malformed["evalops_context_version"])
+    XCTAssertNil(malformed["traceparent"])
+    XCTAssertEqual(malformed["custom"], "kept")
+  }
+
   func testAgentConfigDecodesSecretBroker() throws {
     let data = """
       {
@@ -534,6 +557,23 @@ final class SubmitterTests: XCTestCase {
     XCTAssertNotNil(root["batch"])
   }
 
+  func testLocalPersistFailureReturnsFailedInsteadOfPretendingQueued() async throws {
+    let dir = try makeTemporaryDirectory()
+    let occupiedPath = dir.appendingPathComponent("not-a-directory")
+    try Data("occupied".utf8).write(to: occupiedPath)
+    let submitter = try Submitter(
+      endpoint: URL(string: "http://127.0.0.1:8787/submit")!,
+      localOnly: true,
+      batchDirectory: occupiedPath
+    )
+
+    let result = await submitter.submit(Self.batch())
+
+    XCTAssertEqual(result, .failed)
+    let description = await submitter.lastSubmitResult()
+    XCTAssertEqual(description, "failed to persist local batch batch_fixture")
+  }
+
   func testEncryptedLocalBatchFailsClosedWithWrongKey() async throws {
     let dir = try makeTemporaryDirectory()
     let submitter = try Submitter(
@@ -700,6 +740,52 @@ final class SubmitterTests: XCTestCase {
     XCTAssertEqual(result, .submitted(nil))
     let submittedBatchIds = await recorder.values()
     XCTAssertEqual(submittedBatchIds, ["live_batch", "queued_batch"])
+    let remaining = try FileManager.default.contentsOfDirectory(
+      at: dir,
+      includingPropertiesForKeys: nil
+    )
+    XCTAssertTrue(remaining.isEmpty)
+  }
+
+  func testReplayDoesNotSweepUnsubmittedQueuedFilesDuringPass() async throws {
+    let dir = try makeTemporaryDirectory()
+    try writeBatchRequestFile(
+      dir.appendingPathComponent("oldest.json"),
+      batch: Self.batch(id: "oldest"),
+      modified: Date(timeIntervalSince1970: 1))
+    try writeBatchRequestFile(
+      dir.appendingPathComponent("middle.json"),
+      batch: Self.batch(id: "middle"),
+      modified: Date(timeIntervalSince1970: 2))
+    try writeBatchRequestFile(
+      dir.appendingPathComponent("newest.json"),
+      batch: Self.batch(id: "newest"),
+      modified: Date(timeIntervalSince1970: 3))
+
+    let recorder = StringRecorder()
+    let submitter = try Submitter(
+      endpoint: URL(string: "https://chronicle.example.com/submit")!,
+      localOnly: false,
+      authMode: .bearer(keychainService: "svc", keychainAccount: "acct"),
+      credentialProvider: StubCredentialProvider(token: "token"),
+      client: StubHTTPClient { request in
+        let body = try XCTUnwrap(request.httpBody)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let batch = try XCTUnwrap(root["batch"] as? [String: Any])
+        let batchId = try XCTUnwrap(batch["batchId"] as? String)
+        await recorder.record(batchId)
+        return (Data(), Self.response(for: request.url!, statusCode: 200))
+      },
+      batchDirectory: dir,
+      maxBatchBytes: 150,
+      maxBatchAgeDays: 365 * 100
+    )
+
+    let replay = await submitter.retryLocalBatches()
+
+    XCTAssertEqual(replay, LocalBatchReplayResult(submitted: 3, failed: 0))
+    let submittedBatchIds = await recorder.values()
+    XCTAssertEqual(submittedBatchIds, ["oldest", "middle", "newest"])
     let remaining = try FileManager.default.contentsOfDirectory(
       at: dir,
       includingPropertiesForKeys: nil
@@ -916,6 +1002,11 @@ final class SubmitterTests: XCTestCase {
 
   private func writeBatchFile(_ url: URL, bytes: Int, modified: Date) throws {
     try Data(repeating: 0x41, count: bytes).write(to: url)
+    try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: url.path)
+  }
+
+  private func writeBatchRequestFile(_ url: URL, batch: Batch, modified: Date) throws {
+    try encodeSubmitBatchRequest(batch, localOnly: false).write(to: url)
     try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: url.path)
   }
 

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -13,6 +13,11 @@ entitlements="${AGENTD_ENTITLEMENTS:-"$root/support/agentd.entitlements"}"
 
 mkdir -p "$dist_dir"
 
+create_zip() {
+  rm -f "$zip_path"
+  ditto -c -k --keepParent "$app_path" "$zip_path"
+}
+
 swift build -c "$configuration" --product "$product"
 build_bin_dir="$(swift build -c "$configuration" --product "$product" --show-bin-path)"
 binary="$build_bin_dir/$product"
@@ -20,6 +25,7 @@ binary="$build_bin_dir/$product"
 rm -rf "$app_path" "$zip_path"
 mkdir -p "$app_path/Contents/MacOS" "$app_path/Contents/Resources"
 cp "$root/support/Info.plist" "$app_path/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleExecutable $product" "$app_path/Contents/Info.plist"
 cp "$binary" "$app_path/Contents/MacOS/$product"
 chmod 0755 "$app_path/Contents/MacOS/$product"
 
@@ -35,7 +41,7 @@ fi
 codesign "${codesign_args[@]}" "$app_path"
 codesign --verify --strict --deep --verbose=2 "$app_path"
 
-ditto -c -k --keepParent "$app_path" "$zip_path"
+create_zip
 
 notarized=0
 if [[ -n "${AGENTD_NOTARY_PROFILE:-}" ]]; then
@@ -56,8 +62,13 @@ fi
 
 if [[ "$notarized" == "1" ]] && command -v spctl >/dev/null 2>&1; then
   spctl -a -t exec -vv "$app_path"
+  create_zip
 fi
 
+notarized_json=false
+if [[ "$notarized" == "1" ]]; then
+  notarized_json=true
+fi
 zip_sha256="$(shasum -a 256 "$zip_path" | awk '{print $1}')"
 app_binary_sha256="$(shasum -a 256 "$app_path/Contents/MacOS/$product" | awk '{print $1}')"
 cat > "$dist_dir/update-channel.json" <<JSON
@@ -69,7 +80,7 @@ cat > "$dist_dir/update-channel.json" <<JSON
   "archiveSha256": "$zip_sha256",
   "appBinarySha256": "$app_binary_sha256",
   "codesignIdentity": "$identity",
-  "notarized": $notarized
+  "notarized": $notarized_json
 }
 JSON
 

--- a/scripts/permission_smoke.sh
+++ b/scripts/permission_smoke.sh
@@ -44,7 +44,11 @@ if [[ -f "$root/dist/agentd.zip" ]]; then
 fi
 macos_version="$(sw_vers -productVersion)"
 build_version="$(sw_vers -buildVersion)"
-codesign_summary="$(codesign -dv "$app_path" 2>&1 | sed -n 's/^Authority=//p' | paste -sd ', ' -)"
+codesign_summary="$(
+  codesign -dvv "$app_path" 2>&1 \
+    | sed -n 's/^Authority=//p' \
+    | awk 'NF { if (seen++) printf ", "; printf "%s", $0 } END { if (seen) print "" }'
+)"
 
 cat > "$report_path" <<REPORT
 # agentd Permission Smoke Report

--- a/support/Info.plist
+++ b/support/Info.plist
@@ -8,6 +8,8 @@
     <string>agentd</string>
     <key>CFBundleDisplayName</key>
     <string>EvalOps agentd</string>
+    <key>CFBundleExecutable</key>
+    <string>agentd</string>
     <key>CFBundleVersion</key>
     <string>0.0.1</string>
     <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## Summary
- add a typed `EvalOpsContextMetadata` helper for canonical `evalops.context.v1` metadata cleanup and Secret Broker metadata construction
- harden local batch persistence/replay so failed local writes return `failed`, pipeline batches remain pending for retry, and replay no longer runs retention sweeps between queued files
- fix packaging/release feedback: explicit `CFBundleExecutable`, regenerate notarized zip after stapling, boolean `notarized` metadata, artifact-root checksums, and permission smoke authority parsing
- tighten secret scrub patterns for modern OpenAI keys and Discord false positives; correct heartbeat pending-frame accounting and remove duplicate policy reconcile refreshes

## Backlog / feedback covered
- Fixes #47
- Addresses #24 and #25 packaging/smoke tooling defects; credentialed notarization and interactive TCC validation still require release credentials + desktop session
- Partially addresses #39/#34 follow-ups by cleaning heartbeat accounting and related safety rails
- Covers merged-PR review feedback from #21, #23, #26, #27, #37, #38, and #40

## Validation
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `shellcheck scripts/package_app.sh scripts/permission_smoke.sh`
- `actionlint .github/workflows/package-release.yml`
- `scripts/package_app.sh`
- `scripts/permission_smoke.sh --no-launch`
- `git diff --check`