### PR TITLE
feat: add opt-in event capture scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ local inspection of the shipped arm64 `codex_chronicle` helper bundled with
 - A bounded OCR result cache reuses Vision output for unchanged window/content
   observations while still running SecretScrubber on every frame before
   persistence.
+- Optional event-triggered capture mode arms one-shot captures on focused-window
+  changes, clipboard updates, and idle fallback ticks behind
+  `eventCaptureEnabled`, with debounce/min-gap counters in diagnostics.
 - Batches every 30s or 24 frames, whichever first.
 - Local-only mode persists batches under `~/.evalops/agentd/batches/` as
   `0o600` JSON by default and sweeps old or over-budget batches; HTTP mode
@@ -157,6 +160,12 @@ agentd reads and writes `~/.evalops/agentd/config.json`. Important defaults:
 - `adaptiveOcrBacklogBytes: 67108864`
 - `ocrDiffSamplerEnabled: false`
 - `ocrDiffSimilarityThreshold: 0.92`
+- `eventCaptureEnabled: false`
+- `eventCapturePollSeconds: 0.5`
+- `eventCaptureDebounceSeconds: 0.25`
+- `eventCaptureMinGapSeconds: 1`
+- `eventCaptureIdleFallbackSeconds: 30`
+- `eventCaptureTimeoutSeconds: 5`
 - `sparseFrameStorageRoot: null`
 - `sparseFrameRetentionHours: 6`
 - `sparseFrameIncludeOcrText: false`
@@ -257,10 +266,10 @@ encrypted `.agentdbatch` batches.
 
 Diagnostics reports are written under `~/.evalops/agentd/diagnostics/` with
 `0o600` permissions. They summarize permissions, policy, queue pressure, local
-batches, OCR cache hit-rate counters, active display frame/drop counters, and
-last submit health without OCR text or raw payloads. The same binary also supports `list-displays`,
-`capture-once`, and `selftest` diagnostic subcommands; see
-`docs/diagnostics.md`.
+batches, OCR cache hit-rate counters, event-capture trigger counters, active
+display frame/drop counters, and last submit health without OCR text or raw
+payloads. The same binary also supports `list-displays`, `capture-once`, and
+`selftest` diagnostic subcommands; see `docs/diagnostics.md`.
 
 For Chronicle-style local introspection, set `sparseFrameStorageRoot` to a
 directory such as `~/.evalops/agentd/sparse-frames`. agentd then writes

--- a/Sources/agentd/CaptureService.swift
+++ b/Sources/agentd/CaptureService.swift
@@ -45,6 +45,17 @@ enum DisplaySelection {
   }
 }
 
