### PR TITLE
feat: pause capture for protected foreground content

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ local inspection of the shipped arm64 `codex_chronicle` helper bundled with
   Stripe markers — match → frame dropped, never partial-redacted.
 - Per-app allow/deny list and per-path deny list.
 - Window-title pause patterns (Zoom, FaceTime, 1Password…).
+- Foreground privacy pause releases active ScreenCaptureKit streams when known
+  protected streaming or remote-desktop content is focused, rather than merely
+  dropping frames after capture.
 - Scheduled pause windows from managed policy pause capture for meetings,
   interviews, private/focus blocks, or Platform-driven policy windows; manual
   pause always wins over automatic resume.
@@ -239,8 +242,9 @@ and bytes. `RegisterDevice` and `Heartbeat` responses may include a
 scheduled pause windows, selected-display scope, batch interval, and max-frame
 settings at runtime.
 Server `PAUSED` capture mode stops capture until a later policy resumes it.
-Manual user pause wins over scheduled pause, and scheduled pause wins over
-server policy pause for visible menu/diagnostic state.
+Manual user pause wins over scheduled pause, scheduled pause wins over
+foreground privacy pauses, and foreground privacy pauses win over server policy
+pause for visible menu/diagnostic state.
 
 Encrypted local batches use the `.agentdbatch` extension. The encryption key is
 created or loaded from Keychain service `dev.evalops.agentd.local-batch-key`,

--- a/Sources/agentd/ForegroundPrivacyPause.swift
+++ b/Sources/agentd/ForegroundPrivacyPause.swift
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import Foundation
+
+enum ForegroundPrivacyPauseDetector {
+  static func reason(context: WindowContext?, config: AgentConfig) -> String? {
+    guard let context else { return nil }
+
+    if config.pauseWindowTitlePatterns.contains(where: { pattern in
+      !pattern.isEmpty && context.windowTitle.localizedCaseInsensitiveContains(pattern)
+    }) {
+      return "window_title_pattern"
+    }
+    if isProtectedApplication(context.appName) {
+      return "protected_application"
+    }
+    if isProtectedURL(context.documentPath) || isProtectedURL(context.windowTitle) {
+      return "protected_content_url"
+    }
+    if isProtectedTitle(context.windowTitle) {
+      return "protected_content_title"
+    }
+    return nil
+  }
+
+  static func isProtectedApplication(_ value: String) -> Bool {
+    let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard !normalized.isEmpty else { return false }
+    if normalized == "max" {
+      return true
+    }
+    return protectedApplicationFragments.contains { normalized.contains($0) }
+  }
+
+  static func isProtectedTitle(_ value: String) -> Bool {
+    let normalized = value.lowercased()
+    guard !normalized.isEmpty else { return false }
+    return protectedTitleFragments.contains { normalized.contains($0) }
+  }
+
+  static func isProtectedURL(_ value: String?) -> Bool {
+    guard let value, !value.isEmpty else { return false }
+    let lower = value.lowercased()
+    guard lower.contains("://") || protectedDomains.contains(where: { lower.contains($0) })
+    else {
+      return false
+    }
+    guard let components = URLComponents(string: lower),
+      let rawHost = components.host
+    else {
+      return protectedDomains.contains { lower.contains($0) }
+    }
+    let host = rawHost.replacingOccurrences(of: "www.", with: "")
+    return protectedDomains.contains { domain in
+      host == domain || host.hasSuffix(".\(domain)")
+    } || (host == "amazon.com" && components.path.hasPrefix("/gp/video/"))
+  }
+
+  private static let protectedApplicationFragments: [String] = [
+    "netflix",
+    "disney+",
+    "hulu",
+    "prime video",
+    "apple tv",
+    "peacock",
+    "paramount+",
+    "hbo max",
+    "crunchyroll",
+    "dazn",
+    "horizon client",
+    "vmware horizon",
+    "omnissa horizon",
+  ]
+
+  private static let protectedTitleFragments: [String] = [
+    "netflix",
+    "disney+",
+    "hulu",
+    "prime video",
+    "apple tv",
+    "peacock",
+    "paramount+",
+    "hbo max",
+    "crunchyroll",
+    "dazn",
+  ]
+
+  private static let protectedDomains: [String] = [
+    "netflix.com",
+    "disneyplus.com",
+    "hulu.com",
+    "primevideo.com",
+    "tv.apple.com",
+    "peacocktv.com",
+    "paramountplus.com",
+    "play.max.com",
+    "crunchyroll.com",
+    "dazn.com",
+  ]
+}

