### PR TITLE
docs: add macOS availability audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Validate Chronicle contract fixtures
         run: python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
 
+      - name: Validate macOS availability floor
+        run: python3 scripts/macos_availability_audit.py
+
       - name: Lint Swift formatting
         run: xcrun swift-format lint --strict --recursive Sources Tests Package.swift
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ are available.
   ([evalops/platform#1078](https://github.com/evalops/platform/issues/1078)).
 - Hardware-backed permission-flow smoke test for Screen Recording and
   Accessibility prompts.
+- macOS framework availability inventory: `docs/macos-availability.md`.
 
 ## Layout
 

--- a/docs/macos-availability.md
+++ b/docs/macos-availability.md
@@ -1,0 +1,46 @@
+# macOS Availability Audit
+
+agentd's supported deployment floor is macOS 14.0. The Swift package declares
+`.macOS(.v14)` in `Package.swift`, and the packaged app declares
+`LSMinimumSystemVersion` as `14.0` in `support/Info.plist`.
+
+This audit covers the macOS framework APIs that gate capture, OCR, permissions,
+window context, and launch-at-login.
+
+| API | Call site | SDK availability | agentd posture |
+| --- | --- | --- | --- |
+| `SCShareableContent.excludingDesktopWindows(_:onScreenWindowsOnly:)` | `Sources/agentd/CaptureService.swift` | `SCShareableContent` is available since macOS 12.3. The current-process-only variant is macOS 14.4 and is not used. | Safe at the macOS 14.0 floor. |
+| `SCContentFilter(display:excludingApplications:exceptingWindows:)` | `Sources/agentd/CaptureService.swift` | `SCContentFilter` is available since macOS 12.3. The metadata properties `style`, `pointPixelScale`, and `contentRect` are macOS 14.0 and are not used. | Safe at the macOS 14.0 floor. |
+| `SCStream`, `addStreamOutput`, `startCapture`, `stopCapture`, `updateConfiguration` | `Sources/agentd/CaptureService.swift` | `SCStream` is available since macOS 12.3. | Safe at the macOS 14.0 floor. |
+| `SCStreamConfiguration.width`, `height`, `minimumFrameInterval`, `queueDepth`, `showsCursor`, `pixelFormat` | `Sources/agentd/CaptureService.swift` | The base configuration object and these properties predate macOS 14.0. Properties such as `captureMicrophone`, `showMouseClicks`, `captureDynamicRange`, and `streamConfigurationWithPreset` are macOS 15.0+ and are not used. | Safe at the macOS 14.0 floor. |
+| `SCStreamOutput.stream(_:didOutputSampleBuffer:of:)` | `Sources/agentd/CaptureService.swift` | `SCStreamOutput` is available since macOS 12.3. | Safe at the macOS 14.0 floor. |
+| `VNRecognizeTextRequest` with `VNRecognizeTextRequestRevision3` | `Sources/agentd/VisionOCR.swift` | Revision 3 is available before macOS 14.0 and replaces deprecated revisions 1 and 2. | Safe at the macOS 14.0 floor. |
+| `CGPreflightScreenCaptureAccess` | `Sources/agentd/main.swift` | Available since macOS 10.15. | Safe at the macOS 14.0 floor. |
+| `AXIsProcessTrusted`, `AXIsProcessTrustedWithOptions`, `AXUIElementCopyAttributeValue` | `Sources/agentd/main.swift`, `Sources/agentd/WindowContext.swift` | `AXIsProcessTrustedWithOptions` is available since macOS 10.9; `AXIsProcessTrusted` and the AX element calls predate the floor. | Safe at the macOS 14.0 floor. |
+| `SMAppService.mainApp`, `register`, `unregister`, `status` | `Sources/agentd/LaunchAtLoginController.swift` | Available since macOS 13.0. | Safe at the macOS 14.0 floor. |
+| `NSWorkspace.frontmostApplication`, `activateFileViewerSelecting` | `Sources/agentd/WindowContext.swift`, `Sources/agentd/main.swift` | Available before macOS 14.0. | Safe at the macOS 14.0 floor. |
+
+## Guardrail
+
+`scripts/macos_availability_audit.py` is the CI tripwire for this inventory. It
+checks that `Package.swift` and `support/Info.plist` agree on macOS 14.0, and it
+fails if the source tree starts using known post-floor capture APIs without an
+explicit availability review.
+
+The blocked API list intentionally includes the Codex Chronicle-style future
+paths from the local binary archaeology pass:
+
+- `captureScreenshot` / `SCScreenshotConfiguration` / `SCScreenshotOutput`
+  (macOS 26.0);
+- `streamDidBecomeActive` / `streamDidBecomeInactive` and
+  `includedDisplays` / `includedApplications` / `includedWindows`
+  (macOS 15.2);
+- `captureMicrophone`, `microphoneCaptureDeviceID`, `showMouseClicks`,
+  `captureDynamicRange`, and `streamConfigurationWithPreset` (macOS 15.0);
+- `includeMenuBar` and `SCStreamFrameInfoPresenterOverlayContentRect`
+  (macOS 14.2);
+- `SCShareableContent.currentProcess()` (macOS 14.4).
+
+If agentd needs one of those APIs, add a focused code path with
+`if #available(...)` / `@available(...)`, update this table, and adjust the
+audit script in the same PR.

--- a/scripts/macos_availability_audit.py
+++ b/scripts/macos_availability_audit.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Static guardrail for agentd's macOS framework availability floor."""
+
+from __future__ import annotations
+
+import plistlib
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "Package.swift"
+INFO_PLIST = ROOT / "support" / "Info.plist"
+SOURCE_ROOTS = [ROOT / "Sources", ROOT / "Tests"]
+
+EXPECTED_PACKAGE_FLOOR = ".macOS(.v14)"
+EXPECTED_INFO_FLOOR = "14.0"
+
+POST_FLOOR_PATTERNS = {
+    # macOS 26.0 ScreenCaptureKit screenshot output APIs.
+    "captureScreenshot": "macOS 26.0 ScreenCaptureKit screenshot API",
+    "SCScreenshotConfiguration": "macOS 26.0 ScreenCaptureKit screenshot API",
+    "SCScreenshotOutput": "macOS 26.0 ScreenCaptureKit screenshot API",
+    # macOS 15.2 ScreenCaptureKit stream/filter convenience APIs.
+    "streamDidBecomeActive": "macOS 15.2 SCStreamDelegate callback",
+    "streamDidBecomeInactive": "macOS 15.2 SCStreamDelegate callback",
+    "includedDisplays": "macOS 15.2 SCContentFilter metadata",
+    "includedApplications": "macOS 15.2 SCContentFilter metadata",
+    "includedWindows": "macOS 15.2 SCContentFilter metadata",
+    # macOS 15.0 ScreenCaptureKit optional capture features.
+    "captureMicrophone": "macOS 15.0 microphone capture",
+    "microphoneCaptureDeviceID": "macOS 15.0 microphone capture",
+    "showMouseClicks": "macOS 15.0 mouse-click rendering",
+    "captureDynamicRange": "macOS 15.0 HDR capture",
+    "streamConfigurationWithPreset": "macOS 15.0 stream presets",
+    # macOS 14.2+ APIs above the declared 14.0 floor.
+    "includeMenuBar": "macOS 14.2 SCContentFilter property",
+    "SCStreamFrameInfoPresenterOverlayContentRect": "macOS 14.2 frame info key",
+    "currentProcess()": "macOS 14.4 SCShareableContent current-process enumeration",
+}
+
+
+def fail(message: str) -> None:
+    print(f"macos availability audit failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def source_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SOURCE_ROOTS:
+        files.extend(path for path in root.rglob("*.swift") if path.is_file())
+    return files
+
+
+def assert_minimums() -> None:
+    package_text = PACKAGE.read_text(encoding="utf-8")
+    if EXPECTED_PACKAGE_FLOOR not in package_text:
+        fail(f"Package.swift must keep platforms: [{EXPECTED_PACKAGE_FLOOR}]")
+
+    with INFO_PLIST.open("rb") as handle:
+        info = plistlib.load(handle)
+    actual = info.get("LSMinimumSystemVersion")
+    if actual != EXPECTED_INFO_FLOOR:
+        fail(
+            f"support/Info.plist LSMinimumSystemVersion must be {EXPECTED_INFO_FLOOR}, got {actual!r}"
+        )
+
+
+def assert_no_post_floor_apis() -> None:
+    violations: list[str] = []
+    for path in source_files():
+        text = path.read_text(encoding="utf-8")
+        for pattern, reason in POST_FLOOR_PATTERNS.items():
+            if re.search(rf"(?<![A-Za-z0-9_]){re.escape(pattern)}(?![A-Za-z0-9_])", text):
+                rel = path.relative_to(ROOT)
+                violations.append(f"{rel}: uses {pattern} ({reason})")
+    if violations:
+        fail(
+            "post-macOS-14 API usage requires an explicit availability-gated PR:\n"
+            + "\n".join(f"- {violation}" for violation in violations)
+        )
+
+
+def main() -> int:
+    assert_minimums()
+    assert_no_post_floor_apis()
+    print("macos availability audit passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document the macOS 14.0 availability floor across SCKit, Vision, AX, launch-at-login, and workspace APIs
- add a CI guardrail that keeps Package.swift and Info.plist aligned and fails on known post-floor ScreenCaptureKit API usage
- link the inventory from the README follow-up section

Closes #56

## Validation
- python3 scripts/macos_availability_audit.py
- python3 -m py_compile scripts/macos_availability_audit.py
- git diff --check
- xcrun swift-format lint --strict --recursive Sources Tests Package.swift
- python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
- swift test
- swift build -Xswiftc -warnings-as-errors
- scripts/package_app.sh