### PR TITLE
feat: add one-shot diagnostic CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ local inspection of the shipped arm64 `codex_chronicle` helper bundled with
 ```
 swift build
 swift run agentd       # foreground; menu-bar item appears
+swift run agentd -- list-displays
+swift run agentd -- capture-once --no-ocr
 swift test
 python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
 scripts/package_app.sh # release .app bundle with hardened runtime signing
@@ -247,7 +249,9 @@ encrypted `.agentdbatch` batches.
 Diagnostics reports are written under `~/.evalops/agentd/diagnostics/` with
 `0o600` permissions. They summarize permissions, policy, queue pressure, local
 batches, active display frame/drop counters, and last submit health without OCR
-text or raw payloads.
+text or raw payloads. The same binary also supports `list-displays`,
+`capture-once`, and `selftest` diagnostic subcommands; see
+`docs/diagnostics.md`.
 
 For Chronicle-style local introspection, set `sparseFrameStorageRoot` to a
 directory such as `~/.evalops/agentd/sparse-frames`. agentd then writes

--- a/Sources/agentd/AgentdRuntimeLock.swift
+++ b/Sources/agentd/AgentdRuntimeLock.swift
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import Darwin
+import Foundation
+
+final class AgentdRuntimeLock: @unchecked Sendable {
+  private let fd: Int32
+  let url: URL
+
+  private init(fd: Int32, url: URL) {
+    self.fd = fd
+    self.url = url
+  }
+
+  static func acquire(purpose: String, now: Date = Date()) throws -> AgentdRuntimeLock {
+    let url = lockURL
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    let fd = open(url.path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR)
+    guard fd >= 0 else {
+      throw RuntimeLockError.openFailed(String(cString: strerror(errno)))
+    }
+    if flock(fd, LOCK_EX | LOCK_NB) != 0 {
+      let message = String(cString: strerror(errno))
+      close(fd)
+      throw RuntimeLockError.alreadyHeld(message)
+    }
+
+    let metadata = RuntimeLockMetadata(
+      pid: ProcessInfo.processInfo.processIdentifier,
+      purpose: purpose,
+      acquiredAt: now
+    )
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(metadata)
+    _ = ftruncate(fd, 0)
+    _ = lseek(fd, 0, SEEK_SET)
+    data.withUnsafeBytes { buffer in
+      _ = write(fd, buffer.baseAddress, buffer.count)
+    }
+    return AgentdRuntimeLock(fd: fd, url: url)
+  }
+
+  static var lockURL: URL {
+    FileManager.default.homeDirectoryForCurrentUser
+      .appendingPathComponent(".evalops/agentd/agentd-runtime.lock")
+  }
+
+  deinit {
+    _ = flock(fd, LOCK_UN)
+    close(fd)
+  }
+}
+
+private struct RuntimeLockMetadata: Codable {
+  let pid: Int32
+  let purpose: String
+  let acquiredAt: Date
+}
+
+enum RuntimeLockError: Error, LocalizedError {
+  case openFailed(String)
+  case alreadyHeld(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .openFailed(let message):
+      return "could not open agentd runtime lock: \(message)"
+    case .alreadyHeld:
+      return "agentd is already running or another diagnostic capture is active"
+    }
+  }
+}

--- a/Sources/agentd/DiagnosticCLI.swift
+++ b/Sources/agentd/DiagnosticCLI.swift
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import AppKit
+import Foundation
+@preconcurrency import ScreenCaptureKit
+
+enum DiagnosticCLI {
+  static let handledCommands = [
+    "list-displays", "capture-once", "selftest", "help", "--help", "-h",
+  ]
+
+  static func shouldHandle(_ arguments: [String]) -> Bool {
+    guard let command = arguments.dropFirst().first else { return false }
+    return handledCommands.contains(command)
+  }
+
+  static func run(arguments: [String]) async -> Int32 {
+    do {
+      let command = try DiagnosticCommand.parse(Array(arguments.dropFirst()))
+      switch command {
+      case .help:
+        FileHandle.standardOutput.writeString(help)
+      case .listDisplays:
+        let payload = try await DisplayDiagnostics.snapshot()
+        try writeJSON(payload, to: nil)
+      case .captureOnce(let options):
+        if options.noScrub {
+          throw DiagnosticCLIError.unscrubbedCaptureUnavailable
+        }
+        let lock = try AgentdRuntimeLock.acquire(purpose: "diagnostic-capture-once")
+        _ = lock
+        let payload = try await CaptureOnceDiagnostics.run(options: options)
+        try writeJSON(payload, to: options.out)
+      case .selftest:
+        let payload = await SelftestDiagnostics.run()
+        try writeJSON(payload, to: nil)
+      }
+      return 0
+    } catch let error as DiagnosticCLIError {
+      FileHandle.standardError.writeString("agentd: \(error.localizedDescription)\n")
+      if error.showsUsage {
+        FileHandle.standardError.writeString(help)
+      }
+      return 2
+    } catch {
+      FileHandle.standardError.writeString("agentd: \(error.localizedDescription)\n")
+      return 1
+    }
+  }
+
+  private static func writeJSON<T: Encodable>(_ value: T, to url: URL?) throws {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(value) + Data([0x0A])
+    if let url {
+      try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try data.write(to: url, options: .atomic)
+      try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    } else {
+      FileHandle.standardOutput.write(data)
+    }
+  }
+
+  static let help = """
+    Usage:
+      agentd list-displays
+      agentd capture-once [--display-id ID] [--no-ocr] [--out PATH]
+      agentd selftest
+
+    Diagnostic commands emit redacted JSON and never start the menu-bar app.
+    capture-once uses the normal privacy filters, SecretScrubber, and OCR pipeline.
+
+    """
+}
+
+enum DiagnosticCommand: Equatable {
+  case help
+  case listDisplays
+  case captureOnce(CaptureOnceOptions)
+  case selftest
+
+  static func parse(_ arguments: [String]) throws -> DiagnosticCommand {
+    guard let command = arguments.first else { return .help }
+    let tail = Array(arguments.dropFirst())
+    switch command {
+    case "help", "--help", "-h":
+      return .help
+    case "list-displays":
+      guard tail.isEmpty else { throw DiagnosticCLIError.usage("list-displays takes no flags") }
+      return .listDisplays
+    case "capture-once":
+      return .captureOnce(try CaptureOnceOptions.parse(tail))
+    case "selftest":
+      guard tail.isEmpty else { throw DiagnosticCLIError.usage("selftest takes no flags") }
+      return .selftest
+    default:
+      throw DiagnosticCLIError.usage("unknown diagnostic command '\(command)'")
+    }
+  }
+}
+
+struct CaptureOnceOptions: Equatable {
+  var displayId: UInt32?
+  var noOCR = false
+  var noScrub = false
+  var out: URL?
+
+  static func parse(_ arguments: [String]) throws -> CaptureOnceOptions {
+    var options = CaptureOnceOptions()
+    var index = 0
+    while index < arguments.count {
+      let flag = arguments[index]
+      switch flag {
+      case "--display-id":
+        index += 1
+        guard index < arguments.count, let value = UInt32(arguments[index]) else {
+          throw DiagnosticCLIError.usage("--display-id requires a UInt32 display id")
+        }
+        options.displayId = value
+      case "--no-ocr":
+        options.noOCR = true
+      case "--no-scrub":
+        options.noScrub = true
+      case "--out":
+        index += 1
+        guard index < arguments.count else {
+          throw DiagnosticCLIError.usage("--out requires a path")
+        }
+        options.out = URL(fileURLWithPath: arguments[index])
+      case "--help", "-h":
+        throw DiagnosticCLIError.usage("")
+      default:
+        throw DiagnosticCLIError.usage("unknown capture-once flag '\(flag)'")
+      }
+      index += 1
+    }
+    return options
+  }
+}
+
+enum DiagnosticCLIError: Error, LocalizedError {
+  case usage(String)
+  case timeout
+  case noWindowContext
+  case noBatchProduced
+  case unscrubbedCaptureUnavailable
+
+  var errorDescription: String? {
+    switch self {
+    case .usage(let message):
+      return message.isEmpty ? "usage requested" : message
+    case .timeout:
+      return "timed out waiting for a captured frame"
+    case .noWindowContext:
+      return "could not read frontmost window context; grant Accessibility permission and retry"
+    case .noBatchProduced:
+      return "capture produced no batch; privacy filters may have dropped the frame"
+    case .unscrubbedCaptureUnavailable:
+      return
+        "--no-scrub is recognized but intentionally unavailable; diagnostic captures stay scrubbed"
+    }
+  }
+
+  var showsUsage: Bool {
+    if case .usage = self { return true }
+    return false
+  }
+}
+
+struct DisplayDiagnosticsSnapshot: Codable {
+  let generatedAt: Date
+  let permissions: PermissionSnapshot
+  let displays: [DisplayDiagnostic]
+}
+
+struct DisplayDiagnostic: Codable, Equatable {
+  let displayId: UInt32
+  let name: String
+  let width: Int
+  let height: Int
+  let scale: Double?
+  let isMain: Bool
+  let bounds: DisplayBounds
+}
+
+struct DisplayBounds: Codable, Equatable {
+  let x: Double
+  let y: Double
+  let width: Double
+  let height: Double
+}
+
+enum DisplayDiagnostics {
+  @MainActor
+  static func snapshot() async throws -> DisplayDiagnosticsSnapshot {
+    let content = try await SCShareableContent.excludingDesktopWindows(
+      true, onScreenWindowsOnly: true
+    )
+    let displays = content.displays.sorted { $0.displayID < $1.displayID }.map { display in
+      DisplayDiagnostic(
+        displayId: display.displayID,
+        name: displayName(display.displayID),
+        width: display.width,
+        height: display.height,
+        scale: displayScale(display.displayID),
+        isMain: display.displayID == CGMainDisplayID(),
+        bounds: DisplayBounds(
+          x: display.frame.origin.x,
+          y: display.frame.origin.y,
+          width: display.frame.width,
+          height: display.frame.height
+        )
+      )
+    }
+    return DisplayDiagnosticsSnapshot(
+      generatedAt: Date(),
+      permissions: PermissionSnapshot.current(promptForAccessibility: false),
+      displays: displays
+    )
+  }
+
+  static func availableDisplayIds() async throws -> Set<UInt32> {
+    let content = try await SCShareableContent.excludingDesktopWindows(
+      true, onScreenWindowsOnly: true
+    )
+    return Set(content.displays.map(\.displayID))
+  }
+
+  private static func displayName(_ displayId: CGDirectDisplayID) -> String {
+    let numberKey = NSDeviceDescriptionKey("NSScreenNumber")
+    if let screen = NSScreen.screens.first(where: {
+      ($0.deviceDescription[numberKey] as? NSNumber)?.uint32Value == displayId
+    }) {
+      return screen.localizedName
+    }
+    return "Display \(displayId)"
+  }
+
+  static func displayScale(_ displayId: CGDirectDisplayID) -> Double? {
+    let pixelWidth = CGDisplayPixelsWide(displayId)
+    guard pixelWidth > 0 else { return nil }
+    let boundsWidth = CGDisplayBounds(displayId).width
+    guard boundsWidth > 0 else { return nil }
+    return Double(pixelWidth) / Double(boundsWidth)
+  }
+}
+
+struct CaptureOnceOutput: Codable {
+  let generatedAt: Date
+  let permissions: PermissionSnapshot
+  let batch: Batch
+}
+
+enum CaptureOnceDiagnostics {
+  static func run(options: CaptureOnceOptions) async throws -> CaptureOnceOutput {
+    let cfg = ConfigStore.load()
+    let recorder = DiagnosticBatchRecorder()
+    let ocr: any OCRRecognizing = options.noOCR ? EmptyOCR() : VisionOCR()
+    let pipeline = FramePipeline(config: cfg, ocr: ocr) { batch in
+      await recorder.append(batch)
+      return .submitted(nil)
+    }
+    let frame = try await captureOneFrame(
+      displayId: options.displayId, timeoutSeconds: 6)
+    await pipeline.consume(
+      frame,
+      context: try await MainActor.run {
+        guard let context = WindowContextProbe.current() else {
+          throw DiagnosticCLIError.noWindowContext
+        }
+        return context
+      }
+    )
+    await pipeline.flush()
+    let batches = await recorder.snapshot()
+    guard let batch = batches.last else { throw DiagnosticCLIError.noBatchProduced }
+    return CaptureOnceOutput(
+      generatedAt: Date(),
+      permissions: await MainActor.run {
+        PermissionSnapshot.current(promptForAccessibility: false)
+      },
+      batch: batch
+    )
+  }
+
+  private static func captureOneFrame(
+    displayId: UInt32?,
+    timeoutSeconds: UInt64
+  ) async throws -> CapturedFrame {
+    if let displayId {
+      let available = try await DisplayDiagnostics.availableDisplayIds()
+      guard available.contains(displayId) else {
+        throw DiagnosticCLIError.usage(
+          "display id \(displayId) is not available; run agentd list-displays")
+      }
+    }
+    let receiver = OneShotFrameReceiver()
+    let oneShotCapture = CaptureService { frame in
+      await receiver.record(frame)
+    }
+    try await oneShotCapture.start(
+      targetFps: 2,
+      captureAllDisplays: false,
+      selectedDisplayIds: displayId.map { [$0] } ?? []
+    )
+    defer {
+      Task { await oneShotCapture.stop() }
+    }
+    return try await withThrowingTaskGroup(of: CapturedFrame.self) { group in
+      group.addTask {
+        await receiver.wait()
+      }
+      group.addTask {
+        try await Task.sleep(nanoseconds: timeoutSeconds * 1_000_000_000)
+        throw DiagnosticCLIError.timeout
+      }
+      guard let frame = try await group.next() else {
+        throw DiagnosticCLIError.timeout
+      }
+      group.cancelAll()
+      await oneShotCapture.stop()
+      return frame
+    }
+  }
+}
+
+actor OneShotFrameReceiver {
+  private var frame: CapturedFrame?
+  private var continuation: CheckedContinuation<CapturedFrame, Never>?
+
+  func record(_ frame: CapturedFrame) {
+    guard self.frame == nil else { return }
+    self.frame = frame
+    continuation?.resume(returning: frame)
+    continuation = nil
+  }
+
+  func wait() async -> CapturedFrame {
+    if let frame { return frame }
+    return await withCheckedContinuation { continuation in
+      self.continuation = continuation
+    }
+  }
+}
+
+actor DiagnosticBatchRecorder {
+  private var batches: [Batch] = []
+
+  func append(_ batch: Batch) {
+    batches.append(batch)
+  }
+
+  func snapshot() -> [Batch] {
+    batches
+  }
+}
+
+struct EmptyOCR: OCRRecognizing {
+  func recognize(cgImage: CGImage) async throws -> OCRResult {
+    OCRResult(text: "", confidence: 0, language: "und")
+  }
+}
+
+struct SelftestOutput: Codable {
+  let generatedAt: Date
+  let permissions: PermissionSnapshot
+  let configPath: String
+  let runtimeLockPath: String
+  let mockChronicle: SelftestCommandResult?
+}
+
+struct SelftestCommandResult: Codable {
+  let command: [String]
+  let exitCode: Int32
+}
+
+enum SelftestDiagnostics {
+  @MainActor
+  static func run() -> SelftestOutput {
+    SelftestOutput(
+      generatedAt: Date(),
+      permissions: PermissionSnapshot.current(promptForAccessibility: false),
+      configPath: ConfigStore.path.path,
+      runtimeLockPath: AgentdRuntimeLock.lockURL.path,
+      mockChronicle: runMockChronicleIfAvailable()
+    )
+  }
+
+  private static func runMockChronicleIfAvailable() -> SelftestCommandResult? {
+    let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    let script = cwd.appendingPathComponent("scripts/mock_chronicle.py")
+    let fixtures = cwd.appendingPathComponent("Tests/Fixtures/chronicle")
+    guard FileManager.default.fileExists(atPath: script.path),
+      FileManager.default.fileExists(atPath: fixtures.path)
+    else { return nil }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+    process.arguments = [script.path, "--self-test", fixtures.path]
+    process.standardOutput = FileHandle.standardError
+    process.standardError = FileHandle.standardError
+    do {
+      try process.run()
+      process.waitUntilExit()
+      return SelftestCommandResult(
+        command: ["/usr/bin/python3", script.path, "--self-test", fixtures.path],
+        exitCode: process.terminationStatus
+      )
+    } catch {
+      return SelftestCommandResult(
+        command: ["/usr/bin/python3", script.path, "--self-test", fixtures.path],
+        exitCode: 127
+      )
+    }
+  }
+}
+
+extension FileHandle {
+  fileprivate func writeString(_ value: String) {
+    write(Data(value.utf8))
+  }
+}

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -10,6 +10,7 @@ final class AppController {
   private let pipeline: FramePipeline
   private let submitter: Submitter
   private let controlClient: ChronicleControlClient?
+  private var runtimeLock: AgentdRuntimeLock?
   private var capture: CaptureService!
   private var menuBar: MenuBarController!
   private var userPaused = false
@@ -79,6 +80,16 @@ final class AppController {
   }
 
   func boot() async {
+    do {
+      runtimeLock = try AgentdRuntimeLock.acquire(purpose: "daemon")
+    } catch {
+      controlState.lastError = error.localizedDescription
+      Log.app.fault(
+        "agentd runtime lock unavailable: \(error.localizedDescription, privacy: .public)")
+      NSApp.terminate(nil)
+      return
+    }
+
     let permissions = PermissionSnapshot.current(promptForAccessibility: true)
     if !permissions.accessibilityTrusted {
       Log.app.warning("Accessibility not granted yet — window-context will be empty until granted")
@@ -436,7 +447,7 @@ final class AppController {
   }
 }
 
-struct PermissionSnapshot: Sendable, Equatable {
+struct PermissionSnapshot: Sendable, Equatable, Codable {
   let accessibilityTrusted: Bool
   let screenCaptureTrusted: Bool
 
@@ -460,6 +471,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     controller = c
     Task { await c.boot() }
   }
+}
+
+if DiagnosticCLI.shouldHandle(CommandLine.arguments) {
+  let code = await DiagnosticCLI.run(arguments: CommandLine.arguments)
+  exit(code)
 }
 
 // Status-bar-only app — no Dock icon, no main window.

--- a/Tests/agentdTests/DiagnosticCLITests.swift
+++ b/Tests/agentdTests/DiagnosticCLITests.swift
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import Foundation
+import XCTest
+
+@testable import agentd
+
+final class DiagnosticCLITests: XCTestCase {
+  func testShouldHandleOnlyDiagnosticCommands() {
+    XCTAssertFalse(DiagnosticCLI.shouldHandle(["agentd"]))
+    XCTAssertTrue(DiagnosticCLI.shouldHandle(["agentd", "list-displays"]))
+    XCTAssertTrue(DiagnosticCLI.shouldHandle(["agentd", "capture-once"]))
+    XCTAssertTrue(DiagnosticCLI.shouldHandle(["agentd", "selftest"]))
+    XCTAssertFalse(DiagnosticCLI.shouldHandle(["agentd", "--local-only"]))
+  }
+
+  func testCaptureOnceParserAcceptsSafeFlags() throws {
+    let command = try DiagnosticCommand.parse([
+      "capture-once", "--display-id", "42", "--no-ocr", "--out", "/tmp/agentd.json",
+    ])
+
+    guard case .captureOnce(let options) = command else {
+      return XCTFail("expected capture-once")
+    }
+    XCTAssertEqual(options.displayId, 42)
+    XCTAssertTrue(options.noOCR)
+    XCTAssertEqual(options.out?.path, "/tmp/agentd.json")
+  }
+
+  func testCaptureOnceParserRecognizesUnsafeScrubBypassForRuntimeRefusal() throws {
+    let command = try DiagnosticCommand.parse(["capture-once", "--no-scrub"])
+
+    guard case .captureOnce(let options) = command else {
+      return XCTFail("expected capture-once")
+    }
+    XCTAssertTrue(options.noScrub)
+  }
+
+  func testCaptureOnceParserRejectsUnknownFlags() {
+    XCTAssertThrowsError(try DiagnosticCommand.parse(["capture-once", "--stream"])) { error in
+      guard let cliError = error as? DiagnosticCLIError else {
+        return XCTFail("expected DiagnosticCLIError")
+      }
+      XCTAssertTrue(cliError.showsUsage)
+      XCTAssertTrue(cliError.localizedDescription.contains("unknown capture-once flag"))
+    }
+  }
+
+  func testListDisplaysRejectsFlags() {
+    XCTAssertThrowsError(try DiagnosticCommand.parse(["list-displays", "--json"])) { error in
+      guard let cliError = error as? DiagnosticCLIError else {
+        return XCTFail("expected DiagnosticCLIError")
+      }
+      XCTAssertTrue(cliError.showsUsage)
+      XCTAssertTrue(cliError.localizedDescription.contains("takes no flags"))
+    }
+  }
+}

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -20,3 +20,26 @@ strings, redacts secret-looking strings, and shortens home-directory paths.
 The menu also includes `Delete Queued Batches`, which removes local plaintext
 and encrypted fallback batches from the configured batch directory.
 
+## One-shot CLI
+
+The executable also has diagnostic subcommands that emit JSON without starting
+the menu-bar app:
+
+```sh
+agentd list-displays
+agentd capture-once --display-id 1 --out ~/.evalops/agentd/diagnostics/cli/capture.json
+agentd capture-once --no-ocr
+agentd selftest
+```
+
+`list-displays` reports display id, bounds, scale, main-display status, and the
+current Accessibility/Screen Recording preflight state. `capture-once` captures
+a single frame, runs the normal privacy filters, SecretScrubber, and OCR
+pipeline, then writes a redacted batch JSON object to stdout or an `0o600`
+`--out` path. It refuses to run while another agentd daemon or diagnostic
+capture holds the runtime lock, which avoids ScreenCaptureKit contention during
+support sessions.
+
+`--no-ocr` keeps the capture and scrubber path intact but records an empty OCR
+result. `--no-scrub` is recognized for operator muscle memory but deliberately
+refused; local diagnostics should not bypass the scrubber.


### PR DESCRIPTION
## Summary
- add diagnostic subcommands before app boot: list-displays, capture-once, and selftest
- run capture-once through the existing privacy filters, SecretScrubber, OCR pipeline, and 0600 JSON output path
- add a runtime lock so diagnostic capture refuses to contend with an active daemon
- document the CLI and add parser coverage

Part of #55

## Validation
- xcrun swift-format format --in-place --recursive Sources Tests Package.swift
- swift test
- swift build -Xswiftc -warnings-as-errors
- xcrun swift-format lint --strict --recursive Sources Tests Package.swift
- git diff --check
- python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
- ./.build/debug/agentd list-displays
- ./.build/debug/agentd capture-once --no-ocr --out /tmp/agentd-capture-once.json (hit expected macOS TCC denial after rebuild)
- scripts/package_app.sh