### PR TITLE
fix: deepen permission smoke tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ This is the desktop component of the work tracked in
   with pending local queue pressure, and applies server-returned capture policy
   without requiring an app restart. Local hard-deny safety rails remain
   fail-closed even when a remote policy allows a bundle or path.
+- The default local allowlist includes common developer surfaces, terminals,
+  browsers, issue/chat tools, and LLM coding apps such as Codex, ChatGPT, and
+  Claude Desktop.
 - Menu-bar UI: pause/resume (`⌃⌥⌘P`), flush now (`⌃⌥⌘F`), reveal batches dir,
   diagnostics report (`⌃⌥⌘D`), delete queued batches, launch-at-login, quit.
 
@@ -60,12 +63,21 @@ python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
 scripts/package_app.sh # release .app bundle with hardened runtime signing
 scripts/permission_smoke.sh --no-launch # generate permission-smoke evidence template
 ./script/build_and_run.sh --verify # package, launch, and verify the menu app process
+./script/build_and_run.sh --tcc-verify # relaunch the existing app without rebuilding
+./script/build_and_run.sh --local-batch-verify # verify sanitized local batch output
 ```
 
 First run will trigger the system Screen Recording and Accessibility prompts the
 first time the gated APIs are called. Grant both in System Settings → Privacy &
 Security. If capture starts before the grants are complete, agentd retries
 capture startup in the background so a full relaunch is not required.
+For ad-hoc local builds, approve the exact packaged app you are testing and use
+`./script/build_and_run.sh --tcc-verify`; rebuilding changes the CDHash and can
+make macOS treat it as a different TCC client.
+`--local-batch-verify` also relaunches without rebuilding, activates Codex by
+default, and prints only frame counts/metadata lengths so OCR text is not echoed
+into the terminal. Set `AGENTD_SMOKE_FOREGROUND_APP=Terminal` or another
+allowed app to probe a different foreground surface.
 
 `scripts/package_app.sh` creates `dist/EvalOps agentd.app` and
 `dist/agentd.zip`. By default CI uses ad-hoc signing with hardened runtime so

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -338,9 +338,14 @@ struct AgentConfig: Codable, Sendable {
     "com.apple.dt.Xcode",
     "com.microsoft.VSCode",
     "com.todesktop.230313mzl4w4u92",  // Cursor
+    "com.todesktop.230313mzl4w4u92.helper",  // Cursor helpers can be foreground in terminals
     "com.googlecode.iterm2",
     "com.apple.Terminal",
+    "com.mitchellh.ghostty",
     "dev.warp.Warp-Stable",
+    "com.openai.codex",
+    "com.openai.chat",
+    "com.anthropic.claudefordesktop",
     "company.thebrowser.Browser",  // Arc
     "com.google.Chrome",
     "com.apple.Safari",

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -353,6 +353,7 @@ actor FramePipeline {
       !config.allowedBundleIds.contains(ctx.bundleId)
     {
       droppedDeniedApp += 1
+      Log.scrub.info("allowlist miss bundle=\(ctx.bundleId, privacy: .public)")
       return
     }
 

--- a/Tests/agentdTests/SubmitterTests.swift
+++ b/Tests/agentdTests/SubmitterTests.swift
@@ -84,6 +84,10 @@ final class SubmitterTests: XCTestCase {
     let cfg = try JSONDecoder().decode(AgentConfig.self, from: legacy)
     XCTAssertEqual(cfg.organizationId, "org_legacy")
     XCTAssertEqual(cfg.allowedBundleIds, AgentConfig.defaultAllowedBundleIds)
+    XCTAssertTrue(cfg.allowedBundleIds.contains("com.openai.codex"))
+    XCTAssertTrue(cfg.allowedBundleIds.contains("com.openai.chat"))
+    XCTAssertTrue(cfg.allowedBundleIds.contains("com.anthropic.claudefordesktop"))
+    XCTAssertTrue(cfg.allowedBundleIds.contains("com.mitchellh.ghostty"))
     XCTAssertEqual(cfg.maxOcrTextChars, 4096)
     XCTAssertEqual(cfg.maxBatchBytes, 512 * 1024 * 1024)
 
@@ -343,6 +347,7 @@ final class SubmitterTests: XCTestCase {
         Self.response(for: url, statusCode: 200)
       )
     }
+    let dir = try makeTemporaryDirectory()
     let submitter = try Submitter(
       endpoint: URL(
         string: "https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch")!,
@@ -357,7 +362,8 @@ final class SubmitterTests: XCTestCase {
         "agentd:chronicle": "chronicle-token",
         "agentd:secret-broker": "broker-session",
       ]),
-      client: client
+      client: client,
+      batchDirectory: dir
     )
 
     let result = await submitter.submit(Self.batch())
@@ -446,6 +452,7 @@ final class SubmitterTests: XCTestCase {
       droppedCounts: DropCounts(secret: 0, duplicate: 0, deniedApp: 0, deniedPath: 0)
     )
 
+    let dir = try makeTemporaryDirectory()
     let submitter = try Submitter(
       endpoint: URL(
         string: "https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch")!,
@@ -460,7 +467,8 @@ final class SubmitterTests: XCTestCase {
         "agentd:chronicle": "chronicle-token",
         "agentd:secret-broker": "broker-session",
       ]),
-      client: client
+      client: client,
+      batchDirectory: dir
     )
 
     let result = await submitter.submit(batch)

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -9,7 +9,7 @@ bundle_id="dev.evalops.agentd"
 app_bundle="$root/dist/$app_name.app"
 
 usage() {
-  echo "usage: $0 [run|--debug|--logs|--telemetry|--verify|--permission-smoke]" >&2
+  echo "usage: $0 [run|--debug|--logs|--telemetry|--verify|--reuse|--tcc-verify|--local-batch-verify|--permission-smoke]" >&2
   exit 2
 }
 
@@ -21,8 +21,23 @@ build_app() {
   "$root/scripts/package_app.sh"
 }
 
+require_existing_app() {
+  if [[ ! -x "$app_bundle/Contents/MacOS/$process_name" ]]; then
+    echo "Missing packaged app: $app_bundle" >&2
+    echo "Run $0 once before no-rebuild verification." >&2
+    exit 66
+  fi
+}
+
 open_app() {
   /usr/bin/open -n "$app_bundle"
+}
+
+activate_probe_app() {
+  local foreground_app="${AGENTD_SMOKE_FOREGROUND_APP:-Codex}"
+  if [[ -n "$foreground_app" ]]; then
+    osascript -e "tell application \"$foreground_app\" to activate" >/dev/null 2>&1 || true
+  fi
 }
 
 stop_running
@@ -51,6 +66,88 @@ case "$mode" in
     open_app
     sleep 2
     pgrep -x "$process_name" >/dev/null
+    ;;
+  --reuse|reuse)
+    require_existing_app
+    open_app
+    ;;
+  --tcc-verify|tcc-verify)
+    require_existing_app
+    open_app
+    sleep 2
+    app_pid="$(pgrep -nx "$process_name" || true)"
+    if [[ -z "$app_pid" ]]; then
+      echo "TCC verification failed: $process_name did not stay running." >&2
+      exit 76
+    fi
+    sleep 18
+    recent_logs="$(
+      /usr/bin/log show --last 45s --info --style compact --predicate "subsystem == \"$bundle_id\" && processID == $app_pid" 2>/dev/null \
+        | tail -120
+    )"
+    printf '%s\n' "$recent_logs"
+    if grep -q 'capture started' <<<"$recent_logs"; then
+      echo "TCC verification passed: capture started."
+    elif grep -q 'capture start failed' <<<"$recent_logs"; then
+      echo "TCC verification failed: capture did not start. If this app is ad-hoc signed, approve this exact packaged copy and rerun --tcc-verify without rebuilding." >&2
+      exit 78
+    else
+      echo "TCC verification inconclusive: no capture start/failure log found." >&2
+      exit 75
+    fi
+    ;;
+  --local-batch-verify|local-batch-verify)
+    require_existing_app
+    start_epoch="$(date +%s)"
+    open_app
+    activate_probe_app
+    sleep 35
+    latest_batch="$(
+      {
+        find "$HOME/.evalops/agentd/batches" -type f -name '*.json' -print0 2>/dev/null \
+          | xargs -0 stat -f '%m %N' 2>/dev/null \
+          | sort -rn \
+          | sed -n '1s/^[0-9][0-9]* //p'
+      } || true
+    )"
+    if [[ -z "$latest_batch" ]]; then
+      echo "Local batch verification failed: no local JSON batches found." >&2
+      exit 79
+    fi
+    batch_epoch="$(stat -f %m "$latest_batch")"
+    if (( batch_epoch < start_epoch )); then
+      echo "Local batch verification failed: newest batch predates this run: $latest_batch" >&2
+      exit 79
+    fi
+    summary="$(
+      jq '{
+        file: input_filename,
+        localOnly,
+        batchId: .batch.batchId,
+        frames: (.batch.frames | length),
+        droppedCounts: .batch.droppedCounts,
+        firstFrame: ((.batch.frames[0] // {}) | {
+          bundleId,
+          appName,
+          windowTitleLength: (.windowTitle | length // 0),
+          displayId,
+          ocrTextLength: (.ocrText | length // 0),
+          ocrTextTruncated
+        })
+      }' "$latest_batch"
+    )"
+    printf '%s\n' "$summary"
+    frames="$(jq '.batch.frames | length' "$latest_batch")"
+    denied_app="$(jq '.batch.droppedCounts.deniedApp // 0' "$latest_batch")"
+    if (( frames > 0 )); then
+      echo "Local batch verification passed: persisted sanitized frame metadata without printing OCR text."
+    elif (( denied_app > 0 )); then
+      echo "Local batch verification failed: frames were captured but denied by app policy. Check allowlist miss logs and AGENTD_SMOKE_FOREGROUND_APP." >&2
+      exit 80
+    else
+      echo "Local batch verification failed: no frames reached the local batch." >&2
+      exit 81
+    fi
     ;;
   --permission-smoke|permission-smoke)
     "$root/scripts/permission_smoke.sh"

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -40,6 +40,10 @@ if [[ "$identity" != "-" ]]; then
 fi
 codesign "${codesign_args[@]}" "$app_path"
 codesign --verify --strict --deep --verbose=2 "$app_path"
+if [[ "$identity" == "-" ]]; then
+  echo "Ad-hoc signed app: macOS TCC approvals can bind to this build's cdhash."
+  echo "For permission smoke, approve this exact packaged app and relaunch without rebuilding."
+fi
 
 create_zip
 

--- a/scripts/permission_smoke.sh
+++ b/scripts/permission_smoke.sh
@@ -44,11 +44,19 @@ if [[ -f "$root/dist/agentd.zip" ]]; then
 fi
 macos_version="$(sw_vers -productVersion)"
 build_version="$(sw_vers -buildVersion)"
+codesign_details="$(codesign -dvvv "$app_path" 2>&1)"
 codesign_summary="$(
-  codesign -dvv "$app_path" 2>&1 \
+  printf '%s\n' "$codesign_details" \
     | sed -n 's/^Authority=//p' \
     | awk 'NF { if (seen++) printf ", "; printf "%s", $0 } END { if (seen) print "" }'
 )"
+codesign_requirement="$(codesign -d -r- "$app_path" 2>&1 | sed -n 's/^# designated => //p')"
+codesign_cdhash="$(
+  printf '%s\n' "$codesign_details" \
+    | sed -n 's/^CDHash=//p; s/^CandidateCDHash sha256=//p' \
+    | head -1
+)"
+codesign_signature="$(printf '%s\n' "$codesign_details" | sed -n 's/^Signature=//p')"
 
 cat > "$report_path" <<REPORT
 # agentd Permission Smoke Report
@@ -59,7 +67,20 @@ cat > "$report_path" <<REPORT
 - App SHA-256: ${app_sha}
 - Zip SHA-256: ${zip_sha:-not generated}
 - Codesign authorities: ${codesign_summary:-ad-hoc}
+- Codesign signature: ${codesign_signature:-unknown}
+- Codesign CDHash: ${codesign_cdhash:-unknown}
+- Codesign requirement: ${codesign_requirement:-unknown}
 - Batch directory: ${batch_dir}
+
+## TCC Stability
+
+If the app is ad-hoc signed, macOS can bind Screen Recording and Accessibility
+approval to the exact CDHash above. Do not rebuild between granting permissions
+and verification. After approving this exact packaged app, relaunch it with:
+
+\`\`\`
+./script/build_and_run.sh --tcc-verify
+\`\`\`
 
 ## Checks
 
@@ -80,7 +101,7 @@ echo "Wrote $report_path"
 if [[ "$launch" == "1" ]]; then
   open "$app_path"
   echo "Opened $app_path"
-  echo "Grant Screen Recording and Accessibility in System Settings, relaunch, then complete $report_path."
+  echo "Grant Screen Recording and Accessibility in System Settings, then run ./script/build_and_run.sh --tcc-verify without rebuilding."
 else
   echo "Skipped launch because --no-launch was supplied."
 fi


### PR DESCRIPTION
## Summary
- document the ad-hoc codesign/CDHash TCC trap and record signature/CDHash/designated requirement in permission smoke evidence
- add no-rebuild `--tcc-verify` and sanitized `--local-batch-verify` flows so developers can validate ScreenCaptureKit and local batch persistence after granting permissions
- add Codex, ChatGPT, Claude Desktop, Ghostty, and Cursor helper bundle IDs to the default local developer allowlist, plus allowlist-miss logging
- isolate Secret Broker submitter tests from the real developer batch queue exposed by local smoke runs

## Local verification
- `shellcheck scripts/package_app.sh scripts/permission_smoke.sh script/build_and_run.sh`
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `git diff --check`
- `scripts/permission_smoke.sh --no-launch`
- `./script/build_and_run.sh --tcc-verify` on the exact approved packaged app: capture started
- `./script/build_and_run.sh --local-batch-verify` on the exact approved packaged app with temporary config expansion: persisted 2 sanitized Codex frames, `deniedApp=0`, `deniedPath=0`, OCR text not printed

## Notes
The local machine has no valid Developer ID/Apple Development signing identities, so ad-hoc builds have a CDHash designated requirement. Rebuilding can invalidate macOS TCC approvals; this PR makes that visible and gives developers a no-rebuild verification path.