+enum CaptureOneShotError: LocalizedError {
+  case timedOut
+
+  var errorDescription: String? {
+    switch self {
+    case .timedOut:
+      return "timed out waiting for a captured frame"
+    }
+  }
+}
+
 actor CaptureService: NSObject {
   private var captures: [CGDirectDisplayID: DisplayCapture] = [:]
   private let onFrame: @Sendable (CapturedFrame) async -> Void
@@ -149,6 +160,50 @@ actor CaptureService: NSObject {
     captures.values.map { $0.output.stats() }.sorted { $0.displayId < $1.displayId }
   }
 
+  static func captureOneFrame(
+    targetFps: Double,
+    captureAllDisplays: Bool,
+    selectedDisplayIds: [UInt32],
+    timeoutSeconds: Double,
+    onFrameDropped: @escaping @Sendable (CGDirectDisplayID) async -> Void = { _ in }
+  ) async throws -> CapturedFrame {
+    let receiver = OneShotFrameReceiver()
+    let service = CaptureService { frame in
+      await receiver.record(frame)
+    } onFrameDropped: { displayId in
+      await onFrameDropped(displayId)
+    }
+
+    try await service.start(
+      targetFps: targetFps,
+      captureAllDisplays: captureAllDisplays,
+      selectedDisplayIds: selectedDisplayIds
+    )
+
+    let waitTask = Task {
+      try await receiver.wait()
+    }
+    let timeoutTask = Task {
+      do {
+        try await Task.sleep(nanoseconds: UInt64(max(0.5, timeoutSeconds) * 1_000_000_000))
+        await receiver.fail(CaptureOneShotError.timedOut)
+      } catch {
+        await receiver.fail(error)
+      }
+    }
+
+    do {
+      let frame = try await waitTask.value
+      timeoutTask.cancel()
+      await service.stop()
+      return frame
+    } catch {
+      timeoutTask.cancel()
+      await service.stop()
+      throw error
+    }
+  }
+
   private static func streamConfiguration(
     display: SCDisplay,
     targetFps: Double
@@ -173,6 +228,31 @@ actor CaptureService: NSObject {
     let boundsWidth = CGDisplayBounds(displayId).width
     guard boundsWidth > 0 else { return nil }
     return Double(pixelWidth) / Double(boundsWidth)
+  }
+}
+
+actor OneShotFrameReceiver {
+  private var frame: CapturedFrame?
+  private var continuation: CheckedContinuation<CapturedFrame, any Error>?
+
+  func record(_ frame: CapturedFrame) {
+    guard self.frame == nil else { return }
+    self.frame = frame
+    continuation?.resume(returning: frame)
+    continuation = nil
+  }
+
+  func wait() async throws -> CapturedFrame {
+    if let frame { return frame }
+    return try await withCheckedThrowingContinuation { continuation in
+      self.continuation = continuation
+    }
+  }
+
+  func fail(_ error: any Error) {
+    guard frame == nil else { return }
+    continuation?.resume(throwing: error)
+    continuation = nil
   }
 }
 

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -81,6 +81,12 @@ struct AgentConfig: Codable, Sendable {
   var adaptiveOcrBacklogBytes: Int64
   var ocrDiffSamplerEnabled: Bool
   var ocrDiffSimilarityThreshold: Double
+  var eventCaptureEnabled: Bool
+  var eventCapturePollSeconds: Double
+  var eventCaptureDebounceSeconds: Double
+  var eventCaptureMinGapSeconds: Double
+  var eventCaptureIdleFallbackSeconds: Double
+  var eventCaptureTimeoutSeconds: Double
   var sparseFrameStorageRoot: String?
   var sparseFrameRetentionHours: Double
   var sparseFrameIncludeOcrText: Bool
@@ -119,6 +125,12 @@ struct AgentConfig: Codable, Sendable {
     case adaptiveOcrBacklogBytes
     case ocrDiffSamplerEnabled
     case ocrDiffSimilarityThreshold
+    case eventCaptureEnabled
+    case eventCapturePollSeconds
+    case eventCaptureDebounceSeconds
+    case eventCaptureMinGapSeconds
+    case eventCaptureIdleFallbackSeconds
+    case eventCaptureTimeoutSeconds
     case sparseFrameStorageRoot
     case sparseFrameRetentionHours
     case sparseFrameIncludeOcrText
@@ -157,6 +169,12 @@ struct AgentConfig: Codable, Sendable {
     adaptiveOcrBacklogBytes: Int64 = 64 * 1024 * 1024,
     ocrDiffSamplerEnabled: Bool = false,
     ocrDiffSimilarityThreshold: Double = 0.92,
+    eventCaptureEnabled: Bool = false,
+    eventCapturePollSeconds: Double = 0.5,
+    eventCaptureDebounceSeconds: Double = 0.25,
+    eventCaptureMinGapSeconds: Double = 1,
+    eventCaptureIdleFallbackSeconds: Double = 30,
+    eventCaptureTimeoutSeconds: Double = 5,
     sparseFrameStorageRoot: String? = nil,
     sparseFrameRetentionHours: Double = 6,
     sparseFrameIncludeOcrText: Bool = false,
@@ -193,6 +211,12 @@ struct AgentConfig: Codable, Sendable {
     self.adaptiveOcrBacklogBytes = adaptiveOcrBacklogBytes
     self.ocrDiffSamplerEnabled = ocrDiffSamplerEnabled
     self.ocrDiffSimilarityThreshold = ocrDiffSimilarityThreshold
+    self.eventCaptureEnabled = eventCaptureEnabled
+    self.eventCapturePollSeconds = eventCapturePollSeconds
+    self.eventCaptureDebounceSeconds = eventCaptureDebounceSeconds
+    self.eventCaptureMinGapSeconds = eventCaptureMinGapSeconds
+    self.eventCaptureIdleFallbackSeconds = eventCaptureIdleFallbackSeconds
+    self.eventCaptureTimeoutSeconds = eventCaptureTimeoutSeconds
     self.sparseFrameStorageRoot = sparseFrameStorageRoot
     self.sparseFrameRetentionHours = sparseFrameRetentionHours
     self.sparseFrameIncludeOcrText = sparseFrameIncludeOcrText
@@ -311,6 +335,18 @@ struct AgentConfig: Codable, Sendable {
       try container.decodeIfPresent(Bool.self, forKey: .ocrDiffSamplerEnabled) ?? false
     ocrDiffSimilarityThreshold =
       try container.decodeIfPresent(Double.self, forKey: .ocrDiffSimilarityThreshold) ?? 0.92
+    eventCaptureEnabled =
+      try container.decodeIfPresent(Bool.self, forKey: .eventCaptureEnabled) ?? false
+    eventCapturePollSeconds =
+      try container.decodeIfPresent(Double.self, forKey: .eventCapturePollSeconds) ?? 0.5
+    eventCaptureDebounceSeconds =
+      try container.decodeIfPresent(Double.self, forKey: .eventCaptureDebounceSeconds) ?? 0.25
+    eventCaptureMinGapSeconds =
+      try container.decodeIfPresent(Double.self, forKey: .eventCaptureMinGapSeconds) ?? 1
+    eventCaptureIdleFallbackSeconds =
+      try container.decodeIfPresent(Double.self, forKey: .eventCaptureIdleFallbackSeconds) ?? 30
+    eventCaptureTimeoutSeconds =
+      try container.decodeIfPresent(Double.self, forKey: .eventCaptureTimeoutSeconds) ?? 5
     sparseFrameStorageRoot = try container.decodeIfPresent(
       String.self, forKey: .sparseFrameStorageRoot)
     sparseFrameRetentionHours =
@@ -360,6 +396,12 @@ struct AgentConfig: Codable, Sendable {
     try container.encode(adaptiveOcrBacklogBytes, forKey: .adaptiveOcrBacklogBytes)
     try container.encode(ocrDiffSamplerEnabled, forKey: .ocrDiffSamplerEnabled)
     try container.encode(ocrDiffSimilarityThreshold, forKey: .ocrDiffSimilarityThreshold)
+    try container.encode(eventCaptureEnabled, forKey: .eventCaptureEnabled)
+    try container.encode(eventCapturePollSeconds, forKey: .eventCapturePollSeconds)
+    try container.encode(eventCaptureDebounceSeconds, forKey: .eventCaptureDebounceSeconds)
+    try container.encode(eventCaptureMinGapSeconds, forKey: .eventCaptureMinGapSeconds)
+    try container.encode(eventCaptureIdleFallbackSeconds, forKey: .eventCaptureIdleFallbackSeconds)
+    try container.encode(eventCaptureTimeoutSeconds, forKey: .eventCaptureTimeoutSeconds)
     try container.encodeIfPresent(sparseFrameStorageRoot, forKey: .sparseFrameStorageRoot)
     try container.encode(sparseFrameRetentionHours, forKey: .sparseFrameRetentionHours)
     try container.encode(sparseFrameIncludeOcrText, forKey: .sparseFrameIncludeOcrText)
@@ -435,6 +477,12 @@ struct AgentConfig: Codable, Sendable {
       adaptiveOcrBacklogBytes: 64 * 1024 * 1024,
       ocrDiffSamplerEnabled: false,
       ocrDiffSimilarityThreshold: 0.92,
+      eventCaptureEnabled: false,
+      eventCapturePollSeconds: 0.5,
+      eventCaptureDebounceSeconds: 0.25,
+      eventCaptureMinGapSeconds: 1,
+      eventCaptureIdleFallbackSeconds: 30,
+      eventCaptureTimeoutSeconds: 5,
       sparseFrameStorageRoot: nil,
       sparseFrameRetentionHours: 6,
       sparseFrameIncludeOcrText: false,

--- a/Sources/agentd/DiagnosticCLI.swift
+++ b/Sources/agentd/DiagnosticCLI.swift
@@ -296,51 +296,17 @@ enum CaptureOnceDiagnostics {
           "display id \(displayId) is not available; run agentd list-displays")
       }
     }
-    let receiver = OneShotFrameReceiver()
-    let oneShotCapture = CaptureService { frame in
-      await receiver.record(frame)
-    }
-    try await oneShotCapture.start(
-      targetFps: 2,
-      captureAllDisplays: false,
-      selectedDisplayIds: displayId.map { [$0] } ?? []
-    )
-    defer {
-      Task { await oneShotCapture.stop() }
-    }
-    return try await withThrowingTaskGroup(of: CapturedFrame.self) { group in
-      group.addTask {
-        await receiver.wait()
-      }
-      group.addTask {
-        try await Task.sleep(nanoseconds: timeoutSeconds * 1_000_000_000)
-        throw DiagnosticCLIError.timeout
-      }
-      guard let frame = try await group.next() else {
-        throw DiagnosticCLIError.timeout
-      }
-      group.cancelAll()
-      await oneShotCapture.stop()
-      return frame
-    }
-  }
-}
-
-actor OneShotFrameReceiver {
-  private var frame: CapturedFrame?
-  private var continuation: CheckedContinuation<CapturedFrame, Never>?
-
-  func record(_ frame: CapturedFrame) {
-    guard self.frame == nil else { return }
-    self.frame = frame
-    continuation?.resume(returning: frame)
-    continuation = nil
-  }
-
-  func wait() async -> CapturedFrame {
-    if let frame { return frame }
-    return await withCheckedContinuation { continuation in
-      self.continuation = continuation
+    do {
+      return try await CaptureService.captureOneFrame(
+        targetFps: 2,
+        captureAllDisplays: false,
+        selectedDisplayIds: displayId.map { [$0] } ?? [],
+        timeoutSeconds: Double(timeoutSeconds)
+      )
+    } catch CaptureOneShotError.timedOut {
+      throw DiagnosticCLIError.timeout
+    } catch {
+      throw error
     }
   }
 }

--- a/Sources/agentd/Diagnostics.swift
+++ b/Sources/agentd/Diagnostics.swift
@@ -13,6 +13,7 @@ struct DiagnosticsSnapshot: Sendable {
   let controlError: String?
   let pendingStats: PendingFrameStats
   let ocrCacheStats: OCRCacheStats
+  let eventCaptureStats: EventCaptureStats
   let localBatchStats: LocalBatchStats
   let localBatches: [LocalBatchSummary]
   let captureDisplayStats: [CaptureDisplayStats]
@@ -43,6 +44,15 @@ enum DiagnosticsReport {
     )
     lines.append("- OCR cache misses: \(snapshot.ocrCacheStats.misses)")
     lines.append("- OCR cache evictions: \(snapshot.ocrCacheStats.evictions)")
+    lines.append("- Event capture enabled: \(snapshot.eventCaptureStats.enabled)")
+    lines.append("- Event capture starts: \(snapshot.eventCaptureStats.capturesStarted)")
+    lines.append("- Event capture successes: \(snapshot.eventCaptureStats.capturesSucceeded)")
+    lines.append("- Event capture failures: \(snapshot.eventCaptureStats.capturesFailed)")
+    lines.append(
+      "- Event capture debounced triggers: \(snapshot.eventCaptureStats.triggersDebounced)")
+    lines.append(
+      "- Event capture min-gap suppressions: \(snapshot.eventCaptureStats.triggersSuppressedByMinGap)"
+    )
     lines.append("- Queued local batches: \(snapshot.localBatchStats.fileCount)")
     lines.append("- Queued local bytes: \(snapshot.localBatchStats.bytes)")
     lines.append("- Last submit result: \(snapshot.lastSubmitResult ?? "unknown")")
@@ -65,6 +75,20 @@ enum DiagnosticsReport {
     lines.append("- Max frames per batch: \(snapshot.config.maxFramesPerBatch)")
     lines.append("- Max OCR text chars: \(snapshot.config.maxOcrTextChars)")
     lines.append("- Adaptive OCR min chars: \(snapshot.config.adaptiveOcrMinChars)")
+    lines.append("- Event capture poll seconds: \(snapshot.config.eventCapturePollSeconds)")
+    lines.append(
+      "- Event capture idle fallback seconds: \(snapshot.config.eventCaptureIdleFallbackSeconds)"
+    )
+    lines.append("")
+    lines.append("## Event Capture")
+    lines.append("")
+    lines.append("| Trigger | Count |")
+    lines.append("| --- | ---: |")
+    for trigger in EventCaptureTrigger.allCases {
+      lines.append(
+        "| \(trigger.rawValue) | \(snapshot.eventCaptureStats.triggerCounts[trigger] ?? 0) |"
+      )
+    }
     lines.append("")
     lines.append("## Capture Displays")
     lines.append("")

--- a/Sources/agentd/EventCaptureScheduler.swift
+++ b/Sources/agentd/EventCaptureScheduler.swift
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import CryptoKit
+import Foundation
+
+enum EventCaptureTrigger: String, Codable, CaseIterable, Sendable, Hashable {
+  case focusedWindow
+  case clipboard
+  case idleFallback
+  case click
+  case typingPause
+  case scrollStop
+  case manual
+}
+
+struct EventCaptureStats: Sendable, Equatable {
+  let enabled: Bool
+  let triggerCounts: [EventCaptureTrigger: Int]
+  let capturesStarted: Int
+  let capturesSucceeded: Int
+  let capturesFailed: Int
+  let triggersDebounced: Int
+  let triggersSuppressedByMinGap: Int
+
+  static let disabled = EventCaptureStats(
+    enabled: false,
+    triggerCounts: [:],
+    capturesStarted: 0,
+    capturesSucceeded: 0,
+    capturesFailed: 0,
+    triggersDebounced: 0,
+    triggersSuppressedByMinGap: 0
+  )
+}
+
+struct EventCaptureScheduler: Sendable {
+  private var config: AgentConfig
+  private var lastAcceptedAt: Date?
+  private var lastIdleFallbackAt: Date?
+  private var lastFocusedWindow: FocusedWindowSignature?
+  private var pendingFocusedWindow: PendingFocusedWindow?
+  private var lastClipboardChangeCount: Int?
+  private var triggerCounts: [EventCaptureTrigger: Int] = [:]
+  private var capturesStarted = 0
+  private var capturesSucceeded = 0
+  private var capturesFailed = 0
+  private var triggersDebounced = 0
+  private var triggersSuppressedByMinGap = 0
+
+  init(config: AgentConfig) {
+    self.config = config
+  }
+
+  mutating func updateConfig(_ next: AgentConfig) {
+    config = next
+    if !next.eventCaptureEnabled {
+      pendingFocusedWindow = nil
+    }
+  }
+
+  mutating func observe(
+    context: WindowContext?,
+    clipboardChangeCount: Int?,
+    now: Date
+  ) -> [EventCaptureTrigger] {
+    guard config.eventCaptureEnabled else { return [] }
+
+    var triggers: [EventCaptureTrigger] = []
+    if observeFocusedWindow(context: context, now: now) {
+      triggers.append(.focusedWindow)
+    }
+    if observeClipboard(changeCount: clipboardChangeCount) {
+      triggers.append(.clipboard)
+    }
+    if shouldRunIdleFallback(now: now) {
+      triggers.append(.idleFallback)
+    }
+    return triggers.compactMap { accept($0, now: now) }
+  }
+
+  mutating func request(_ trigger: EventCaptureTrigger, now: Date) -> EventCaptureTrigger? {
+    guard config.eventCaptureEnabled else { return nil }
+    return accept(trigger, now: now)
+  }
+
+  mutating func recordCaptureStarted() {
+    capturesStarted += 1
+  }
+
+  mutating func recordCaptureSucceeded() {
+    capturesSucceeded += 1
+  }
+
+  mutating func recordCaptureFailed() {
+    capturesFailed += 1
+  }
+
+  func stats() -> EventCaptureStats {
+    EventCaptureStats(
+      enabled: config.eventCaptureEnabled,
+      triggerCounts: triggerCounts,
+      capturesStarted: capturesStarted,
+      capturesSucceeded: capturesSucceeded,
+      capturesFailed: capturesFailed,
+      triggersDebounced: triggersDebounced,
+      triggersSuppressedByMinGap: triggersSuppressedByMinGap
+    )
+  }
+
+  private mutating func observeFocusedWindow(context: WindowContext?, now: Date) -> Bool {
+    guard let signature = context.map(FocusedWindowSignature.init) else { return false }
+    guard signature != lastFocusedWindow else {
+      pendingFocusedWindow = nil
+      return false
+    }
+
+    if pendingFocusedWindow?.signature != signature {
+      pendingFocusedWindow = PendingFocusedWindow(signature: signature, firstSeenAt: now)
+      triggersDebounced += 1
+      return false
+    }
+
+    guard let pendingFocusedWindow,
+      now.timeIntervalSince(pendingFocusedWindow.firstSeenAt) >= config.eventCaptureDebounceSeconds
+    else {
+      triggersDebounced += 1
+      return false
+    }
+
+    lastFocusedWindow = signature
+    self.pendingFocusedWindow = nil
+    return true
+  }
+
+  private mutating func observeClipboard(changeCount: Int?) -> Bool {
+    guard let changeCount else { return false }
+    defer { lastClipboardChangeCount = changeCount }
+    guard let lastClipboardChangeCount else { return false }
+    return changeCount != lastClipboardChangeCount
+  }
+
+  private mutating func shouldRunIdleFallback(now: Date) -> Bool {
+    guard config.eventCaptureIdleFallbackSeconds > 0 else { return false }
+    let reference = lastIdleFallbackAt ?? lastAcceptedAt
+    guard let reference else { return true }
+    return now.timeIntervalSince(reference) >= config.eventCaptureIdleFallbackSeconds
+  }
+
+  private mutating func accept(
+    _ trigger: EventCaptureTrigger,
+    now: Date
+  ) -> EventCaptureTrigger? {
+    if let lastAcceptedAt,
+      now.timeIntervalSince(lastAcceptedAt) < config.eventCaptureMinGapSeconds
+    {
+      triggersSuppressedByMinGap += 1
+      return nil
+    }
+    lastAcceptedAt = now
+    if trigger == .idleFallback {
+      lastIdleFallbackAt = now
+    }
+    triggerCounts[trigger, default: 0] += 1
+    return trigger
+  }
+}
+
+private struct PendingFocusedWindow: Sendable, Equatable {
+  let signature: FocusedWindowSignature
+  let firstSeenAt: Date
+}
+
+private struct FocusedWindowSignature: Sendable, Equatable {
+  let bundleId: String
+  let pid: pid_t
+  let titleHash: String
+  let documentHash: String
+
+  init(context: WindowContext) {
+    bundleId = context.bundleId
+    pid = context.pid
+    titleHash = Self.hash(context.windowTitle)
+    documentHash = Self.hash(context.documentPath ?? "")
+  }
+
+  private static func hash(_ value: String) -> String {
+    let digest = SHA256.hash(data: Data(value.utf8))
+    return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+  }
+}

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -24,13 +24,17 @@ final class AppController {
   private var pauseWindowTimer: Timer?
   private var captureRetryTimer: Timer?
   private var foregroundPrivacyTimer: Timer?
+  private var eventCaptureTimer: Timer?
   private var foregroundPrivacyPauseReason: String?
+  private var eventCaptureScheduler: EventCaptureScheduler
+  private var eventCaptureInFlight = false
   private var idleMode = false
 
   init() {
     let cfg = ConfigStore.load()
     self.policyBaseConfig = cfg
     self.config = cfg
+    self.eventCaptureScheduler = EventCaptureScheduler(config: cfg)
 
     let submitter: Submitter
     do {
@@ -156,6 +160,7 @@ final class AppController {
     ) { [weak self] _ in
       Task { @MainActor in await self?.pollIdleState() }
     }
+    scheduleEventCaptureTimer()
     if controlClient != nil {
       heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
         Task { @MainActor in await self?.sendHeartbeat() }
@@ -190,6 +195,7 @@ final class AppController {
   }
 
   private func pollIdleState() async {
+    guard !config.eventCaptureEnabled else { return }
     guard captureRunning else { return }
     let idleSeconds = CGEventSource.secondsSinceLastEventType(
       .combinedSessionState,
@@ -317,6 +323,7 @@ final class AppController {
       next.captureAllDisplays != config.captureAllDisplays
       || next.selectedDisplayIds != config.selectedDisplayIds
     config = next
+    eventCaptureScheduler.updateConfig(next)
     await pipeline.updateConfig(next)
     if intervalChanged {
       scheduleFlushTimer()
@@ -326,7 +333,7 @@ final class AppController {
       captureRunning = false
       idleMode = false
     }
-    if captureRunning {
+    if captureRunning, !config.eventCaptureEnabled {
       await capture.updateFps(idleMode ? config.idleFps : config.captureFps)
     }
     await pollForegroundPrivacyState()
@@ -339,10 +346,21 @@ final class AppController {
     if shouldPause, captureRunning {
       captureRetryTimer?.invalidate()
       captureRetryTimer = nil
-      await capture.stop()
+      if config.eventCaptureEnabled {
+        eventCaptureInFlight = false
+      } else {
+        await capture.stop()
+      }
       captureRunning = false
       idleMode = false
     } else if !shouldPause, !captureRunning {
+      if config.eventCaptureEnabled {
+        captureRunning = true
+        scheduleEventCaptureTimer()
+        schedulePauseWindowTimer()
+        updateMenuStatus()
+        return
+      }
       do {
         try await capture.start(
           targetFps: config.captureFps,
@@ -363,6 +381,7 @@ final class AppController {
   }
 
   private func scheduleCaptureRetry() {
+    guard !config.eventCaptureEnabled else { return }
     guard captureRetryTimer == nil else { return }
     captureRetryTimer = Timer.scheduledTimer(withTimeInterval: 15, repeats: false) {
       [weak self] _ in
@@ -421,6 +440,7 @@ final class AppController {
       controlError: controlState.lastError,
       pendingStats: pending,
       ocrCacheStats: ocrCacheStats,
+      eventCaptureStats: eventCaptureScheduler.stats(),
       localBatchStats: localStats,
       localBatches: localBatches,
       captureDisplayStats: captureDisplayStats,
@@ -455,11 +475,64 @@ final class AppController {
     }
   }
 
+  private func scheduleEventCaptureTimer() {
+    eventCaptureTimer?.invalidate()
+    guard config.eventCaptureEnabled else {
+      eventCaptureTimer = nil
+      return
+    }
+    eventCaptureTimer = Timer.scheduledTimer(
+      withTimeInterval: max(0.1, config.eventCapturePollSeconds),
+      repeats: true
+    ) { [weak self] _ in
+      Task { @MainActor in await self?.pollEventCaptureTriggers() }
+    }
+  }
+
+  private func pollEventCaptureTriggers() async {
+    guard captureRunning, config.eventCaptureEnabled, !effectivePauseState().paused else { return }
+    let triggers = eventCaptureScheduler.observe(
+      context: WindowContextProbe.current(),
+      clipboardChangeCount: NSPasteboard.general.changeCount,
+      now: Date()
+    )
+    guard let trigger = triggers.first else { return }
+    await captureEvent(trigger: trigger)
+  }
+
+  private func captureEvent(trigger: EventCaptureTrigger) async {
+    guard !eventCaptureInFlight else { return }
+    eventCaptureInFlight = true
+    eventCaptureScheduler.recordCaptureStarted()
+    do {
+      let frame = try await CaptureService.captureOneFrame(
+        targetFps: max(1, config.captureFps),
+        captureAllDisplays: config.captureAllDisplays,
+        selectedDisplayIds: config.selectedDisplayIds,
+        timeoutSeconds: config.eventCaptureTimeoutSeconds,
+        onFrameDropped: { [pipeline] _ in await pipeline.recordBackpressureDrop() }
+      )
+      let context = WindowContextProbe.current()
+      await pipeline.consume(frame, context: context)
+      eventCaptureScheduler.recordCaptureSucceeded()
+      Log.capture.info("event capture succeeded trigger=\(trigger.rawValue, privacy: .public)")
+    } catch {
+      eventCaptureScheduler.recordCaptureFailed()
+      Log.capture.error(
+        "event capture failed trigger=\(trigger.rawValue, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+      )
+    }
+    eventCaptureInFlight = false
+    updateMenuStatus()
+  }
+
   private func updateMenuStatus() {
     let detail: String
     let pauseState = effectivePauseState()
     if pauseState.paused {
       detail = pauseState.detail
+    } else if captureRunning, config.eventCaptureEnabled {
+      detail = controlState.registered ? "event capture armed, registered" : "event capture armed"
     } else if captureRunning {
       detail = controlState.registered ? "capturing, registered" : "capturing"
     } else if let error = controlState.lastError {

--- a/Tests/agentdTests/DiagnosticsTests.swift
+++ b/Tests/agentdTests/DiagnosticsTests.swift
@@ -37,6 +37,15 @@ final class DiagnosticsTests: XCTestCase {
       controlError: "none",
       pendingStats: PendingFrameStats(frameCount: 2, estimatedBytes: 4096),
       ocrCacheStats: OCRCacheStats(entries: 3, hits: 7, misses: 1, evictions: 2),
+      eventCaptureStats: EventCaptureStats(
+        enabled: true,
+        triggerCounts: [.focusedWindow: 2, .idleFallback: 1],
+        capturesStarted: 3,
+        capturesSucceeded: 2,
+        capturesFailed: 1,
+        triggersDebounced: 4,
+        triggersSuppressedByMinGap: 1
+      ),
       localBatchStats: LocalBatchStats(fileCount: 1, bytes: 1234),
       localBatches: [
         LocalBatchSummary(
@@ -68,6 +77,9 @@ final class DiagnosticsTests: XCTestCase {
     XCTAssertTrue(report.contains("OCR cache entries: 3"))
     XCTAssertTrue(report.contains("OCR cache hit rate: 0.88"))
     XCTAssertTrue(report.contains("OCR cache evictions: 2"))
+    XCTAssertTrue(report.contains("Event capture enabled: true"))
+    XCTAssertTrue(report.contains("Event capture successes: 2"))
+    XCTAssertTrue(report.contains("| focusedWindow | 2 |"))
     XCTAssertTrue(report.contains("| batch_1 |"))
     XCTAssertTrue(
       report.contains("https://chronicle.example.com/chronicle.v1.ChronicleService/SubmitBatch"))

--- a/Tests/agentdTests/EventCaptureSchedulerTests.swift
+++ b/Tests/agentdTests/EventCaptureSchedulerTests.swift
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import XCTest
+
+@testable import agentd
+
+final class EventCaptureSchedulerTests: XCTestCase {
+  func testFocusedWindowTriggerWaitsForDebounce() {
+    var scheduler = EventCaptureScheduler(config: Self.config())
+    let start = Date(timeIntervalSince1970: 100)
+
+    XCTAssertEqual(
+      scheduler.observe(
+        context: Self.context(windowTitle: "A"), clipboardChangeCount: 1, now: start),
+      []
+    )
+    XCTAssertEqual(
+      scheduler.observe(
+        context: Self.context(windowTitle: "A"),
+        clipboardChangeCount: 1,
+        now: start.addingTimeInterval(0.1)
+      ),
+      []
+    )
+    XCTAssertEqual(
+      scheduler.observe(
+        context: Self.context(windowTitle: "A"),
+        clipboardChangeCount: 1,
+        now: start.addingTimeInterval(0.3)
+      ),
+      [.focusedWindow]
+    )
+
+    let stats = scheduler.stats()
+    XCTAssertEqual(stats.triggerCounts[.focusedWindow], 1)
+    XCTAssertEqual(stats.triggersDebounced, 2)
+  }
+
+  func testMinGapSuppressesRapidTriggers() {
+    var scheduler = EventCaptureScheduler(config: Self.config())
+    let start = Date(timeIntervalSince1970: 100)
+
+    XCTAssertEqual(
+      scheduler.observe(
+        context: Self.context(windowTitle: "A"),
+        clipboardChangeCount: 1,
+        now: start.addingTimeInterval(0.3)
+      ),
+      []
+    )
+    XCTAssertEqual(
+      scheduler.observe(
+        context: Self.context(windowTitle: "A"),
+        clipboardChangeCount: 1,
+        now: start.addingTimeInterval(0.6)
+      ),
+      [.focusedWindow]
+    )
+    XCTAssertEqual(
+      scheduler.observe(
+        context: Self.context(windowTitle: "A"),
+        clipboardChangeCount: 2,
+        now: start.addingTimeInterval(0.7)
+      ),
+      []
+    )
+
+    XCTAssertEqual(scheduler.stats().triggersSuppressedByMinGap, 1)
+  }
+
+  func testIdleFallbackRunsAfterConfiguredGap() {
+    var cfg = Self.config()
+    cfg.eventCaptureIdleFallbackSeconds = 5
+    cfg.eventCaptureMinGapSeconds = 0
+    var scheduler = EventCaptureScheduler(config: cfg)
+    let start = Date(timeIntervalSince1970: 100)
+
+    XCTAssertEqual(
+      scheduler.observe(context: nil, clipboardChangeCount: 1, now: start),
+      [.idleFallback]
+    )
+    XCTAssertEqual(
+      scheduler.observe(context: nil, clipboardChangeCount: 1, now: start.addingTimeInterval(4)),
+      []
+    )
+    XCTAssertEqual(
+      scheduler.observe(context: nil, clipboardChangeCount: 1, now: start.addingTimeInterval(5)),
+      [.idleFallback]
+    )
+  }
+
+  func testDisabledSchedulerIgnoresSignals() {
+    var cfg = Self.config()
+    cfg.eventCaptureEnabled = false
+    var scheduler = EventCaptureScheduler(config: cfg)
+
+    XCTAssertEqual(
+      scheduler.observe(
+        context: Self.context(windowTitle: "A"),
+        clipboardChangeCount: 2,
+        now: Date(timeIntervalSince1970: 1)
+      ),
+      []
+    )
+    XCTAssertFalse(scheduler.stats().enabled)
+  }
+
+  private static func config() -> AgentConfig {
+    AgentConfig(
+      deviceId: "device_1",
+      organizationId: "org_1",
+      endpoint: URL(string: "http://127.0.0.1:8787/chronicle.v1.ChronicleService/SubmitBatch")!,
+      allowedBundleIds: AgentConfig.defaultAllowedBundleIds,
+      deniedBundleIds: AgentConfig.defaultDeniedBundleIds,
+      deniedPathPrefixes: AgentConfig.defaultDeniedPathPrefixes,
+      pauseWindowTitlePatterns: AgentConfig.defaultPauseWindowPatterns,
+      captureFps: 1,
+      idleFps: 0.2,
+      batchIntervalSeconds: 30,
+      maxFramesPerBatch: 24,
+      eventCaptureEnabled: true,
+      eventCaptureDebounceSeconds: 0.25,
+      eventCaptureMinGapSeconds: 1,
+      eventCaptureIdleFallbackSeconds: 0,
+      localOnly: true
+    )
+  }
+
+  private static func context(windowTitle: String) -> WindowContext {
+    WindowContext(
+      bundleId: "com.test.App",
+      appName: "Test",
+      windowTitle: windowTitle,
+      documentPath: nil,
+      pid: 123,
+      timestamp: Date()
+    )
+  }
+}

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -13,6 +13,8 @@ The report includes:
   policy source;
 - in-memory frame pressure and queued local batch count/bytes;
 - OCR cache entry, hit-rate, miss, and eviction counters;
+- event-capture trigger counts, debounce/min-gap suppressions, and one-shot
+  capture success/failure counts;
 - queued batch id, modification time, size, and encryption state.
 
 The report omits OCR text and raw queued payloads. It strips endpoint query


### PR DESCRIPTION
## Summary
- add an opt-in event capture scheduler with focused-window debounce, clipboard triggers, idle fallback, min-gap suppression, and trigger/capture diagnostics
- wire event mode into the app as one-shot capture requests instead of the steady SCStream cadence when `eventCaptureEnabled` is true
- share a cancellation-safe one-shot capture helper with the diagnostic CLI
- document the event capture config knobs and diagnostics counters

Part of #66.

## SOTA notes
- `gh` research found screenpipe/screenpipe moving toward event-driven capture and AX-first text extraction instead of blind polling:
  https://github.com/screenpipe/screenpipe/blob/d9ad0b8d1a50edcbee921c8e27cb4b01696092c6/docs/EVENT_DRIVEN_CAPTURE_SPEC.md

## Validation
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `git diff --check`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `scripts/package_app.sh`

## Notes
- `swift run agentd -- selftest` and direct `agentd -- list-displays` both hung locally in the ScreenCaptureKit/TCC diagnostic path during smoke, so I killed those processes and relied on the direct mock Chronicle self-test plus package smoke for this PR. The diagnostic CLI code path still gets unit coverage and now shares the same one-shot helper.