--- a/Sources/agentd/PauseState.swift
+++ b/Sources/agentd/PauseState.swift
@@ -6,13 +6,14 @@ enum EffectivePauseState: Sendable, Equatable {
   case active
   case manual
   case scheduled(id: String, reason: String, endsAt: Date)
+  case foregroundPrivacy(reason: String)
   case policy(reason: String?)
 
   var paused: Bool {
     switch self {
     case .active:
       return false
-    case .manual, .scheduled, .policy:
+    case .manual, .scheduled, .foregroundPrivacy, .policy:
       return true
     }
   }
@@ -25,6 +26,8 @@ enum EffectivePauseState: Sendable, Equatable {
       return "manual"
     case .scheduled(_, let reason, _):
       return "scheduled:\(reason)"
+    case .foregroundPrivacy(let reason):
+      return "foreground_privacy:\(reason)"
     case .policy(let reason):
       return reason.map { "policy:\($0)" } ?? "policy"
     }
@@ -38,6 +41,8 @@ enum EffectivePauseState: Sendable, Equatable {
       return "paused by user"
     case .scheduled(_, let reason, _):
       return "paused by schedule: \(reason)"
+    case .foregroundPrivacy(let reason):
+      return "paused for foreground privacy: \(reason)"
     case .policy(let reason):
       return "paused by policy\(reason.map { ": \($0)" } ?? "")"
     }
@@ -48,6 +53,7 @@ struct PauseStateResolver: Sendable {
   static func resolve(
     userPaused: Bool,
     scheduledWindows: [ScheduledPauseWindow],
+    foregroundPrivacyReason: String?,
     policyPaused: Bool,
     policyReason: String?,
     now: Date
@@ -57,6 +63,9 @@ struct PauseStateResolver: Sendable {
     }
     if let window = scheduledWindows.first(where: { $0.startsAt <= now && now < $0.endsAt }) {
       return .scheduled(id: window.id, reason: window.reason, endsAt: window.endsAt)
+    }
+    if let foregroundPrivacyReason {
+      return .foregroundPrivacy(reason: foregroundPrivacyReason)
     }
     if policyPaused {
       return .policy(reason: policyReason)

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -23,6 +23,8 @@ final class AppController {
   private var heartbeatTimer: Timer?
   private var pauseWindowTimer: Timer?
   private var captureRetryTimer: Timer?
+  private var foregroundPrivacyTimer: Timer?
+  private var foregroundPrivacyPauseReason: String?
   private var idleMode = false
 
   init() {
@@ -140,9 +142,15 @@ final class AppController {
     )
 
     await registerWithChronicle(permissions: permissions)
+    await pollForegroundPrivacyState()
     await reconcileCaptureState()
 
     scheduleFlushTimer()
+    foregroundPrivacyTimer = Timer.scheduledTimer(
+      withTimeInterval: max(1, min(2, config.idlePollSeconds)), repeats: true
+    ) { [weak self] _ in
+      Task { @MainActor in await self?.pollForegroundPrivacyState() }
+    }
     idleTimer = Timer.scheduledTimer(
       withTimeInterval: max(1, config.idlePollSeconds), repeats: true
     ) { [weak self] _ in
@@ -161,6 +169,23 @@ final class AppController {
 
   private func applyPause(_ paused: Bool) async {
     userPaused = paused
+    await reconcileCaptureState()
+  }
+
+  private func pollForegroundPrivacyState() async {
+    let next = ForegroundPrivacyPauseDetector.reason(
+      context: WindowContextProbe.current(),
+      config: config
+    )
+    guard next != foregroundPrivacyPauseReason else { return }
+    foregroundPrivacyPauseReason = next
+    if let next {
+      Log.capture.notice(
+        "foreground privacy pause engaged reason=\(next, privacy: .public); releasing capture streams"
+      )
+    } else {
+      Log.capture.notice("foreground privacy pause cleared")
+    }
     await reconcileCaptureState()
   }
 
@@ -304,6 +329,7 @@ final class AppController {
     if captureRunning {
       await capture.updateFps(idleMode ? config.idleFps : config.captureFps)
     }
+    await pollForegroundPrivacyState()
     await reconcileCaptureState()
   }
 
@@ -351,6 +377,7 @@ final class AppController {
     PauseStateResolver.resolve(
       userPaused: userPaused,
       scheduledWindows: scheduledPauseWindows,
+      foregroundPrivacyReason: foregroundPrivacyPauseReason,
       policyPaused: controlState.serverPaused,
       policyReason: controlState.serverPauseReason,
       now: now

--- a/Tests/agentdTests/ForegroundPrivacyPauseTests.swift
+++ b/Tests/agentdTests/ForegroundPrivacyPauseTests.swift
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import Foundation
+import XCTest
+
+@testable import agentd
+
+final class ForegroundPrivacyPauseTests: XCTestCase {
+  func testPauseWindowTitlePatternTriggersForegroundPause() {
+    let reason = ForegroundPrivacyPauseDetector.reason(
+      context: Self.context(title: "1Password - Production Vault"),
+      config: Self.config()
+    )
+
+    XCTAssertEqual(reason, "window_title_pattern")
+  }
+
+  func testProtectedStreamingDomainTriggersForegroundPause() {
+    let reason = ForegroundPrivacyPauseDetector.reason(
+      context: Self.context(title: "Safari", documentPath: "https://www.netflix.com/watch/123"),
+      config: Self.config()
+    )
+
+    XCTAssertEqual(reason, "protected_content_url")
+  }
+
+  func testProtectedRemoteDesktopApplicationTriggersForegroundPause() {
+    let reason = ForegroundPrivacyPauseDetector.reason(
+      context: Self.context(appName: "Omnissa Horizon Client"),
+      config: Self.config()
+    )
+
+    XCTAssertEqual(reason, "protected_application")
+  }
+
+  func testUnrelatedWindowDoesNotPause() {
+    XCTAssertNil(
+      ForegroundPrivacyPauseDetector.reason(
+        context: Self.context(title: "main.swift - agentd"),
+        config: Self.config()
+      ))
+  }
+
+  private static func config() -> AgentConfig {
+    AgentConfig(
+      deviceId: "device_1",
+      organizationId: "org_1",
+      endpoint: URL(string: "http://127.0.0.1:8787/submit")!,
+      allowedBundleIds: AgentConfig.defaultAllowedBundleIds,
+      deniedBundleIds: AgentConfig.defaultDeniedBundleIds,
+      deniedPathPrefixes: AgentConfig.defaultDeniedPathPrefixes,
+      pauseWindowTitlePatterns: AgentConfig.defaultPauseWindowPatterns,
+      captureFps: 1,
+      idleFps: 0.2,
+      batchIntervalSeconds: 30,
+      maxFramesPerBatch: 24,
+      localOnly: true
+    )
+  }
+
+  private static func context(
+    appName: String = "Safari",
+    title: String = "normal",
+    documentPath: String? = nil
+  ) -> WindowContext {
+    WindowContext(
+      bundleId: "com.apple.Safari",
+      appName: appName,
+      windowTitle: title,
+      documentPath: documentPath,
+      pid: 123,
+      timestamp: Date()
+    )
+  }
+}

--- a/Tests/agentdTests/PauseStateTests.swift
+++ b/Tests/agentdTests/PauseStateTests.swift
@@ -18,6 +18,7 @@ final class PauseStateTests: XCTestCase {
     let state = PauseStateResolver.resolve(
       userPaused: true,
       scheduledWindows: [window],
+      foregroundPrivacyReason: "protected_content_url",
       policyPaused: true,
       policyReason: "fleet",
       now: now
@@ -40,6 +41,7 @@ final class PauseStateTests: XCTestCase {
       PauseStateResolver.resolve(
         userPaused: false,
         scheduledWindows: [window],
+        foregroundPrivacyReason: "protected_content_url",
         policyPaused: true,
         policyReason: "fleet",
         now: now
@@ -50,6 +52,7 @@ final class PauseStateTests: XCTestCase {
       PauseStateResolver.resolve(
         userPaused: false,
         scheduledWindows: [window],
+        foregroundPrivacyReason: nil,
         policyPaused: false,
         policyReason: nil,
         now: now.addingTimeInterval(11)
@@ -76,5 +79,21 @@ final class PauseStateTests: XCTestCase {
         after: now.addingTimeInterval(40), scheduledWindows: [window]),
       now.addingTimeInterval(90)
     )
+  }
+
+  func testForegroundPrivacyWinsOverPolicy() {
+    let now = Date(timeIntervalSince1970: 100)
+
+    let state = PauseStateResolver.resolve(
+      userPaused: false,
+      scheduledWindows: [],
+      foregroundPrivacyReason: "protected_content_url",
+      policyPaused: true,
+      policyReason: "fleet",
+      now: now
+    )
+
+    XCTAssertEqual(state, .foregroundPrivacy(reason: "protected_content_url"))
+    XCTAssertEqual(state.reason, "foreground_privacy:protected_content_url")
   }
 }

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -20,6 +20,12 @@ strings, redacts secret-looking strings, and shortens home-directory paths.
 The menu also includes `Delete Queued Batches`, which removes local plaintext
 and encrypted fallback batches from the configured batch directory.
 
+Foreground privacy pauses are visible as capture-state reasons. These pauses
+release active ScreenCaptureKit streams while known protected streaming content,
+remote-desktop content, or configured pause-window title patterns are focused,
+so support reports can distinguish deliberate privacy release from capture
+failure.
+
 ## One-shot CLI
 
 The executable also has diagnostic subcommands that emit JSON without starting


### PR DESCRIPTION
## Summary
- add a foreground privacy pause detector for configured pause-title patterns, protected streaming surfaces, and Horizon-style remote desktop clients
- promote foreground privacy to a first-class pause reason so menu, diagnostics, and heartbeat state show why SCK streams were released
- poll foreground privacy state before capture startup and while running, stopping capture streams instead of only dropping frames after ScreenCaptureKit has captured them
- document the new protected-content pause behavior

Part of #54 and #39.

## SOTA notes
- `gh` research found screenpipe/screenpipe’s protected-content approach in `crates/screenpipe-engine/src/drm_detector.rs`: detect DRM / remote-desktop foreground content and fully release ScreenCaptureKit handles while focused.
- screenpipe’s event-driven capture spec also reinforces the direction of foreground/event-triggered capture rather than blind polling.
- OpenAdapt’s privacy package reinforces keeping privacy reasons explicit and auditable rather than buried in raw capture output.

## Validation
- xcrun swift-format format --in-place --recursive Sources Tests Package.swift
- swift test
- swift build -Xswiftc -warnings-as-errors
- xcrun swift-format lint --strict --recursive Sources Tests Package.swift
- git diff --check
- python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
- scripts/package_app.sh