### PR TITLE
feat: add OCR result cache diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ local inspection of the shipped arm64 `codex_chronicle` helper bundled with
   frame is batched.
 - OCR text is scrubbed at full length, then capped to `maxOcrTextChars`
   (default 4096) with `ocrTextTruncated` set when the cap applies.
+- A bounded OCR result cache reuses Vision output for unchanged window/content
+  observations while still running SecretScrubber on every frame before
+  persistence.
 - Batches every 30s or 24 frames, whichever first.
 - Local-only mode persists batches under `~/.evalops/agentd/batches/` as
   `0o600` JSON by default and sweeps old or over-budget batches; HTTP mode
@@ -254,8 +257,8 @@ encrypted `.agentdbatch` batches.
 
 Diagnostics reports are written under `~/.evalops/agentd/diagnostics/` with
 `0o600` permissions. They summarize permissions, policy, queue pressure, local
-batches, active display frame/drop counters, and last submit health without OCR
-text or raw payloads. The same binary also supports `list-displays`,
+batches, OCR cache hit-rate counters, active display frame/drop counters, and
+last submit health without OCR text or raw payloads. The same binary also supports `list-displays`,
 `capture-once`, and `selftest` diagnostic subcommands; see
 `docs/diagnostics.md`.
 

--- a/Sources/agentd/Diagnostics.swift
+++ b/Sources/agentd/Diagnostics.swift
@@ -12,6 +12,7 @@ struct DiagnosticsSnapshot: Sendable {
   let policySource: String?
   let controlError: String?
   let pendingStats: PendingFrameStats
+  let ocrCacheStats: OCRCacheStats
   let localBatchStats: LocalBatchStats
   let localBatches: [LocalBatchSummary]
   let captureDisplayStats: [CaptureDisplayStats]
@@ -36,6 +37,12 @@ enum DiagnosticsReport {
     lines.append("- Last control error: \(redact(snapshot.controlError ?? "none"))")
     lines.append("- Pending in-memory frames: \(snapshot.pendingStats.frameCount)")
     lines.append("- Pending in-memory bytes: \(snapshot.pendingStats.estimatedBytes)")
+    lines.append("- OCR cache entries: \(snapshot.ocrCacheStats.entries)")
+    lines.append(
+      "- OCR cache hit rate: \(String(format: "%.2f", snapshot.ocrCacheStats.hitRate))"
+    )
+    lines.append("- OCR cache misses: \(snapshot.ocrCacheStats.misses)")
+    lines.append("- OCR cache evictions: \(snapshot.ocrCacheStats.evictions)")
     lines.append("- Queued local batches: \(snapshot.localBatchStats.fileCount)")
     lines.append("- Queued local bytes: \(snapshot.localBatchStats.bytes)")
     lines.append("- Last submit result: \(snapshot.lastSubmitResult ?? "unknown")")

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -347,6 +347,118 @@ struct OcrDiffSampler: Sendable {
   }
 }
 
+struct OCRCacheStats: Sendable, Equatable {
+  let entries: Int
+  let hits: Int
+  let misses: Int
+  let evictions: Int
+
+  var hitRate: Double {
+    let total = hits + misses
+    guard total > 0 else { return 0 }
+    return Double(hits) / Double(total)
+  }
+}
+
+struct OCRResultCache: Sendable {
+  private var entries: [OCRCacheKey: OCRCacheEntry] = [:]
+  private var order: [OCRCacheKey] = []
+  private let maxEntries: Int
+  private var hits = 0
+  private var misses = 0
+  private var evictions = 0
+
+  init(maxEntries: Int = 128) {
+    self.maxEntries = max(1, maxEntries)
+  }
+
+  mutating func result(for key: OCRCacheKey) -> OCRResult? {
+    guard let entry = entries[key] else {
+      misses += 1
+      return nil
+    }
+    hits += 1
+    return entry.result
+  }
+
+  mutating func insert(_ result: OCRResult, for key: OCRCacheKey) {
+    if entries[key] == nil {
+      order.append(key)
+    }
+    entries[key] = OCRCacheEntry(result: result)
+    evictIfNeeded()
+  }
+
+  func stats() -> OCRCacheStats {
+    OCRCacheStats(entries: entries.count, hits: hits, misses: misses, evictions: evictions)
+  }
+
+  private mutating func evictIfNeeded() {
+    while entries.count > maxEntries, let oldest = order.first {
+      order.removeFirst()
+      if entries.removeValue(forKey: oldest) != nil {
+        evictions += 1
+      }
+    }
+  }
+}
+
+struct OCRCacheKey: Sendable, Hashable {
+  let bundleId: String
+  let pid: pid_t
+  let titleHash: String
+  let documentHash: String
+  let imageHash: UInt64
+
+  init(context: WindowContext, imageHash: UInt64) {
+    self.bundleId = context.bundleId
+    self.pid = context.pid
+    self.titleHash = Self.hashSurface(context.windowTitle)
+    self.documentHash = Self.hashSurface(context.documentPath ?? "")
+    self.imageHash = imageHash
+  }
+
+  private static func hashSurface(_ value: String) -> String {
+    let digest = SHA256.hash(data: Data(value.utf8))
+    return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+  }
+}
+
+private struct OCRCacheEntry: Sendable {
+  let result: OCRResult
+}
+
+enum ImageContentHash {
+  static func calculate(cgImage: CGImage, sampleSize: Int = 32) -> UInt64? {
+    let width = max(1, sampleSize)
+    let height = max(1, sampleSize)
+    var pixels = [UInt8](repeating: 0, count: width * height * 4)
+    let drew = pixels.withUnsafeMutableBytes { buffer in
+      guard
+        let context = CGContext(
+          data: buffer.baseAddress,
+          width: width,
+          height: height,
+          bitsPerComponent: 8,
+          bytesPerRow: width * 4,
+          space: CGColorSpaceCreateDeviceRGB(),
+          bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+      else {
+        return false
+      }
+      context.interpolationQuality = .low
+      context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+      return true
+    }
+    guard drew else { return nil }
+    let digest = SHA256.hash(data: Data(pixels))
+    return digest.prefix(8).reduce(UInt64(0)) { partial, byte in
+      (partial << 8) | UInt64(byte)
+    }
+  }
+}
+
 enum PrivacyDropKind: Sendable, Equatable {
   case deniedApp
   case deniedPath
@@ -500,6 +612,7 @@ actor FramePipeline {
   private let ocr: any OCRRecognizing
   private var dedupWindow = DedupWindow(capacity: 16, threshold: 5)
   private var lastEmittedOcrText: String?
+  private var ocrCache = OCRResultCache()
   private var privacyDecisionCache = PrivacyDecisionCache()
   private var sparseFrameStore: SparseFrameStore?
   private var sparseFrameStoreOptions: SparseFrameStoreOptions?
@@ -545,6 +658,10 @@ actor FramePipeline {
     return PendingFrameStats(frameCount: pending.count, estimatedBytes: pendingBytes)
   }
 
+  func ocrCacheStats() -> OCRCacheStats {
+    ocrCache.stats()
+  }
+
   func consume(_ frame: CapturedFrame, context: WindowContext?) async {
     guard let ctx = context else { return }
 
@@ -572,11 +689,21 @@ actor FramePipeline {
     }
 
     let ocrResult: OCRResult
-    do {
-      ocrResult = try await ocr.recognize(cgImage: frame.cgImage)
-    } catch {
-      Log.ocr.error("ocr failed: \(error.localizedDescription, privacy: .public)")
-      return
+    let ocrCacheKey = ImageContentHash.calculate(cgImage: frame.cgImage).map {
+      OCRCacheKey(context: ctx, imageHash: $0)
+    }
+    if let ocrCacheKey, let cached = ocrCache.result(for: ocrCacheKey) {
+      ocrResult = cached
+    } else {
+      do {
+        ocrResult = try await ocr.recognize(cgImage: frame.cgImage)
+        if let ocrCacheKey {
+          ocrCache.insert(ocrResult, for: ocrCacheKey)
+        }
+      } catch {
+        Log.ocr.error("ocr failed: \(error.localizedDescription, privacy: .public)")
+        return
+      }
     }
 
     switch evaluateSecretSurfaces(context: ctx, ocrText: ocrResult.text) {

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -405,6 +405,7 @@ final class AppController {
   private func openDiagnosticsReport() async {
     let permissions = PermissionSnapshot.current(promptForAccessibility: false)
     let pending = await pipeline.pendingStats()
+    let ocrCacheStats = await pipeline.ocrCacheStats()
     let localStats = await submitter.localBatchStats()
     let localBatches = await submitter.localBatchSummaries()
     let lastSubmitResult = await submitter.lastSubmitResult()
@@ -419,6 +420,7 @@ final class AppController {
       policySource: policySource,
       controlError: controlState.lastError,
       pendingStats: pending,
+      ocrCacheStats: ocrCacheStats,
       localBatchStats: localStats,
       localBatches: localBatches,
       captureDisplayStats: captureDisplayStats,

--- a/Tests/agentdTests/DiagnosticsTests.swift
+++ b/Tests/agentdTests/DiagnosticsTests.swift
@@ -36,6 +36,7 @@ final class DiagnosticsTests: XCTestCase {
       policySource: "chronicle://policy/\(SecretScrubberTests.jwtFixture())",
       controlError: "none",
       pendingStats: PendingFrameStats(frameCount: 2, estimatedBytes: 4096),
+      ocrCacheStats: OCRCacheStats(entries: 3, hits: 7, misses: 1, evictions: 2),
       localBatchStats: LocalBatchStats(fileCount: 1, bytes: 1234),
       localBatches: [
         LocalBatchSummary(
@@ -64,6 +65,9 @@ final class DiagnosticsTests: XCTestCase {
     let report = DiagnosticsReport.markdown(snapshot)
 
     XCTAssertTrue(report.contains("Queued local batches: 1"))
+    XCTAssertTrue(report.contains("OCR cache entries: 3"))
+    XCTAssertTrue(report.contains("OCR cache hit rate: 0.88"))
+    XCTAssertTrue(report.contains("OCR cache evictions: 2"))
     XCTAssertTrue(report.contains("| batch_1 |"))
     XCTAssertTrue(
       report.contains("https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch"))

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -277,7 +277,7 @@ final class PipelineTests: XCTestCase {
     }
 
     await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
-    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAB), context: Self.context())
     await pipeline.flush()
 
     let batches = await recorder.snapshot()
@@ -521,6 +521,66 @@ final class PipelineTests: XCTestCase {
     XCTAssertEqual(decision.dropKind, .deniedPath)
   }
 
+  func testOcrCacheAvoidsRecognizingSameDuplicateWhenSamplerEnabled() async throws {
+    var cfg = Self.config()
+    cfg.ocrDiffSamplerEnabled = true
+    let recorder = BatchRecorder()
+    let ocr = CountingOCR(text: "same visible text")
+    let pipeline = FramePipeline(config: cfg, ocr: ocr) { batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+    await pipeline.flush()
+
+    let callCount = await ocr.callCount()
+    XCTAssertEqual(callCount, 1)
+    let stats = await pipeline.ocrCacheStats()
+    XCTAssertEqual(stats.entries, 1)
+    XCTAssertEqual(stats.hits, 1)
+    XCTAssertEqual(stats.misses, 1)
+    let batches = await recorder.snapshot()
+    let batch = try XCTUnwrap(batches.first)
+    XCTAssertEqual(batch.frames.count, 1)
+    XCTAssertEqual(batch.droppedCounts.duplicate, 1)
+  }
+
+  func testOcrCacheMissesWhenImageContentChanges() async throws {
+    let recorder = BatchRecorder()
+    let ocr = CountingOCR(text: "visible text")
+    let pipeline = FramePipeline(config: Self.config(), ocr: ocr) { batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA), context: Self.context())
+    await pipeline.consume(Self.frame(bits: 0x5555_5555_5555_5555), context: Self.context())
+
+    let callCount = await ocr.callCount()
+    XCTAssertEqual(callCount, 2)
+    let stats = await pipeline.ocrCacheStats()
+    XCTAssertEqual(stats.hits, 0)
+    XCTAssertEqual(stats.misses, 2)
+    XCTAssertEqual(stats.entries, 2)
+  }
+
+  func testOcrCacheEvictsOldestEntry() {
+    var cache = OCRResultCache(maxEntries: 1)
+    let first = OCRCacheKey(context: Self.context(windowTitle: "first"), imageHash: 1)
+    let second = OCRCacheKey(context: Self.context(windowTitle: "second"), imageHash: 2)
+
+    cache.insert(OCRResult(text: "first", confidence: 1, language: "en"), for: first)
+    cache.insert(OCRResult(text: "second", confidence: 1, language: "en"), for: second)
+
+    XCTAssertNil(cache.result(for: first))
+    XCTAssertEqual(cache.result(for: second)?.text, "second")
+    let stats = cache.stats()
+    XCTAssertEqual(stats.entries, 1)
+    XCTAssertEqual(stats.evictions, 1)
+    XCTAssertEqual(stats.hits, 1)
+    XCTAssertEqual(stats.misses, 1)
+  }
+
   static func config(maxFramesPerBatch: Int = 24, maxOcrTextChars: Int = 4096) -> AgentConfig {
     AgentConfig(
       deviceId: "device_1",
@@ -643,6 +703,24 @@ actor SequenceOCR: OCRRecognizing {
   func recognize(cgImage: CGImage) async throws -> OCRResult {
     let text = texts.isEmpty ? "" : texts.removeFirst()
     return OCRResult(text: text, confidence: confidence, language: "en")
+  }
+}
+
+actor CountingOCR: OCRRecognizing {
+  private let text: String
+  private var calls = 0
+
+  init(text: String) {
+    self.text = text
+  }
+
+  func recognize(cgImage: CGImage) async throws -> OCRResult {
+    calls += 1
+    return OCRResult(text: text, confidence: 0.9, language: "en")
+  }
+
+  func callCount() -> Int {
+    calls
   }
 }
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -12,6 +12,7 @@ The report includes:
 - app version, local-only/managed mode, Secret Broker mode, policy version, and
   policy source;
 - in-memory frame pressure and queued local batch count/bytes;
+- OCR cache entry, hit-rate, miss, and eviction counters;
 - queued batch id, modification time, size, and encryption state.
 
 The report omits OCR text and raw queued payloads. It strips endpoint query


### PR DESCRIPTION
## Summary
- add a bounded OCR result cache keyed by stable window surface hashes plus sampled image-content hash
- reuse cached Vision OCR for unchanged window/content observations while still running SecretScrubber every frame
- expose OCR cache entries, hit rate, misses, and evictions in local diagnostics
- add tests for cache hits, content-change misses, eviction, and OCR-diff sampler compatibility

Part of #65.

## SOTA notes
- `gh` research found screenpipe/screenpipe's OCR cache keyed by window identity plus image hash with hit/miss stats:
  https://github.com/screenpipe/screenpipe/blob/d9ad0b8d1a50edcbee921c8e27cb4b01696092c6/crates/screenpipe-screen/src/ocr_cache.rs

## Validation
- `xcrun swift-format format --in-place --recursive Sources Tests Package.swift`
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `git diff --check`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `scripts/package_app.sh`
