### PR TITLE
feat: redact sparse frame text regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ local inspection of the shipped arm64 `codex_chronicle` helper bundled with
 - Optional event-triggered capture mode arms one-shot captures on focused-window
   changes, clipboard updates, and idle fallback ticks behind
   `eventCaptureEnabled`, with debounce/min-gap counters in diagnostics.
+- Optional sparse-frame visual redaction masks OCR text boxes in local JPEG
+  artifacts behind `sparseFrameVisualRedactionEnabled`; remote batch payloads are
+  unchanged.
 - Batches every 30s or 24 frames, whichever first.
 - Local-only mode persists batches under `~/.evalops/agentd/batches/` as
   `0o600` JSON by default and sweeps old or over-budget batches; HTTP mode
@@ -169,6 +172,7 @@ agentd reads and writes `~/.evalops/agentd/config.json`. Important defaults:
 - `sparseFrameStorageRoot: null`
 - `sparseFrameRetentionHours: 6`
 - `sparseFrameIncludeOcrText: false`
+- `sparseFrameVisualRedactionEnabled: false`
 - `batchIntervalSeconds: 30`
 - `maxFramesPerBatch: 24`
 - `maxOcrTextChars: 4096`
@@ -266,10 +270,11 @@ encrypted `.agentdbatch` batches.
 
 Diagnostics reports are written under `~/.evalops/agentd/diagnostics/` with
 `0o600` permissions. They summarize permissions, policy, queue pressure, local
