### PR TITLE
fix: mark agentd bundle as app package

### DIFF
--- a/support/Info.plist
+++ b/support/Info.plist
@@ -10,6 +10,8 @@
     <string>EvalOps agentd</string>
     <key>CFBundleExecutable</key>
     <string>agentd</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
     <key>CFBundleVersion</key>
     <string>0.0.1</string>
     <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## Summary
- add `CFBundlePackageType=APPL` to the packaged app Info.plist so Gatekeeper recognizes the signed bundle as an app

## Why
The first credential-backed `package-release` run after configuring Developer ID/notary secrets successfully signed, uploaded, notarized, and stapled the app, but failed Gatekeeper with:

`rejected (the code is valid but does not seem to be an app)`

That points at bundle metadata, not signing/notary credentials.

## Validation
- `scripts/package_app.sh`
- `plutil -extract CFBundlePackageType raw dist/'EvalOps agentd.app'/Contents/Info.plist` => `APPL`
- `codesign --verify --strict --deep --verbose=2 dist/'EvalOps agentd.app'`
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `shellcheck scripts/package_app.sh scripts/permission_smoke.sh script/build_and_run.sh`
- `git diff --check`
