### PR TITLE
feat: add opt-in sparse frame store

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ agentd reads and writes `~/.evalops/agentd/config.json`. Important defaults:
 - `adaptiveOcrMinChars: 1024`
 - `adaptiveOcrBackpressureThreshold: 8`
 - `adaptiveOcrBacklogBytes: 67108864`
+- `sparseFrameStorageRoot: null`
+- `sparseFrameRetentionHours: 6`
+- `sparseFrameIncludeOcrText: false`
 - `batchIntervalSeconds: 30`
 - `maxFramesPerBatch: 24`
 - `maxOcrTextChars: 4096`
@@ -220,6 +223,15 @@ Diagnostics reports are written under `~/.evalops/agentd/diagnostics/` with
 `0o600` permissions. They summarize permissions, policy, queue pressure, local
 batches, active display frame/drop counters, and last submit health without OCR
 text or raw payloads.
+
+For Chronicle-style local introspection, set `sparseFrameStorageRoot` to a
+directory such as `~/.evalops/agentd/sparse-frames`. agentd then writes
+per-display `*.capture` markers, `*.capture.json` segment metadata,
+`*-latest.jpg` snapshots, sparse historical `frame-*.jpg` images, and OCR
+change sidecars for frames that have already passed allow/deny policy,
+deduplication, pause checks, and full-text secret scanning. OCR sidecars store
+hashes and lengths by default; set `sparseFrameIncludeOcrText: true` only for
+explicit local debugging where raw OCR persistence is acceptable.
 
 `scripts/mock_chronicle.py` provides a strict local mock Chronicle and Secret
 Broker harness. CI validates the golden fixtures in `Tests/Fixtures/chronicle`

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -79,6 +79,9 @@ struct AgentConfig: Codable, Sendable {
   var adaptiveOcrMinChars: Int
   var adaptiveOcrBackpressureThreshold: Int
   var adaptiveOcrBacklogBytes: Int64
+  var sparseFrameStorageRoot: String?
+  var sparseFrameRetentionHours: Double
+  var sparseFrameIncludeOcrText: Bool
   var localOnly: Bool
   var encryptLocalBatches: Bool
   var auth: AuthMode
@@ -112,6 +115,9 @@ struct AgentConfig: Codable, Sendable {
     case adaptiveOcrMinChars
     case adaptiveOcrBackpressureThreshold
     case adaptiveOcrBacklogBytes
+    case sparseFrameStorageRoot
+    case sparseFrameRetentionHours
+    case sparseFrameIncludeOcrText
     case localOnly
     case encryptLocalBatches
     case auth
@@ -145,6 +151,9 @@ struct AgentConfig: Codable, Sendable {
     adaptiveOcrMinChars: Int = 1024,
     adaptiveOcrBackpressureThreshold: Int = 8,
     adaptiveOcrBacklogBytes: Int64 = 64 * 1024 * 1024,
+    sparseFrameStorageRoot: String? = nil,
+    sparseFrameRetentionHours: Double = 6,
+    sparseFrameIncludeOcrText: Bool = false,
     localOnly: Bool,
     encryptLocalBatches: Bool? = nil,
     auth: AuthMode = .none,
@@ -176,6 +185,9 @@ struct AgentConfig: Codable, Sendable {
     self.adaptiveOcrMinChars = adaptiveOcrMinChars
     self.adaptiveOcrBackpressureThreshold = adaptiveOcrBackpressureThreshold
     self.adaptiveOcrBacklogBytes = adaptiveOcrBacklogBytes
+    self.sparseFrameStorageRoot = sparseFrameStorageRoot
+    self.sparseFrameRetentionHours = sparseFrameRetentionHours
+    self.sparseFrameIncludeOcrText = sparseFrameIncludeOcrText
     self.localOnly = localOnly
     self.encryptLocalBatches = encryptLocalBatches ?? (!localOnly || secretBroker != nil)
     self.auth = auth
@@ -287,6 +299,12 @@ struct AgentConfig: Codable, Sendable {
     adaptiveOcrBacklogBytes =
       try container.decodeIfPresent(Int64.self, forKey: .adaptiveOcrBacklogBytes)
       ?? 64 * 1024 * 1024
+    sparseFrameStorageRoot = try container.decodeIfPresent(
+      String.self, forKey: .sparseFrameStorageRoot)
+    sparseFrameRetentionHours =
+      try container.decodeIfPresent(Double.self, forKey: .sparseFrameRetentionHours) ?? 6
+    sparseFrameIncludeOcrText =
+      try container.decodeIfPresent(Bool.self, forKey: .sparseFrameIncludeOcrText) ?? false
     localOnly = try container.decodeIfPresent(Bool.self, forKey: .localOnly) ?? true
     auth = try container.decodeIfPresent(AuthMode.self, forKey: .auth) ?? .none
     secretBroker = try container.decodeIfPresent(SecretBrokerConfig.self, forKey: .secretBroker)
@@ -328,6 +346,9 @@ struct AgentConfig: Codable, Sendable {
     try container.encode(
       adaptiveOcrBackpressureThreshold, forKey: .adaptiveOcrBackpressureThreshold)
     try container.encode(adaptiveOcrBacklogBytes, forKey: .adaptiveOcrBacklogBytes)
+    try container.encodeIfPresent(sparseFrameStorageRoot, forKey: .sparseFrameStorageRoot)
+    try container.encode(sparseFrameRetentionHours, forKey: .sparseFrameRetentionHours)
+    try container.encode(sparseFrameIncludeOcrText, forKey: .sparseFrameIncludeOcrText)
     try container.encode(localOnly, forKey: .localOnly)
     try container.encode(encryptLocalBatches, forKey: .encryptLocalBatches)
     try container.encode(auth, forKey: .auth)
@@ -398,6 +419,9 @@ struct AgentConfig: Codable, Sendable {
       adaptiveOcrMinChars: 1024,
       adaptiveOcrBackpressureThreshold: 8,
       adaptiveOcrBacklogBytes: 64 * 1024 * 1024,
+      sparseFrameStorageRoot: nil,
+      sparseFrameRetentionHours: 6,
+      sparseFrameIncludeOcrText: false,
       localOnly: true,
       encryptLocalBatches: false,
       auth: .none,

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -307,6 +307,8 @@ actor FramePipeline {
   private var config: AgentConfig
   private let ocr: any OCRRecognizing
   private var dedupWindow = DedupWindow(capacity: 16, threshold: 5)
+  private var sparseFrameStore: SparseFrameStore?
+  private var sparseFrameStoreOptions: SparseFrameStoreOptions?
 
   private var pending: [ProcessedFrame] = []
   private var startedAt = Date()
@@ -326,10 +328,17 @@ actor FramePipeline {
     self.config = config
     self.ocr = ocr
     self.onBatch = onBatch
+    let options = Self.sparseFrameStoreOptions(config)
+    self.sparseFrameStoreOptions = options
+    self.sparseFrameStore = options.map(Self.makeSparseFrameStore)
   }
 
   func updateConfig(_ cfg: AgentConfig) {
     self.config = cfg
+    let options = Self.sparseFrameStoreOptions(cfg)
+    guard options != sparseFrameStoreOptions else { return }
+    sparseFrameStoreOptions = options
+    sparseFrameStore = options.map(Self.makeSparseFrameStore)
   }
 
   func recordBackpressureDrop() {
@@ -425,6 +434,15 @@ actor FramePipeline {
 
     pending.append(processed)
     dedupWindow.remember(phash)
+    if let sparseFrameStore {
+      do {
+        try await sparseFrameStore.record(image: frame.cgImage, processed: processed)
+      } catch {
+        Log.capture.error(
+          "sparse frame store write failed display=\(frame.displayId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+        )
+      }
+    }
 
     if pending.count >= config.maxFramesPerBatch {
       await flush()
@@ -504,6 +522,23 @@ actor FramePipeline {
   private func sha256Hex(_ s: String) -> String {
     let digest = SHA256.hash(data: Data(s.utf8))
     return digest.map { String(format: "%02x", $0) }.joined()
+  }
+
+  private static func sparseFrameStoreOptions(_ config: AgentConfig) -> SparseFrameStoreOptions? {
+    guard let root = config.sparseFrameStoreRootURL else { return nil }
+    return SparseFrameStoreOptions(
+      root: root,
+      retentionHours: config.sparseFrameRetentionHours,
+      includeOcrText: config.sparseFrameIncludeOcrText
+    )
+  }
+
+  private static func makeSparseFrameStore(_ options: SparseFrameStoreOptions) -> SparseFrameStore {
+    return SparseFrameStore(
+      root: options.root,
+      retentionHours: options.retentionHours,
+      includeOcrText: options.includeOcrText
+    )
   }
 }
 

--- a/Sources/agentd/SparseFrameStore.swift
+++ b/Sources/agentd/SparseFrameStore.swift
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import CoreGraphics
+import CryptoKit
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+actor SparseFrameStore {
+  private let root: URL
+  private let retentionHours: Double
+  private let includeOcrText: Bool
+  private var sessions: [UInt32: SparseFrameSession] = [:]
+  private let jsonEncoder: JSONEncoder
+
+  init(root: URL, retentionHours: Double = 6, includeOcrText: Bool = false) {
+    self.root = root
+    self.retentionHours = max(0, retentionHours)
+    self.includeOcrText = includeOcrText
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = [.sortedKeys]
+    self.jsonEncoder = encoder
+  }
+
+  func record(image: CGImage, processed: ProcessedFrame) throws {
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    var session = try sessions[processed.displayId] ?? createSession(for: processed)
+
+    let latestURL = session.latestURL
+    try writeJPEG(image, to: latestURL)
+
+    let normalizedText = normalize(processed.ocrText)
+    let textHash = sha256Hex(normalizedText)
+    let materialTextChange = textHash != session.lastOcrHash
+    let staleHistoricalFrame =
+      session.lastHistoricalFrameAt == nil
+      || processed.capturedAt.timeIntervalSince(session.lastHistoricalFrameAt!) >= 60
+
+    if materialTextChange || staleHistoricalFrame {
+      let frameIndex = session.nextFrameIndex
+      session.nextFrameIndex += 1
+      session.lastHistoricalFrameAt = processed.capturedAt
+      let frameURL = session.directory.appendingPathComponent(
+        "frame-\(frameIndex)-\(minuteBucket(processed.capturedAt))Z.jpg")
+      try writeJPEG(image, to: frameURL)
+
+      if materialTextChange {
+        session.lastOcrHash = textHash
+        try appendOCRRecord(
+          SparseFrameOCRRecord(
+            version: 1,
+            displayId: processed.displayId,
+            capturedAt: processed.capturedAt,
+            frameIndex: frameIndex,
+            persistedFramePath: frameURL.path,
+            ocrTextLength: processed.ocrText.count,
+            ocrTextHash: textHash,
+            ocrTextTruncated: processed.ocrTextTruncated,
+            normalizedText: includeOcrText ? normalizedText : nil
+          ),
+          to: session.ocrURL
+        )
+      }
+    }
+
+    sessions[processed.displayId] = session
+    try pruneExpiredArtifacts(now: processed.capturedAt)
+  }
+
+  private func createSession(for processed: ProcessedFrame) throws -> SparseFrameSession {
+    let startedAt = fileTimestamp(processed.capturedAt)
+    let prefix = "\(startedAt)-display-\(processed.displayId)"
+    let directory = root.appendingPathComponent(prefix, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+    let markerURL = root.appendingPathComponent("\(prefix).capture")
+    FileManager.default.createFile(atPath: markerURL.path, contents: Data())
+    try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: markerURL.path)
+
+    let metadataURL = root.appendingPathComponent("\(prefix).capture.json")
+    let metadata = SparseFrameSegmentMetadata(
+      version: 1,
+      displayId: processed.displayId,
+      segmentStartedAt: processed.capturedAt,
+      widthPx: processed.widthPx,
+      heightPx: processed.heightPx,
+      retentionHours: retentionHours,
+      includesRawOcrText: includeOcrText
+    )
+    try jsonEncoder.encode(metadata).write(to: metadataURL, options: .atomic)
+    try? FileManager.default.setAttributes(
+      [.posixPermissions: 0o600], ofItemAtPath: metadataURL.path)
+
+    return SparseFrameSession(
+      prefix: prefix,
+      directory: directory,
+      latestURL: root.appendingPathComponent("\(prefix)-latest.jpg"),
+      ocrURL: root.appendingPathComponent("\(prefix).ocr.jsonl")
+    )
+  }
+
+  private func appendOCRRecord(_ record: SparseFrameOCRRecord, to url: URL) throws {
+    var data = try jsonEncoder.encode(record)
+    data.append(0x0A)
+    if FileManager.default.fileExists(atPath: url.path) {
+      let handle = try FileHandle(forWritingTo: url)
+      defer { try? handle.close() }
+      try handle.seekToEnd()
+      try handle.write(contentsOf: data)
+    } else {
+      try data.write(to: url, options: .atomic)
+      try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+  }
+
+  private func writeJPEG(_ image: CGImage, to url: URL) throws {
+    guard
+      let destination = CGImageDestinationCreateWithURL(
+        url as CFURL, UTType.jpeg.identifier as CFString, 1, nil)
+    else {
+      throw SparseFrameStoreError.jpegDestinationCreateFailed(url.path)
+    }
+    CGImageDestinationAddImage(destination, image, nil)
+    guard CGImageDestinationFinalize(destination) else {
+      throw SparseFrameStoreError.jpegWriteFailed(url.path)
+    }
+    try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+  }
+
+  private func pruneExpiredArtifacts(now: Date) throws {
+    guard retentionHours > 0 else { return }
+    let cutoff = now.addingTimeInterval(-retentionHours * 3600)
+    let urls = try FileManager.default.contentsOfDirectory(
+      at: root,
+      includingPropertiesForKeys: [.contentModificationDateKey, .isDirectoryKey],
+      options: [.skipsHiddenFiles]
+    )
+    for url in urls {
+      let values = try url.resourceValues(forKeys: [.contentModificationDateKey, .isDirectoryKey])
+      guard let modified = values.contentModificationDate, modified < cutoff else { continue }
+      try? FileManager.default.removeItem(at: url)
+    }
+  }
+
+  private func normalize(_ text: String) -> String {
+    text
+      .components(separatedBy: .whitespacesAndNewlines)
+      .filter { !$0.isEmpty }
+      .joined(separator: " ")
+  }
+
+  private func sha256Hex(_ text: String) -> String {
+    SHA256.hash(data: Data(text.utf8)).map { String(format: "%02x", $0) }.joined()
+  }
+
+  private func fileTimestamp(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd'T'HH-mm-ss"
+    return formatter.string(from: date)
+  }
+
+  private func minuteBucket(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd'T'HH-mm"
+    return formatter.string(from: date)
+  }
+}
+
+struct SparseFrameStoreOptions: Sendable, Equatable {
+  let root: URL
+  let retentionHours: Double
+  let includeOcrText: Bool
+}
+
+private struct SparseFrameSession: Sendable {
+  let prefix: String
+  let directory: URL
+  let latestURL: URL
+  let ocrURL: URL
+  var nextFrameIndex = 0
+  var lastOcrHash: String?
+  var lastHistoricalFrameAt: Date?
+}
+
+private struct SparseFrameSegmentMetadata: Codable {
+  let version: Int
+  let displayId: UInt32
+  let segmentStartedAt: Date
+  let widthPx: Int
+  let heightPx: Int
+  let retentionHours: Double
+  let includesRawOcrText: Bool
+}
+
+private struct SparseFrameOCRRecord: Codable {
+  let version: Int
+  let displayId: UInt32
+  let capturedAt: Date
+  let frameIndex: Int
+  let persistedFramePath: String
+  let ocrTextLength: Int
+  let ocrTextHash: String
+  let ocrTextTruncated: Bool
+  let normalizedText: String?
+}
+
+enum SparseFrameStoreError: Error, LocalizedError {
+  case jpegDestinationCreateFailed(String)
+  case jpegWriteFailed(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .jpegDestinationCreateFailed(let path):
+      return "failed to create sparse frame JPEG destination at \(path)"
+    case .jpegWriteFailed(let path):
+      return "failed to write sparse frame JPEG at \(path)"
+    }
+  }
+}
+
+extension AgentConfig {
+  var sparseFrameStoreRootURL: URL? {
+    guard let raw = sparseFrameStorageRoot?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !raw.isEmpty
+    else {
+      return nil
+    }
+    let expanded: String
+    if raw == "~" {
+      expanded = NSHomeDirectory()
+    } else if raw.hasPrefix("~/") {
+      expanded = NSHomeDirectory() + String(raw.dropFirst())
+    } else {
+      expanded = raw
+    }
+    return URL(fileURLWithPath: expanded, isDirectory: true)
+  }
+}

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -283,6 +283,77 @@ final class PipelineTests: XCTestCase {
     XCTAssertGreaterThan(dropped, 0)
   }
 
+  func testSparseFrameStoreWritesChronicleStyleArtifactsAfterScrub() async throws {
+    let root = try Self.temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    var cfg = Self.config()
+    cfg.sparseFrameStorageRoot = root.path
+
+    let recorder = BatchRecorder()
+    let pipeline = FramePipeline(config: cfg, ocr: StubOCR(text: "visible work context")) { batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+    await pipeline.flush()
+
+    let files = try FileManager.default.contentsOfDirectory(atPath: root.path)
+    XCTAssertTrue(files.contains { $0.hasSuffix("-display-1-latest.jpg") })
+    XCTAssertTrue(files.contains { $0.hasSuffix("-display-1.capture") })
+    XCTAssertTrue(files.contains { $0.hasSuffix("-display-1.capture.json") })
+    let ocrSidecar = try XCTUnwrap(files.first(where: { $0.hasSuffix("-display-1.ocr.jsonl") }))
+    let ocrText = try String(contentsOf: root.appendingPathComponent(ocrSidecar), encoding: .utf8)
+    XCTAssertTrue(ocrText.contains("\"ocrTextHash\""))
+    XCTAssertFalse(ocrText.contains("visible work context"))
+
+    let segmentDirectory = try XCTUnwrap(
+      files.first(where: { $0.contains("-display-1") && !$0.contains(".") }))
+    let sparseFrames = try FileManager.default.contentsOfDirectory(
+      atPath: root.appendingPathComponent(segmentDirectory).path)
+    XCTAssertTrue(sparseFrames.contains { $0.hasPrefix("frame-0-") && $0.hasSuffix("Z.jpg") })
+  }
+
+  func testSparseFrameStoreCanOptIntoRawOcrSidecarForLocalDebugging() async throws {
+    let root = try Self.temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    var cfg = Self.config()
+    cfg.sparseFrameStorageRoot = root.path
+    cfg.sparseFrameIncludeOcrText = true
+
+    let recorder = BatchRecorder()
+    let pipeline = FramePipeline(config: cfg, ocr: StubOCR(text: "debuggable text")) { batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+
+    let sidecar = try XCTUnwrap(
+      try FileManager.default.contentsOfDirectory(atPath: root.path).first {
+        $0.hasSuffix(".ocr.jsonl")
+      })
+    let ocrText = try String(contentsOf: root.appendingPathComponent(sidecar), encoding: .utf8)
+    XCTAssertTrue(ocrText.contains("debuggable text"))
+  }
+
+  func testSparseFrameStoreKeepsSessionAcrossUnchangedConfigRefresh() async throws {
+    let root = try Self.temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    var cfg = Self.config()
+    cfg.sparseFrameStorageRoot = root.path
+
+    let recorder = BatchRecorder()
+    let pipeline = FramePipeline(config: cfg, ocr: StubOCR(text: "same session")) { batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+    await pipeline.updateConfig(cfg)
+    await pipeline.consume(Self.frame(bits: 0x5555_5555_5555_5555), context: Self.context())
+
+    let files = try FileManager.default.contentsOfDirectory(atPath: root.path)
+    XCTAssertEqual(files.filter { $0.contains("-display-1") && !$0.contains(".") }.count, 1)
+  }
+
   func testDisplaySelectionPrefersExplicitIdsThenAllThenPrimary() {
     XCTAssertEqual(
       DisplaySelection.selectedDisplayIds(
@@ -374,6 +445,12 @@ final class PipelineTests: XCTestCase {
       }
     }
     return context.makeImage()!
+  }
+
+  static func temporaryDirectory() throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
   }
 }
 

--- a/docs/chronicle-comparison.md
+++ b/docs/chronicle-comparison.md
@@ -12,11 +12,13 @@ Chronicle-style local capture.
 | Broker mode | Optional ASB Secret Broker artifact wrapping | No broker artifact path |
 | Summarization | Server/control-plane concern, not device default | LLM summarizer loop |
 | Prompt-injection posture | Observed content is not fed to an on-device agent by default | Prompt framing around observed content |
+| Local sparse artifacts | Opt-in sparse-frame store after policy and secret scrub | Default local temp frame/OCR sidecars |
 | Release evidence | Developer ID/notarization workflow plus hardware-smoke helper | Signed/notarized app bundle |
 
 Borrowed ideas worth keeping:
 
 - material-text-change OCR diffs as a secondary sampler;
+- sessionized per-display latest-frame and sparse historical frame artifacts;
 - multi-display observability;
 - downstream heartbeat-recency checks;
 - explicit prompt-injection taxonomies for any future summarizer consumer.
@@ -29,4 +31,3 @@ Things agentd should not copy:
 - audio capture without a stated audit reason;
 - update metadata that can advance without the signing/notarization evidence
   chain.
-


### PR DESCRIPTION
## Summary

- add an opt-in Chronicle-style sparse frame store for local developer introspection
- write per-display capture markers, metadata, latest snapshots, sparse historical JPEGs, and OCR-change sidecars after policy/dedup/secret-scrub gates pass
- keep raw OCR sidecar text off by default, with an explicit local debugging opt-in
- document the config and comparison delta vs Codex Chronicle

Refs #39.
Refs #52. This intentionally does not close #52 because the pHash duplicate override / samplerReason proto work remains.

## Privacy / Security Impact

- Default behavior is unchanged: `sparseFrameStorageRoot` is `null`, so no screenshot artifacts are written.
- When enabled, sparse artifacts are only written after allow/deny policy, pause checks, pHash dedupe, and full-text secret scanning have accepted the frame.
- Sidecars persist OCR hashes and lengths by default, not raw OCR text. `sparseFrameIncludeOcrText: true` is an explicit local-debug setting.
- Sparse files are written with `0o600` permissions and pruned by `sparseFrameRetentionHours`.

## Validation

- `swift test`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `swift build -Xswiftc -warnings-as-errors`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `git diff --check`
- `scripts/package_app.sh`
- `scripts/permission_smoke.sh --no-launch`
