### PR TITLE
feat: cache stable privacy decisions

### DIFF
--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -347,11 +347,160 @@ struct OcrDiffSampler: Sendable {
   }
 }
 
+enum PrivacyDropKind: Sendable, Equatable {
+  case deniedApp
+  case deniedPath
+}
+
+struct PrivacyDecision: Sendable, Equatable {
+  let allowed: Bool
+  let reasonCode: String
+  let dropKind: PrivacyDropKind?
+  let observationId: String
+  let cached: Bool
+}
+
+struct PrivacyDecisionCache: Sendable {
+  private var entries: [PrivacyObservationSignature: PrivacyDecisionCacheEntry] = [:]
+  private var policyGeneration = 0
+
+  mutating func invalidateForPolicyUpdate() {
+    entries.removeAll(keepingCapacity: true)
+    policyGeneration += 1
+  }
+
+  mutating func decision(
+    for context: WindowContext,
+    config: AgentConfig,
+    now: Date = Date()
+  ) -> PrivacyDecision {
+    let signature = PrivacyObservationSignature(context: context, config: config)
+    if var entry = entries[signature] {
+      entry.lastEvaluatedAt = now
+      entries[signature] = entry
+      return PrivacyDecision(
+        allowed: entry.allowed,
+        reasonCode: entry.reasonCode,
+        dropKind: entry.dropKind,
+        observationId: entry.observationId,
+        cached: true
+      )
+    }
+
+    let evaluated = Self.evaluate(signature: signature, context: context, config: config)
+    let observationId = Self.observationId(signature: signature, policyGeneration: policyGeneration)
+    entries[signature] = PrivacyDecisionCacheEntry(
+      allowed: evaluated.allowed,
+      reasonCode: evaluated.reasonCode,
+      dropKind: evaluated.dropKind,
+      observationId: observationId,
+      observedAt: now,
+      lastEvaluatedAt: now
+    )
+    return PrivacyDecision(
+      allowed: evaluated.allowed,
+      reasonCode: evaluated.reasonCode,
+      dropKind: evaluated.dropKind,
+      observationId: observationId,
+      cached: false
+    )
+  }
+
+  private static func evaluate(
+    signature: PrivacyObservationSignature,
+    context: WindowContext,
+    config: AgentConfig
+  ) -> (allowed: Bool, reasonCode: String, dropKind: PrivacyDropKind?) {
+    if config.deniedBundleIds.contains(context.bundleId) {
+      return (false, "denied_bundle", .deniedApp)
+    }
+    if !config.allowedBundleIds.isEmpty,
+      !config.allowedBundleIds.contains(context.bundleId)
+    {
+      return (false, "allowlist_miss", .deniedApp)
+    }
+    if signature.pathClass.hasPrefix("denied:") {
+      return (false, "denied_path", .deniedPath)
+    }
+    if signature.titleClass.hasPrefix("pause:") {
+      return (false, "pause_title_pattern", .deniedApp)
+    }
+    return (true, "allowed", nil)
+  }
+
+  private static func observationId(
+    signature: PrivacyObservationSignature,
+    policyGeneration: Int
+  ) -> String {
+    let raw = [
+      String(policyGeneration),
+      signature.bundleId,
+      String(signature.pid),
+      signature.titleClass,
+      signature.pathClass,
+    ].joined(separator: "|")
+    let digest = SHA256.hash(data: Data(raw.utf8))
+    return digest.prefix(12).map { String(format: "%02x", $0) }.joined()
+  }
+}
+
+struct PrivacyObservationSignature: Sendable, Hashable {
+  let bundleId: String
+  let pid: pid_t
+  let titleClass: String
+  let pathClass: String
+
+  init(context: WindowContext, config: AgentConfig) {
+    self.bundleId = context.bundleId
+    self.pid = context.pid
+    self.titleClass = Self.titleClass(
+      context.windowTitle, pausePatterns: config.pauseWindowTitlePatterns)
+    self.pathClass = Self.pathClass(
+      context.documentPath, deniedPrefixes: config.deniedPathPrefixes)
+  }
+
+  static func titleClass(_ title: String, pausePatterns: [String]) -> String {
+    guard !title.isEmpty else { return "missing" }
+    if let match = pausePatterns.first(where: { title.contains($0) }) {
+      return "pause:\(stableClassHash(match))"
+    }
+    return "normal"
+  }
+
+  static func pathClass(_ path: String?, deniedPrefixes: [String]) -> String {
+    guard let path, !path.isEmpty else { return "none" }
+    let policy = PathPolicy(deniedPrefixes: deniedPrefixes)
+    if policy.deny(path) {
+      let matched = deniedPrefixes.first { prefix in
+        let expanded = NSString(string: prefix).expandingTildeInPath
+        return path.hasPrefix(expanded) || path.hasPrefix(prefix)
+      }
+      return "denied:\(stableClassHash(matched ?? "path"))"
+    }
+    return "present"
+  }
+
+  private static func stableClassHash(_ value: String) -> String {
+    let digest = SHA256.hash(data: Data(value.utf8))
+    return digest.prefix(6).map { String(format: "%02x", $0) }.joined()
+  }
+}
+
+private struct PrivacyDecisionCacheEntry: Sendable {
+  let allowed: Bool
+  let reasonCode: String
+  let dropKind: PrivacyDropKind?
+  let observationId: String
+  let observedAt: Date
+  var lastEvaluatedAt: Date
+}
+
 actor FramePipeline {
   private var config: AgentConfig
   private let ocr: any OCRRecognizing
   private var dedupWindow = DedupWindow(capacity: 16, threshold: 5)
   private var lastEmittedOcrText: String?
+  private var privacyDecisionCache = PrivacyDecisionCache()
   private var sparseFrameStore: SparseFrameStore?
   private var sparseFrameStoreOptions: SparseFrameStoreOptions?
 
@@ -380,6 +529,7 @@ actor FramePipeline {
 
   func updateConfig(_ cfg: AgentConfig) {
     self.config = cfg
+    privacyDecisionCache.invalidateForPolicyUpdate()
     let options = Self.sparseFrameStoreOptions(cfg)
     guard options != sparseFrameStoreOptions else { return }
     sparseFrameStoreOptions = options
@@ -398,27 +548,19 @@ actor FramePipeline {
   func consume(_ frame: CapturedFrame, context: WindowContext?) async {
     guard let ctx = context else { return }
 
-    if config.deniedBundleIds.contains(ctx.bundleId) {
-      droppedDeniedApp += 1
-      Log.scrub.debug("denied bundle \(ctx.bundleId, privacy: .public)")
-      return
+    let privacyDecision = privacyDecisionCache.decision(for: ctx, config: config)
+    if !privacyDecision.cached {
+      Log.scrub.info(
+        "privacy_decision observation=\(privacyDecision.observationId, privacy: .public) decision=\(privacyDecision.allowed ? "allow" : "deny", privacy: .public) reason=\(privacyDecision.reasonCode, privacy: .public)"
+      )
     }
-    if !config.allowedBundleIds.isEmpty,
-      !config.allowedBundleIds.contains(ctx.bundleId)
-    {
-      droppedDeniedApp += 1
-      Log.scrub.info("allowlist miss bundle=\(ctx.bundleId, privacy: .public)")
-      return
-    }
-
-    let pathPolicy = PathPolicy(deniedPrefixes: config.deniedPathPrefixes)
-    if let p = ctx.documentPath, pathPolicy.deny(p) {
-      droppedDeniedPath += 1
-      Log.scrub.info("denied path bundle=\(ctx.bundleId, privacy: .public)")
-      return
-    }
-    if config.pauseWindowTitlePatterns.contains(where: { ctx.windowTitle.contains($0) }) {
-      droppedDeniedApp += 1
+    guard privacyDecision.allowed else {
+      switch privacyDecision.dropKind {
+      case .deniedPath:
+        droppedDeniedPath += 1
+      case .deniedApp, nil:
+        droppedDeniedApp += 1
+      }
       return
     }
 

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -457,6 +457,70 @@ final class PipelineTests: XCTestCase {
     )
   }
 
+  func testPrivacyDecisionCacheReusesStableNormalWindowClass() {
+    var cache = PrivacyDecisionCache()
+    let cfg = Self.config()
+
+    let first = cache.decision(
+      for: Self.context(windowTitle: "Editor - file one", documentPath: "/tmp/a.swift"),
+      config: cfg,
+      now: Date(timeIntervalSince1970: 1)
+    )
+    let second = cache.decision(
+      for: Self.context(windowTitle: "Editor - file two", documentPath: "/tmp/b.swift"),
+      config: cfg,
+      now: Date(timeIntervalSince1970: 2)
+    )
+
+    XCTAssertTrue(first.allowed)
+    XCTAssertFalse(first.cached)
+    XCTAssertTrue(second.allowed)
+    XCTAssertTrue(second.cached)
+    XCTAssertEqual(first.observationId, second.observationId)
+  }
+
+  func testPrivacyDecisionCacheInvalidatesWhenTitleClassChanges() {
+    var cache = PrivacyDecisionCache()
+    let cfg = Self.config()
+
+    let normal = cache.decision(for: Self.context(windowTitle: "Editor"), config: cfg)
+    let privateWindow = cache.decision(
+      for: Self.context(windowTitle: "Private Browsing - Example"), config: cfg)
+
+    XCTAssertTrue(normal.allowed)
+    XCTAssertFalse(privateWindow.allowed)
+    XCTAssertFalse(privateWindow.cached)
+    XCTAssertEqual(privateWindow.reasonCode, "pause_title_pattern")
+    XCTAssertEqual(privateWindow.dropKind, .deniedApp)
+    XCTAssertNotEqual(normal.observationId, privateWindow.observationId)
+  }
+
+  func testPrivacyDecisionCachePolicyInvalidationChangesObservationId() {
+    var cache = PrivacyDecisionCache()
+    let cfg = Self.config()
+
+    let before = cache.decision(for: Self.context(), config: cfg)
+    cache.invalidateForPolicyUpdate()
+    let after = cache.decision(for: Self.context(), config: cfg)
+
+    XCTAssertFalse(before.cached)
+    XCTAssertFalse(after.cached)
+    XCTAssertNotEqual(before.observationId, after.observationId)
+  }
+
+  func testPrivacyDecisionCacheDeniedPathStaysPathDrop() {
+    var cache = PrivacyDecisionCache()
+    let cfg = Self.config()
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+
+    let decision = cache.decision(
+      for: Self.context(documentPath: "\(home)/.ssh/id_ed25519"), config: cfg)
+
+    XCTAssertFalse(decision.allowed)
+    XCTAssertEqual(decision.reasonCode, "denied_path")
+    XCTAssertEqual(decision.dropKind, .deniedPath)
+  }
+
   static func config(maxFramesPerBatch: Int = 24, maxOcrTextChars: Int = 4096) -> AgentConfig {
     AgentConfig(
       deviceId: "device_1",


### PR DESCRIPTION
## Summary
- add a stable privacy decision cache keyed by bundle, pid, title class, and document-path class
- emit one privacy_decision log per new observation while reusing cached allow/deny decisions for stable windows
- invalidate cached decisions on capture policy updates and keep SecretScrubber evaluation on every frame
- add cache coverage for stable normal windows, title-class transitions, policy invalidation, and denied-path drops

Part of #54

## Validation
- xcrun swift-format format --in-place --recursive Sources Tests Package.swift
- swift test
- swift build -Xswiftc -warnings-as-errors
- xcrun swift-format lint --strict --recursive Sources Tests Package.swift
- git diff --check
- python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
- scripts/package_app.sh