### PR TITLE
docs: compare agentd to Codex Chronicle

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,31 @@ events for `cmd/chronicle` in `evalops/platform`.
 This is the desktop component of the work tracked in
 [evalops/platform#1075](https://github.com/evalops/platform/issues/1075).
 
+## How agentd compares to OpenAI Codex Chronicle
+
+| Axis | OpenAI Codex Chronicle | agentd |
+| --- | --- | --- |
+| Subject of capture | Single user's work context, opt-in per device | Humans-and-agents-at-work evidence for the EvalOps Chronicle pipeline |
+| Governance posture | Single-user app toggle and local pause controls | `RegisterDevice`, `Heartbeat`, server-pushed `CapturePolicy`, and local-hard-deny rails that win over server allow rules |
+| Data plane | Screen frames and OCR are processed by OpenAI to generate local Codex memories | Self-hosted Connect/proto JSON `chronicle.v1.ChronicleService.SubmitBatch`, with optional ASB Secret Broker artifact wrapping |
+| Evidence model | LLM-summarized markdown memories under `$CODEX_HOME/memories_extensions/chronicle/` plus temporary sparse frames | Frame batches with OCR, window/path metadata, pHash dedupe, drop counts, and optional sparse local frame artifacts |
+| Privacy filter | Window-identity filters for browser private/incognito and meeting surfaces | Window identity, app/path policy, pause windows, and content scrub for AWS/GCP/SSH/JWT/GitHub/Anthropic/OpenAI/Slack/Stripe-style secrets |
+| Encryption at rest | Temporary JPEG/OCR sidecars and plaintext markdown memories on local disk | `.agentdbatch` AES-GCM by default in remote or Secret Broker mode, Keychain-managed keys, and local-only opt-in encryption |
+| Crash isolation | ScreenCaptureKit capture work runs through child-process paths with termination handling | In-process ScreenCaptureKit today; out-of-process capture supervisor tracked in [#53](https://github.com/evalops/agentd/issues/53) |
+| Prompt-injection exposure | Observed screen content is summarized by an LLM with prompt-level untrusted-input framing | Observed content is not fed to an on-device LLM by default; any future summarizer belongs in the controlled server pipeline |
+| Distribution | Notarized `Codex.app` bundle | Notarized `EvalOps agentd.app` release workflow and permission-smoke evidence |
+
+Things agentd deliberately does not copy:
+
+- Shipping frames or OCR text to a third-party LLM provider for summarization.
+- Window-identity-only privacy filtering without content-aware secret scrub.
+- Plaintext screen memories as the default managed-mode storage format.
+
+Source for the Codex column: the public
+[Chronicle docs](https://developers.openai.com/codex/memories/chronicle) and a
+local inspection of the shipped arm64 `codex_chronicle` helper bundled with
+`Codex.app`.
+
 ## What it does
 
 - Captures one display by default, or all/selected displays via


### PR DESCRIPTION
## Summary

- add the README comparison table requested in #57
- keep it factual and axis-by-axis: governance, data plane, evidence model, privacy filter, encryption, crash isolation, prompt-injection exposure, and distribution
- call out the specific things agentd should not copy from Codex Chronicle

Closes #57.

## Validation

- `git diff --check`
- `swift test`