-batches, OCR cache hit-rate counters, event-capture trigger counters, active
-display frame/drop counters, and last submit health without OCR text or raw
-payloads. The same binary also supports `list-displays`, `capture-once`, and
-`selftest` diagnostic subcommands; see `docs/diagnostics.md`.
+batches, OCR cache hit-rate counters, event-capture trigger counters,
+sparse-frame visual-redaction state, active display frame/drop counters, and
+last submit health without OCR text or raw payloads. The same binary also
+supports `list-displays`, `capture-once`, and `selftest` diagnostic subcommands;
+see `docs/diagnostics.md`.
 
 For Chronicle-style local introspection, set `sparseFrameStorageRoot` to a
 directory such as `~/.evalops/agentd/sparse-frames`. agentd then writes

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -90,6 +90,7 @@ struct AgentConfig: Codable, Sendable {
   var sparseFrameStorageRoot: String?
   var sparseFrameRetentionHours: Double
   var sparseFrameIncludeOcrText: Bool
+  var sparseFrameVisualRedactionEnabled: Bool
   var localOnly: Bool
   var encryptLocalBatches: Bool
   var auth: AuthMode
@@ -134,6 +135,7 @@ struct AgentConfig: Codable, Sendable {
     case sparseFrameStorageRoot
     case sparseFrameRetentionHours
     case sparseFrameIncludeOcrText
+    case sparseFrameVisualRedactionEnabled
     case localOnly
     case encryptLocalBatches
     case auth
@@ -178,6 +180,7 @@ struct AgentConfig: Codable, Sendable {
     sparseFrameStorageRoot: String? = nil,
     sparseFrameRetentionHours: Double = 6,
     sparseFrameIncludeOcrText: Bool = false,
+    sparseFrameVisualRedactionEnabled: Bool = false,
     localOnly: Bool,
     encryptLocalBatches: Bool? = nil,
     auth: AuthMode = .none,
@@ -220,6 +223,7 @@ struct AgentConfig: Codable, Sendable {
     self.sparseFrameStorageRoot = sparseFrameStorageRoot
     self.sparseFrameRetentionHours = sparseFrameRetentionHours
     self.sparseFrameIncludeOcrText = sparseFrameIncludeOcrText
+    self.sparseFrameVisualRedactionEnabled = sparseFrameVisualRedactionEnabled
     self.localOnly = localOnly
     self.encryptLocalBatches = encryptLocalBatches ?? (!localOnly || secretBroker != nil)
     self.auth = auth
@@ -353,6 +357,8 @@ struct AgentConfig: Codable, Sendable {
       try container.decodeIfPresent(Double.self, forKey: .sparseFrameRetentionHours) ?? 6
     sparseFrameIncludeOcrText =
       try container.decodeIfPresent(Bool.self, forKey: .sparseFrameIncludeOcrText) ?? false
+    sparseFrameVisualRedactionEnabled =
+      try container.decodeIfPresent(Bool.self, forKey: .sparseFrameVisualRedactionEnabled) ?? false
     localOnly = try container.decodeIfPresent(Bool.self, forKey: .localOnly) ?? true
     auth = try container.decodeIfPresent(AuthMode.self, forKey: .auth) ?? .none
     secretBroker = try container.decodeIfPresent(SecretBrokerConfig.self, forKey: .secretBroker)
@@ -405,6 +411,8 @@ struct AgentConfig: Codable, Sendable {
     try container.encodeIfPresent(sparseFrameStorageRoot, forKey: .sparseFrameStorageRoot)
     try container.encode(sparseFrameRetentionHours, forKey: .sparseFrameRetentionHours)
     try container.encode(sparseFrameIncludeOcrText, forKey: .sparseFrameIncludeOcrText)
+    try container.encode(
+      sparseFrameVisualRedactionEnabled, forKey: .sparseFrameVisualRedactionEnabled)
     try container.encode(localOnly, forKey: .localOnly)
     try container.encode(encryptLocalBatches, forKey: .encryptLocalBatches)
     try container.encode(auth, forKey: .auth)
@@ -486,6 +494,7 @@ struct AgentConfig: Codable, Sendable {
       sparseFrameStorageRoot: nil,
       sparseFrameRetentionHours: 6,
       sparseFrameIncludeOcrText: false,
+      sparseFrameVisualRedactionEnabled: false,
       localOnly: true,
       encryptLocalBatches: false,
       auth: .none,

--- a/Sources/agentd/Diagnostics.swift
+++ b/Sources/agentd/Diagnostics.swift
@@ -79,6 +79,9 @@ enum DiagnosticsReport {
     lines.append(
       "- Event capture idle fallback seconds: \(snapshot.config.eventCaptureIdleFallbackSeconds)"
     )
+    lines.append(
+      "- Sparse frame visual redaction: \(snapshot.config.sparseFrameVisualRedactionEnabled)"
+    )
     lines.append("")
     lines.append("## Event Capture")
     lines.append("")

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -19,6 +19,7 @@ struct ProcessedFrame: Sendable, Codable {
   let ocrText: String
   let ocrTextTruncated: Bool
   let ocrConfidence: Float
+  let ocrTextRegions: [OCRTextRegion]
   let widthPx: Int
   let heightPx: Int
   let bytesPng: Int
@@ -56,6 +57,7 @@ struct ProcessedFrame: Sendable, Codable {
     ocrText: String,
     ocrTextTruncated: Bool = false,
     ocrConfidence: Float,
+    ocrTextRegions: [OCRTextRegion] = [],
     widthPx: Int,
     heightPx: Int,
     bytesPng: Int,
@@ -73,6 +75,7 @@ struct ProcessedFrame: Sendable, Codable {
     self.ocrText = ocrText
     self.ocrTextTruncated = ocrTextTruncated
     self.ocrConfidence = ocrConfidence
+    self.ocrTextRegions = ocrTextRegions
     self.widthPx = widthPx
     self.heightPx = heightPx
     self.bytesPng = bytesPng
@@ -98,6 +101,7 @@ struct ProcessedFrame: Sendable, Codable {
     ocrText = try container.decode(String.self, forKey: .ocrText)
     ocrTextTruncated = try container.decodeIfPresent(Bool.self, forKey: .ocrTextTruncated) ?? false
     ocrConfidence = try container.decode(Float.self, forKey: .ocrConfidence)
+    ocrTextRegions = []
     widthPx = try container.decode(Int.self, forKey: .widthPx)
     heightPx = try container.decode(Int.self, forKey: .heightPx)
     if let value = try? container.decode(Int.self, forKey: .bytesPng) {
@@ -754,6 +758,7 @@ actor FramePipeline {
       ocrText: ocrText.value,
       ocrTextTruncated: ocrText.truncated,
       ocrConfidence: ocrResult.confidence,
+      ocrTextRegions: ocrResult.regions,
       widthPx: frame.cgImage.width,
       heightPx: frame.cgImage.height,
       bytesPng: estimatedBytes,
@@ -860,7 +865,8 @@ actor FramePipeline {
     return SparseFrameStoreOptions(
       root: root,
       retentionHours: config.sparseFrameRetentionHours,
-      includeOcrText: config.sparseFrameIncludeOcrText
+      includeOcrText: config.sparseFrameIncludeOcrText,
+      visualRedactionEnabled: config.sparseFrameVisualRedactionEnabled
     )
   }
 
@@ -868,7 +874,8 @@ actor FramePipeline {
     return SparseFrameStore(
       root: options.root,
       retentionHours: options.retentionHours,
-      includeOcrText: options.includeOcrText
+      includeOcrText: options.includeOcrText,
+      visualRedactionEnabled: options.visualRedactionEnabled
     )
   }
 }

--- a/Sources/agentd/SparseFrameStore.swift
+++ b/Sources/agentd/SparseFrameStore.swift
@@ -10,13 +10,20 @@ actor SparseFrameStore {
   private let root: URL
   private let retentionHours: Double
   private let includeOcrText: Bool
+  private let visualRedactionEnabled: Bool
   private var sessions: [UInt32: SparseFrameSession] = [:]
   private let jsonEncoder: JSONEncoder
 
-  init(root: URL, retentionHours: Double = 6, includeOcrText: Bool = false) {
+  init(
+    root: URL,
+    retentionHours: Double = 6,
+    includeOcrText: Bool = false,
+    visualRedactionEnabled: Bool = false
+  ) {
     self.root = root
     self.retentionHours = max(0, retentionHours)
     self.includeOcrText = includeOcrText
+    self.visualRedactionEnabled = visualRedactionEnabled
     let encoder = JSONEncoder()
     encoder.dateEncodingStrategy = .iso8601
     encoder.outputFormatting = [.sortedKeys]
@@ -26,9 +33,13 @@ actor SparseFrameStore {
   func record(image: CGImage, processed: ProcessedFrame) throws {
     try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
     var session = try sessions[processed.displayId] ?? createSession(for: processed)
+    let storageImage =
+      visualRedactionEnabled
+      ? SparseFrameVisualRedactor.mask(image: image, regions: processed.ocrTextRegions)
+      : image
 
     let latestURL = session.latestURL
-    try writeJPEG(image, to: latestURL)
+    try writeJPEG(storageImage, to: latestURL)
 
     let normalizedText = normalize(processed.ocrText)
     let textHash = sha256Hex(normalizedText)
@@ -43,7 +54,7 @@ actor SparseFrameStore {
       session.lastHistoricalFrameAt = processed.capturedAt
       let frameURL = session.directory.appendingPathComponent(
         "frame-\(frameIndex)-\(minuteBucket(processed.capturedAt))Z.jpg")
-      try writeJPEG(image, to: frameURL)
+      try writeJPEG(storageImage, to: frameURL)
 
       if materialTextChange {
         session.lastOcrHash = textHash
@@ -86,7 +97,8 @@ actor SparseFrameStore {
       widthPx: processed.widthPx,
       heightPx: processed.heightPx,
       retentionHours: retentionHours,
-      includesRawOcrText: includeOcrText
+      includesRawOcrText: includeOcrText,
+      visualRedactionEnabled: visualRedactionEnabled
     )
     try jsonEncoder.encode(metadata).write(to: metadataURL, options: .atomic)
     try? FileManager.default.setAttributes(
@@ -175,6 +187,60 @@ struct SparseFrameStoreOptions: Sendable, Equatable {
   let root: URL
   let retentionHours: Double
   let includeOcrText: Bool
+  let visualRedactionEnabled: Bool
+}
+
+enum SparseFrameVisualRedactor {
+  static func mask(
+    image: CGImage,
+    regions: [OCRTextRegion],
+    paddingPixels: CGFloat = 2
+  ) -> CGImage {
+    guard !regions.isEmpty else { return image }
+    let width = image.width
+    let height = image.height
+    guard
+      let context = CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    else {
+      return image
+    }
+    let bounds = CGRect(x: 0, y: 0, width: width, height: height)
+    context.draw(image, in: bounds)
+    context.setFillColor(CGColor(gray: 0, alpha: 1))
+    for region in regions {
+      let rect = pixelRect(
+        normalized: region.normalizedBoundingBox,
+        width: width,
+        height: height
+      )
+      .insetBy(dx: -paddingPixels, dy: -paddingPixels)
+      .intersection(bounds)
+      guard !rect.isNull, !rect.isEmpty else { continue }
+      context.fill(rect)
+    }
+    return context.makeImage() ?? image
+  }
+
+  static func pixelRect(normalized: CGRect, width: Int, height: Int) -> CGRect {
+    let imageWidth = CGFloat(width)
+    let imageHeight = CGFloat(height)
+    let x = normalized.minX * imageWidth
+    let y = (1 - normalized.maxY) * imageHeight
+    return CGRect(
+      x: x,
+      y: y,
+      width: normalized.width * imageWidth,
+      height: normalized.height * imageHeight
+    )
+  }
 }
 
 private struct SparseFrameSession: Sendable {
@@ -195,6 +261,7 @@ private struct SparseFrameSegmentMetadata: Codable {
   let heightPx: Int
   let retentionHours: Double
   let includesRawOcrText: Bool
+  let visualRedactionEnabled: Bool
 }
 
 private struct SparseFrameOCRRecord: Codable {

--- a/Sources/agentd/VisionOCR.swift
+++ b/Sources/agentd/VisionOCR.swift
@@ -4,10 +4,27 @@ import CoreGraphics
 import Foundation
 import Vision
 
+struct OCRTextRegion: Sendable, Equatable {
+  let normalizedBoundingBox: CGRect
+}
+
 struct OCRResult: Sendable {
   let text: String
   let confidence: Float
   let language: String?
+  let regions: [OCRTextRegion]
+
+  init(
+    text: String,
+    confidence: Float,
+    language: String?,
+    regions: [OCRTextRegion] = []
+  ) {
+    self.text = text
+    self.confidence = confidence
+    self.language = language
+    self.regions = regions
+  }
 }
 
 actor VisionOCR: OCRRecognizing {
@@ -20,11 +37,13 @@ actor VisionOCR: OCRRecognizing {
         }
         let observations = (req.results as? [VNRecognizedTextObservation]) ?? []
         var lines: [String] = []
+        var regions: [OCRTextRegion] = []
         var confSum: Float = 0
         var confN: Int = 0
         for obs in observations {
           guard let candidate = obs.topCandidates(1).first else { continue }
           lines.append(candidate.string)
+          regions.append(OCRTextRegion(normalizedBoundingBox: obs.boundingBox))
           confSum += candidate.confidence
           confN += 1
         }
@@ -36,7 +55,8 @@ actor VisionOCR: OCRRecognizing {
           returning: OCRResult(
             text: lines.joined(separator: "\n"),
             confidence: conf,
-            language: detectedLang
+            language: detectedLang,
+            regions: regions
           ))
       }
       request.recognitionLevel = .accurate

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -411,6 +411,61 @@ final class PipelineTests: XCTestCase {
     XCTAssertTrue(ocrText.contains("debuggable text"))
   }
 
+  func testSparseFrameVisualRedactorMasksNormalizedVisionBox() {
+    let image = Self.image(bits: UInt64.max)
+    let redacted = SparseFrameVisualRedactor.mask(
+      image: image,
+      regions: [
+        OCRTextRegion(normalizedBoundingBox: CGRect(x: 0.25, y: 0.25, width: 0.5, height: 0.5))
+      ],
+      paddingPixels: 0
+    )
+
+    let center = Self.pixel(redacted, x: 4, y: 4)
+    XCTAssertLessThan(center.red, 10)
+    XCTAssertLessThan(center.green, 10)
+    XCTAssertLessThan(center.blue, 10)
+
+    let corner = Self.pixel(redacted, x: 0, y: 0)
+    XCTAssertGreaterThan(corner.red, 240)
+    XCTAssertGreaterThan(corner.green, 240)
+    XCTAssertGreaterThan(corner.blue, 240)
+  }
+
+  func testSparseFrameStoreCanOptIntoVisualRedactionMetadata() async throws {
+    let root = try Self.temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    var cfg = Self.config()
+    cfg.sparseFrameStorageRoot = root.path
+    cfg.sparseFrameVisualRedactionEnabled = true
+
+    let recorder = BatchRecorder()
+    let pipeline = FramePipeline(
+      config: cfg,
+      ocr: StubOCR(
+        text: "visible work context",
+        regions: [
+          OCRTextRegion(
+            normalizedBoundingBox: CGRect(x: 0.25, y: 0.25, width: 0.5, height: 0.5))
+        ]
+      )
+    ) { batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(Self.frame(bits: UInt64.max), context: Self.context())
+
+    let metadataFile = try XCTUnwrap(
+      try FileManager.default.contentsOfDirectory(atPath: root.path).first {
+        $0.hasSuffix(".capture.json")
+      })
+    let metadata = try String(
+      contentsOf: root.appendingPathComponent(metadataFile),
+      encoding: .utf8
+    )
+    XCTAssertTrue(metadata.contains(#""visualRedactionEnabled":true"#))
+  }
+
   func testSparseFrameStoreKeepsSessionAcrossUnchangedConfigRefresh() async throws {
     let root = try Self.temporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }
@@ -647,6 +702,22 @@ final class PipelineTests: XCTestCase {
     return context.makeImage()!
   }
 
+  static func pixel(_ image: CGImage, x: Int, y: Int) -> (red: UInt8, green: UInt8, blue: UInt8) {
+    var pixel = [UInt8](repeating: 0, count: 4)
+    let context = CGContext(
+      data: &pixel,
+      width: 1,
+      height: 1,
+      bitsPerComponent: 8,
+      bytesPerRow: 4,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    )!
+    context.translateBy(x: -CGFloat(x), y: -CGFloat(y))
+    context.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
+    return (pixel[0], pixel[1], pixel[2])
+  }
+
   static func temporaryDirectory() throws -> URL {
     let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
@@ -680,14 +751,16 @@ actor BatchRecorder {
 struct StubOCR: OCRRecognizing {
   let text: String
   let confidence: Float
+  let regions: [OCRTextRegion]
 
-  init(text: String, confidence: Float = 0.9) {
+  init(text: String, confidence: Float = 0.9, regions: [OCRTextRegion] = []) {
     self.text = text
     self.confidence = confidence
+    self.regions = regions
   }
 
   func recognize(cgImage: CGImage) async throws -> OCRResult {
-    OCRResult(text: text, confidence: confidence, language: "en")
+    OCRResult(text: text, confidence: confidence, language: "en", regions: regions)
   }
 }
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -15,6 +15,7 @@ The report includes:
 - OCR cache entry, hit-rate, miss, and eviction counters;
 - event-capture trigger counts, debounce/min-gap suppressions, and one-shot
   capture success/failure counts;
+- sparse-frame visual-redaction enabled/disabled state;
 - queued batch id, modification time, size, and encryption state.
 
 The report omits OCR text and raw queued payloads. It strips endpoint query


### PR DESCRIPTION
## Summary
- carry Vision OCR bounding boxes in-memory without changing Chronicle batch JSON
- add opt-in sparse-frame visual redaction that masks OCR text regions before local JPEG writes
- persist visual-redaction state in sparse capture metadata and diagnostics/docs
- cover normalized Vision-box geometry and sparse metadata with synthetic tests

Closes the first implementation slice for #67.

## SOTA notes
- `gh` research found OpenAdapt's privacy tooling emphasizing screenshot visual redaction for local artifacts:
  https://github.com/OpenAdaptAI/OpenAdapt/blob/e4d4d0348d1a9ded2152ca24872c0aaee809e472/docs/packages/privacy.md

## Validation
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `git diff --check`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `scripts/package_app.sh`
