### PR TITLE
feat: add OCR diff sampler gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ agentd reads and writes `~/.evalops/agentd/config.json`. Important defaults:
 - `adaptiveOcrMinChars: 1024`
 - `adaptiveOcrBackpressureThreshold: 8`
 - `adaptiveOcrBacklogBytes: 67108864`
+- `ocrDiffSamplerEnabled: false`
+- `ocrDiffSimilarityThreshold: 0.92`
 - `sparseFrameStorageRoot: null`
 - `sparseFrameRetentionHours: 6`
 - `sparseFrameIncludeOcrText: false`

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -79,6 +79,8 @@ struct AgentConfig: Codable, Sendable {
   var adaptiveOcrMinChars: Int
   var adaptiveOcrBackpressureThreshold: Int
   var adaptiveOcrBacklogBytes: Int64
+  var ocrDiffSamplerEnabled: Bool
+  var ocrDiffSimilarityThreshold: Double
   var sparseFrameStorageRoot: String?
   var sparseFrameRetentionHours: Double
   var sparseFrameIncludeOcrText: Bool
@@ -115,6 +117,8 @@ struct AgentConfig: Codable, Sendable {
     case adaptiveOcrMinChars
     case adaptiveOcrBackpressureThreshold
     case adaptiveOcrBacklogBytes
+    case ocrDiffSamplerEnabled
+    case ocrDiffSimilarityThreshold
     case sparseFrameStorageRoot
     case sparseFrameRetentionHours
     case sparseFrameIncludeOcrText
@@ -151,6 +155,8 @@ struct AgentConfig: Codable, Sendable {
     adaptiveOcrMinChars: Int = 1024,
     adaptiveOcrBackpressureThreshold: Int = 8,
     adaptiveOcrBacklogBytes: Int64 = 64 * 1024 * 1024,
+    ocrDiffSamplerEnabled: Bool = false,
+    ocrDiffSimilarityThreshold: Double = 0.92,
     sparseFrameStorageRoot: String? = nil,
     sparseFrameRetentionHours: Double = 6,
     sparseFrameIncludeOcrText: Bool = false,
@@ -185,6 +191,8 @@ struct AgentConfig: Codable, Sendable {
     self.adaptiveOcrMinChars = adaptiveOcrMinChars
     self.adaptiveOcrBackpressureThreshold = adaptiveOcrBackpressureThreshold
     self.adaptiveOcrBacklogBytes = adaptiveOcrBacklogBytes
+    self.ocrDiffSamplerEnabled = ocrDiffSamplerEnabled
+    self.ocrDiffSimilarityThreshold = ocrDiffSimilarityThreshold
     self.sparseFrameStorageRoot = sparseFrameStorageRoot
     self.sparseFrameRetentionHours = sparseFrameRetentionHours
     self.sparseFrameIncludeOcrText = sparseFrameIncludeOcrText
@@ -299,6 +307,10 @@ struct AgentConfig: Codable, Sendable {
     adaptiveOcrBacklogBytes =
       try container.decodeIfPresent(Int64.self, forKey: .adaptiveOcrBacklogBytes)
       ?? 64 * 1024 * 1024
+    ocrDiffSamplerEnabled =
+      try container.decodeIfPresent(Bool.self, forKey: .ocrDiffSamplerEnabled) ?? false
+    ocrDiffSimilarityThreshold =
+      try container.decodeIfPresent(Double.self, forKey: .ocrDiffSimilarityThreshold) ?? 0.92
     sparseFrameStorageRoot = try container.decodeIfPresent(
       String.self, forKey: .sparseFrameStorageRoot)
     sparseFrameRetentionHours =
@@ -346,6 +358,8 @@ struct AgentConfig: Codable, Sendable {
     try container.encode(
       adaptiveOcrBackpressureThreshold, forKey: .adaptiveOcrBackpressureThreshold)
     try container.encode(adaptiveOcrBacklogBytes, forKey: .adaptiveOcrBacklogBytes)
+    try container.encode(ocrDiffSamplerEnabled, forKey: .ocrDiffSamplerEnabled)
+    try container.encode(ocrDiffSimilarityThreshold, forKey: .ocrDiffSimilarityThreshold)
     try container.encodeIfPresent(sparseFrameStorageRoot, forKey: .sparseFrameStorageRoot)
     try container.encode(sparseFrameRetentionHours, forKey: .sparseFrameRetentionHours)
     try container.encode(sparseFrameIncludeOcrText, forKey: .sparseFrameIncludeOcrText)
@@ -419,6 +433,8 @@ struct AgentConfig: Codable, Sendable {
       adaptiveOcrMinChars: 1024,
       adaptiveOcrBackpressureThreshold: 8,
       adaptiveOcrBacklogBytes: 64 * 1024 * 1024,
+      ocrDiffSamplerEnabled: false,
+      ocrDiffSimilarityThreshold: 0.92,
       sparseFrameStorageRoot: nil,
       sparseFrameRetentionHours: 6,
       sparseFrameIncludeOcrText: false,

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -303,10 +303,55 @@ struct DedupWindow: Sendable {
   }
 }
 
+struct OcrDiffSampler: Sendable {
+  static func normalizedText(_ text: String) -> String {
+    text
+      .lowercased()
+      .components(separatedBy: CharacterSet.alphanumerics.inverted)
+      .filter { !$0.isEmpty }
+      .joined(separator: " ")
+  }
+
+  static func shouldOverrideDuplicate(
+    previousText: String?,
+    candidateText: String,
+    threshold: Double
+  ) -> Bool {
+    let candidate = normalizedText(candidateText)
+    guard !candidate.isEmpty else { return false }
+    guard let previousText else { return true }
+    let previous = normalizedText(previousText)
+    guard !previous.isEmpty else { return true }
+    return shingledSimilarity(previous, candidate) < threshold
+  }
+
+  static func shingledSimilarity(_ lhs: String, _ rhs: String) -> Double {
+    let lhsShingles = shingles(lhs)
+    let rhsShingles = shingles(rhs)
+    guard !lhsShingles.isEmpty || !rhsShingles.isEmpty else { return 1 }
+    guard !lhsShingles.isEmpty, !rhsShingles.isEmpty else { return 0 }
+    let intersection = lhsShingles.intersection(rhsShingles).count
+    let union = lhsShingles.union(rhsShingles).count
+    guard union > 0 else { return 1 }
+    return Double(intersection) / Double(union)
+  }
+
+  private static func shingles(_ text: String) -> Set<String> {
+    let tokens = text.split(separator: " ").map(String.init)
+    guard tokens.count > 1 else { return Set(tokens) }
+    var values = Set<String>()
+    for index in 0..<(tokens.count - 1) {
+      values.insert("\(tokens[index]) \(tokens[index + 1])")
+    }
+    return values
+  }
+}
+
 actor FramePipeline {
   private var config: AgentConfig
   private let ocr: any OCRRecognizing
   private var dedupWindow = DedupWindow(capacity: 16, threshold: 5)
+  private var lastEmittedOcrText: String?
   private var sparseFrameStore: SparseFrameStore?
   private var sparseFrameStoreOptions: SparseFrameStoreOptions?
 
@@ -378,7 +423,8 @@ actor FramePipeline {
     }
 
     guard let phash = PerceptualHash(cgImage: frame.cgImage) else { return }
-    if dedupWindow.containsDuplicate(of: phash) {
+    let duplicateByHash = dedupWindow.containsDuplicate(of: phash)
+    if duplicateByHash, !config.ocrDiffSamplerEnabled {
       droppedDup += 1
       return
     }
@@ -398,6 +444,21 @@ actor FramePipeline {
       return
     case .clean:
       break
+    }
+
+    if duplicateByHash {
+      if config.ocrDiffSamplerEnabled,
+        OcrDiffSampler.shouldOverrideDuplicate(
+          previousText: lastEmittedOcrText,
+          candidateText: ocrResult.text,
+          threshold: config.ocrDiffSimilarityThreshold
+        )
+      {
+        Log.capture.info("ocr diff sampler emitted pHash duplicate frame")
+      } else {
+        droppedDup += 1
+        return
+      }
     }
 
     let pendingBytes = pending.reduce(Int64(0)) { $0 + Int64($1.bytesPng) }
@@ -434,6 +495,7 @@ actor FramePipeline {
 
     pending.append(processed)
     dedupWindow.remember(phash)
+    lastEmittedOcrText = ocrResult.text
     if let sparseFrameStore {
       do {
         try await sparseFrameStore.record(image: frame.cgImage, processed: processed)

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -262,6 +262,82 @@ final class PipelineTests: XCTestCase {
     XCTAssertTrue(window.containsDuplicate(of: b))
   }
 
+  func testOcrDiffSamplerOverridesPHashDuplicateWhenTextMateriallyChanges() async throws {
+    let recorder = BatchRecorder()
+    var cfg = Self.config()
+    cfg.ocrDiffSamplerEnabled = true
+    let pipeline = FramePipeline(
+      config: cfg,
+      ocr: SequenceOCR([
+        "build succeeded target alpha",
+        "deployment blocked target beta",
+      ])
+    ) { batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+    await pipeline.flush()
+
+    let batches = await recorder.snapshot()
+    let batch = try XCTUnwrap(batches.first)
+    XCTAssertEqual(batch.frames.count, 2)
+    XCTAssertEqual(batch.droppedCounts.duplicate, 0)
+  }
+
+  func testOcrDiffSamplerKeepsPHashDuplicateDroppedWhenTextIsSimilar() async throws {
+    let recorder = BatchRecorder()
+    var cfg = Self.config()
+    cfg.ocrDiffSamplerEnabled = true
+    let pipeline = FramePipeline(
+      config: cfg,
+      ocr: SequenceOCR([
+        "build succeeded target alpha",
+        "build succeeded target alpha",
+      ])
+    ) { batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+    await pipeline.flush()
+
+    let batches = await recorder.snapshot()
+    let batch = try XCTUnwrap(batches.first)
+    XCTAssertEqual(batch.frames.count, 1)
+    XCTAssertEqual(batch.droppedCounts.duplicate, 1)
+  }
+
+  func testOcrDiffSamplerStaysDisabledByDefault() async throws {
+    let recorder = BatchRecorder()
+    let pipeline = FramePipeline(
+      config: Self.config(),
+      ocr: SequenceOCR([
+        "build succeeded target alpha",
+        "deployment blocked target beta",
+      ])
+    ) { batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+    await pipeline.flush()
+
+    let batches = await recorder.snapshot()
+    let batch = try XCTUnwrap(batches.first)
+    XCTAssertEqual(batch.frames.count, 1)
+    XCTAssertEqual(batch.droppedCounts.duplicate, 1)
+  }
+
+  func testOcrDiffSamplerSimilarityUsesTokenShingles() {
+    XCTAssertEqual(OcrDiffSampler.shingledSimilarity("alpha beta gamma", "alpha beta gamma"), 1)
+    XCTAssertLessThan(
+      OcrDiffSampler.shingledSimilarity("alpha beta gamma", "deploy failed prod"), 0.92)
+  }
+
   func testBufferedFrameDispatcherBoundsBackpressure() async throws {
     let counts = DispatchCounts()
     let dispatcher = BufferedFrameDispatcher(bufferingNewest: 2) { _ in
@@ -488,6 +564,21 @@ struct StubOCR: OCRRecognizing {
 
   func recognize(cgImage: CGImage) async throws -> OCRResult {
     OCRResult(text: text, confidence: confidence, language: "en")
+  }
+}
+
+actor SequenceOCR: OCRRecognizing {
+  private var texts: [String]
+  private let confidence: Float
+
+  init(_ texts: [String], confidence: Float = 0.9) {
+    self.texts = texts
+    self.confidence = confidence
+  }
+
+  func recognize(cgImage: CGImage) async throws -> OCRResult {
+    let text = texts.isEmpty ? "" : texts.removeFirst()
+    return OCRResult(text: text, confidence: confidence, language: "en")
   }
 }
 


### PR DESCRIPTION
## Summary

- add an opt-in OCR-diff sampler gate for pHash duplicate frames
- keep default capture cost unchanged by dropping pHash duplicates before OCR unless `ocrDiffSamplerEnabled` is true
- compare normalized token shingles against the last emitted OCR text and emit materially changed duplicate frames when similarity falls below `ocrDiffSimilarityThreshold`

Refs #52. This does not close #52 yet because per-frame `samplerReason` and the platform/proto wire follow-through remain.

## Privacy / Security Impact

- Default behavior is unchanged: `ocrDiffSamplerEnabled` is false.
- When enabled, OCR-diff override still runs after app/path policy and pause checks, and before persistence it still passes full OCR/window/path secret scanning.
- No wire shape changes are included; this avoids sending unknown frame fields before Chronicle/proto support lands.

## Validation

- `swift test`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `swift build -Xswiftc -warnings-as-errors`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `git diff --check`
- `scripts/package_app.sh`
