### PR TITLE
feat: add AX-first text and native event triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ local inspection of the shipped arm64 `codex_chronicle` helper bundled with
   display id, scale, and main-display metadata for multi-display diagnostics.
 - Reads `(bundleId, windowTitle, documentPath)` per frame via the Accessibility
   API and `NSWorkspace`.
-- Runs Apple Vision OCR on-device.
+- Extracts focused-window Accessibility text first when available, then falls
+  back to Apple Vision OCR on-device for image-heavy or AX-empty frames.
 - Drops near-duplicate frames via a 64-bit pHash ring buffer (Hamming ≤ 5).
 - Fail-closed `SecretScrubber` against AWS / GCP / SSH / JWT / GitHub classic
   and fine-grained tokens / Google API keys / npm / SendGrid / DigitalOcean /
@@ -62,8 +63,9 @@ local inspection of the shipped arm64 `codex_chronicle` helper bundled with
   observations while still running SecretScrubber on every frame before
   persistence.
 - Optional event-triggered capture mode arms one-shot captures on focused-window
-  changes, clipboard updates, and idle fallback ticks behind
-  `eventCaptureEnabled`, with debounce/min-gap counters in diagnostics.
+  changes, clicks, typing pauses, scroll stops, clipboard updates, and idle
+  fallback ticks behind `eventCaptureEnabled`, with debounce/min-gap counters in
+  diagnostics.
 - Optional sparse-frame visual redaction masks OCR text boxes in local JPEG
   artifacts behind `sparseFrameVisualRedactionEnabled`; remote batch payloads are
   unchanged.
@@ -270,11 +272,11 @@ encrypted `.agentdbatch` batches.
 
 Diagnostics reports are written under `~/.evalops/agentd/diagnostics/` with
 `0o600` permissions. They summarize permissions, policy, queue pressure, local
-batches, OCR cache hit-rate counters, event-capture trigger counters,
-sparse-frame visual-redaction state, active display frame/drop counters, and
-last submit health without OCR text or raw payloads. The same binary also
-supports `list-displays`, `capture-once`, and `selftest` diagnostic subcommands;
-see `docs/diagnostics.md`.
+batches, OCR cache hit-rate counters, AX-vs-OCR text-source counters,
+event-capture trigger counters, sparse-frame visual-redaction state, active
+display frame/drop counters, and last submit health without OCR text or raw
+payloads. The same binary also supports `list-displays`, `capture-once`, and
+`selftest` diagnostic subcommands; see `docs/diagnostics.md`.
 
 For Chronicle-style local introspection, set `sparseFrameStorageRoot` to a
 directory such as `~/.evalops/agentd/sparse-frames`. agentd then writes

--- a/Sources/agentd/AccessibilityTextExtractor.swift
+++ b/Sources/agentd/AccessibilityTextExtractor.swift
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+struct AccessibilityTextResult: Sendable, Equatable {
+  let text: String
+  let nodesVisited: Int
+  let truncated: Bool
+}
+
+enum AccessibilityTextExtractor {
+  @MainActor
+  static func current(
+    context: WindowContext?,
+    maxChars: Int = 8192,
+    maxNodes: Int = 160,
+    maxDepth: Int = 6
+  ) -> AccessibilityTextResult? {
+    guard AXIsProcessTrusted(), maxChars > 0, maxNodes > 0, maxDepth >= 0 else { return nil }
+    let pid: pid_t
+    if let context {
+      pid = context.pid
+    } else if let app = NSWorkspace.shared.frontmostApplication {
+      pid = app.processIdentifier
+    } else {
+      return nil
+    }
+
+    let appElement = AXUIElementCreateApplication(pid)
+    guard let focused = copyElement(appElement, attribute: kAXFocusedWindowAttribute) else {
+      return nil
+    }
+
+    return extract(
+      root: focused,
+      maxChars: maxChars,
+      maxNodes: maxNodes,
+      maxDepth: maxDepth
+    )
+  }
+
+  static func extract(
+    root: AXUIElement,
+    maxChars: Int = 8192,
+    maxNodes: Int = 160,
+    maxDepth: Int = 6
+  ) -> AccessibilityTextResult {
+    var stack: [(AXUIElement, Int)] = [(root, 0)]
+    var textParts: [String] = []
+    var seenText = Set<String>()
+    var nodesVisited = 0
+    var remainingChars = max(0, maxChars)
+    var truncated = false
+
+    while let (element, depth) = stack.popLast(), nodesVisited < maxNodes, remainingChars > 0 {
+      nodesVisited += 1
+      for value in textValues(element) {
+        let normalized = normalize(value)
+        guard !normalized.isEmpty, seenText.insert(normalized).inserted else { continue }
+        if normalized.count > remainingChars {
+          textParts.append(String(normalized.prefix(remainingChars)))
+          remainingChars = 0
+          truncated = true
+          break
+        }
+        textParts.append(normalized)
+        remainingChars -= normalized.count
+      }
+
+      guard depth < maxDepth, remainingChars > 0 else { continue }
+      var children = childElements(element, attribute: kAXChildrenAttribute)
+      children += childElements(element, attribute: kAXVisibleChildrenAttribute)
+      for child in children.reversed() {
+        stack.append((child, depth + 1))
+      }
+    }
+
+    if nodesVisited >= maxNodes, !stack.isEmpty {
+      truncated = true
+    }
+
+    let text = normalize(textParts.joined(separator: "\n"))
+    guard !text.isEmpty else {
+      return AccessibilityTextResult(text: "", nodesVisited: nodesVisited, truncated: truncated)
+    }
+    return AccessibilityTextResult(text: text, nodesVisited: nodesVisited, truncated: truncated)
+  }
+
+  static func normalize(_ value: String) -> String {
+    value
+      .components(separatedBy: .whitespacesAndNewlines)
+      .filter { !$0.isEmpty }
+      .joined(separator: " ")
+  }
+
+  private static func textValues(_ element: AXUIElement) -> [String] {
+    [
+      kAXSelectedTextAttribute,
+      kAXValueAttribute,
+      kAXTitleAttribute,
+      kAXDescriptionAttribute,
+      kAXHelpAttribute,
+    ]
+    .compactMap { copyString(element, attribute: $0) }
+  }
+
+  private static func childElements(_ element: AXUIElement, attribute: String) -> [AXUIElement] {
+    var raw: AnyObject?
+    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &raw) == .success,
+      let raw
+    else {
+      return []
+    }
+    if CFGetTypeID(raw) == AXUIElementGetTypeID() {
+      // swift-format-ignore
+      return [raw as! AXUIElement]
+    }
+    guard let array = raw as? [AnyObject] else { return [] }
+    return array.compactMap { value in
+      guard CFGetTypeID(value) == AXUIElementGetTypeID() else { return nil }
+      // swift-format-ignore
+      return (value as! AXUIElement)
+    }
+  }
+
+  private static func copyElement(_ element: AXUIElement, attribute: String) -> AXUIElement? {
+    var raw: AnyObject?
+    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &raw) == .success,
+      let raw,
+      CFGetTypeID(raw) == AXUIElementGetTypeID()
+    else {
+      return nil
+    }
+    // swift-format-ignore
+    return (raw as! AXUIElement)
+  }
+
+  private static func copyString(_ element: AXUIElement, attribute: String) -> String? {
+    var raw: AnyObject?
+    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &raw) == .success,
+      let raw
+    else {
+      return nil
+    }
+    if let value = raw as? String {
+      return value
+    }
+    if let value = raw as? NSAttributedString {
+      return value.string
+    }
+    if let value = raw as? URL {
+      return value.absoluteString
+    }
+    return nil
+  }
+}

--- a/Sources/agentd/DiagnosticCLI.swift
+++ b/Sources/agentd/DiagnosticCLI.swift
@@ -264,14 +264,17 @@ enum CaptureOnceDiagnostics {
     }
     let frame = try await captureOneFrame(
       displayId: options.displayId, timeoutSeconds: 6)
+    let context = try await MainActor.run {
+      guard let context = WindowContextProbe.current() else {
+        throw DiagnosticCLIError.noWindowContext
+      }
+      return context
+    }
+    let axText = await MainActor.run { AccessibilityTextExtractor.current(context: context) }
     await pipeline.consume(
       frame,
-      context: try await MainActor.run {
-        guard let context = WindowContextProbe.current() else {
-          throw DiagnosticCLIError.noWindowContext
-        }
-        return context
-      }
+      context: context,
+      accessibilityText: axText
     )
     await pipeline.flush()
     let batches = await recorder.snapshot()

--- a/Sources/agentd/Diagnostics.swift
+++ b/Sources/agentd/Diagnostics.swift
@@ -13,6 +13,7 @@ struct DiagnosticsSnapshot: Sendable {
   let controlError: String?
   let pendingStats: PendingFrameStats
   let ocrCacheStats: OCRCacheStats
+  let textSourceStats: TextSourceStats
   let eventCaptureStats: EventCaptureStats
   let localBatchStats: LocalBatchStats
   let localBatches: [LocalBatchSummary]
@@ -44,6 +45,11 @@ enum DiagnosticsReport {
     )
     lines.append("- OCR cache misses: \(snapshot.ocrCacheStats.misses)")
     lines.append("- OCR cache evictions: \(snapshot.ocrCacheStats.evictions)")
+    for source in FrameTextSource.allCases {
+      lines.append(
+        "- Text source \(source.rawValue): \(snapshot.textSourceStats.counts[source] ?? 0)"
+      )
+    }
     lines.append("- Event capture enabled: \(snapshot.eventCaptureStats.enabled)")
     lines.append("- Event capture starts: \(snapshot.eventCaptureStats.capturesStarted)")
     lines.append("- Event capture successes: \(snapshot.eventCaptureStats.capturesSucceeded)")

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -8,6 +8,18 @@ protocol OCRRecognizing: Sendable {
   func recognize(cgImage: CGImage) async throws -> OCRResult
 }
 
+enum FrameTextSource: String, CaseIterable, Sendable, Hashable {
+  case accessibility
+  case visionOCR
+  case cachedOCR
+}
+
+struct TextSourceStats: Sendable, Equatable {
+  let counts: [FrameTextSource: Int]
+
+  static let empty = TextSourceStats(counts: [:])
+}
+
 struct ProcessedFrame: Sendable, Codable {
   let frameHash: String
   let perceptualHash: UInt64
@@ -666,7 +678,17 @@ actor FramePipeline {
     ocrCache.stats()
   }
 
-  func consume(_ frame: CapturedFrame, context: WindowContext?) async {
+  private var textSourceCounts: [FrameTextSource: Int] = [:]
+
+  func textSourceStats() -> TextSourceStats {
+    TextSourceStats(counts: textSourceCounts)
+  }
+
+  func consume(
+    _ frame: CapturedFrame,
+    context: WindowContext?,
+    accessibilityText: AccessibilityTextResult? = nil
+  ) async {
     guard let ctx = context else { return }
 
     let privacyDecision = privacyDecisionCache.decision(for: ctx, config: config)
@@ -693,22 +715,32 @@ actor FramePipeline {
     }
 
     let ocrResult: OCRResult
-    let ocrCacheKey = ImageContentHash.calculate(cgImage: frame.cgImage).map {
-      OCRCacheKey(context: ctx, imageHash: $0)
-    }
-    if let ocrCacheKey, let cached = ocrCache.result(for: ocrCacheKey) {
-      ocrResult = cached
+    let textSource: FrameTextSource
+    let axText = accessibilityText.map { AccessibilityTextExtractor.normalize($0.text) } ?? ""
+    if !axText.isEmpty {
+      ocrResult = OCRResult(text: axText, confidence: 1, language: nil)
+      textSource = .accessibility
     } else {
-      do {
-        ocrResult = try await ocr.recognize(cgImage: frame.cgImage)
-        if let ocrCacheKey {
-          ocrCache.insert(ocrResult, for: ocrCacheKey)
+      let ocrCacheKey = ImageContentHash.calculate(cgImage: frame.cgImage).map {
+        OCRCacheKey(context: ctx, imageHash: $0)
+      }
+      if let ocrCacheKey, let cached = ocrCache.result(for: ocrCacheKey) {
+        ocrResult = cached
+        textSource = .cachedOCR
+      } else {
+        do {
+          ocrResult = try await ocr.recognize(cgImage: frame.cgImage)
+          textSource = .visionOCR
+          if let ocrCacheKey {
+            ocrCache.insert(ocrResult, for: ocrCacheKey)
+          }
+        } catch {
+          Log.ocr.error("ocr failed: \(error.localizedDescription, privacy: .public)")
+          return
         }
-      } catch {
-        Log.ocr.error("ocr failed: \(error.localizedDescription, privacy: .public)")
-        return
       }
     }
+    textSourceCounts[textSource, default: 0] += 1
 
     switch evaluateSecretSurfaces(context: ctx, ocrText: ocrResult.text) {
     case .dropped(let reason):

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -25,6 +25,9 @@ final class AppController {
   private var captureRetryTimer: Timer?
   private var foregroundPrivacyTimer: Timer?
   private var eventCaptureTimer: Timer?
+  private var eventMonitors: [Any] = []
+  private var typingPauseTimer: Timer?
+  private var scrollStopTimer: Timer?
   private var foregroundPrivacyPauseReason: String?
   private var eventCaptureScheduler: EventCaptureScheduler
   private var eventCaptureInFlight = false
@@ -104,7 +107,8 @@ final class AppController {
     let pipeline = pipeline
     capture = CaptureService { [pipeline] frame in
       let ctx = await MainActor.run { WindowContextProbe.current() }
-      await pipeline.consume(frame, context: ctx)
+      let axText = await MainActor.run { AccessibilityTextExtractor.current(context: ctx) }
+      await pipeline.consume(frame, context: ctx, accessibilityText: axText)
     } onFrameDropped: { [pipeline] _ in
       await pipeline.recordBackpressureDrop()
     }
@@ -160,7 +164,7 @@ final class AppController {
     ) { [weak self] _ in
       Task { @MainActor in await self?.pollIdleState() }
     }
-    scheduleEventCaptureTimer()
+    scheduleEventCaptureInfrastructure()
     if controlClient != nil {
       heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
         Task { @MainActor in await self?.sendHeartbeat() }
@@ -325,6 +329,7 @@ final class AppController {
     config = next
     eventCaptureScheduler.updateConfig(next)
     await pipeline.updateConfig(next)
+    scheduleEventCaptureInfrastructure()
     if intervalChanged {
       scheduleFlushTimer()
     }
@@ -356,7 +361,7 @@ final class AppController {
     } else if !shouldPause, !captureRunning {
       if config.eventCaptureEnabled {
         captureRunning = true
-        scheduleEventCaptureTimer()
+        scheduleEventCaptureInfrastructure()
         schedulePauseWindowTimer()
         updateMenuStatus()
         return
@@ -425,6 +430,7 @@ final class AppController {
     let permissions = PermissionSnapshot.current(promptForAccessibility: false)
     let pending = await pipeline.pendingStats()
     let ocrCacheStats = await pipeline.ocrCacheStats()
+    let textSourceStats = await pipeline.textSourceStats()
     let localStats = await submitter.localBatchStats()
     let localBatches = await submitter.localBatchSummaries()
     let lastSubmitResult = await submitter.lastSubmitResult()
@@ -440,6 +446,7 @@ final class AppController {
       controlError: controlState.lastError,
       pendingStats: pending,
       ocrCacheStats: ocrCacheStats,
+      textSourceStats: textSourceStats,
       eventCaptureStats: eventCaptureScheduler.stats(),
       localBatchStats: localStats,
       localBatches: localBatches,
@@ -489,6 +496,67 @@ final class AppController {
     }
   }
 
+  private func scheduleEventCaptureInfrastructure() {
+    scheduleEventCaptureTimer()
+    installNativeEventMonitors()
+  }
+
+  private func installNativeEventMonitors() {
+    for monitor in eventMonitors {
+      NSEvent.removeMonitor(monitor)
+    }
+    eventMonitors.removeAll()
+    typingPauseTimer?.invalidate()
+    typingPauseTimer = nil
+    scrollStopTimer?.invalidate()
+    scrollStopTimer = nil
+
+    guard config.eventCaptureEnabled else { return }
+    let clickMonitor = NSEvent.addGlobalMonitorForEvents(
+      matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+    ) { [weak self] _ in
+      Task { @MainActor in await self?.requestEventCapture(.click) }
+    }
+    let keyMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.keyDown]) { [weak self] _ in
+      Task { @MainActor in self?.scheduleTypingPauseTrigger() }
+    }
+    let scrollMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.scrollWheel]) {
+      [weak self] _ in
+      Task { @MainActor in self?.scheduleScrollStopTrigger() }
+    }
+    eventMonitors = [clickMonitor, keyMonitor, scrollMonitor].compactMap { $0 }
+    if eventMonitors.count < 3 {
+      Log.capture.warning(
+        "native event capture monitors unavailable; polling triggers remain active")
+    }
+  }
+
+  private func scheduleTypingPauseTrigger() {
+    typingPauseTimer?.invalidate()
+    typingPauseTimer = Timer.scheduledTimer(
+      withTimeInterval: max(0.1, config.eventCaptureDebounceSeconds),
+      repeats: false
+    ) { [weak self] _ in
+      Task { @MainActor in await self?.requestEventCapture(.typingPause) }
+    }
+  }
+
+  private func scheduleScrollStopTrigger() {
+    scrollStopTimer?.invalidate()
+    scrollStopTimer = Timer.scheduledTimer(
+      withTimeInterval: max(0.1, config.eventCaptureDebounceSeconds),
+      repeats: false
+    ) { [weak self] _ in
+      Task { @MainActor in await self?.requestEventCapture(.scrollStop) }
+    }
+  }
+
+  private func requestEventCapture(_ trigger: EventCaptureTrigger) async {
+    guard captureRunning, config.eventCaptureEnabled, !effectivePauseState().paused else { return }
+    guard let accepted = eventCaptureScheduler.request(trigger, now: Date()) else { return }
+    await captureEvent(trigger: accepted)
+  }
+
   private func pollEventCaptureTriggers() async {
     guard captureRunning, config.eventCaptureEnabled, !effectivePauseState().paused else { return }
     let triggers = eventCaptureScheduler.observe(
@@ -513,7 +581,8 @@ final class AppController {
         onFrameDropped: { [pipeline] _ in await pipeline.recordBackpressureDrop() }
       )
       let context = WindowContextProbe.current()
-      await pipeline.consume(frame, context: context)
+      let axText = AccessibilityTextExtractor.current(context: context)
+      await pipeline.consume(frame, context: context, accessibilityText: axText)
       eventCaptureScheduler.recordCaptureSucceeded()
       Log.capture.info("event capture succeeded trigger=\(trigger.rawValue, privacy: .public)")
     } catch {

--- a/Tests/agentdTests/DiagnosticsTests.swift
+++ b/Tests/agentdTests/DiagnosticsTests.swift
@@ -37,6 +37,9 @@ final class DiagnosticsTests: XCTestCase {
       controlError: "none",
       pendingStats: PendingFrameStats(frameCount: 2, estimatedBytes: 4096),
       ocrCacheStats: OCRCacheStats(entries: 3, hits: 7, misses: 1, evictions: 2),
+      textSourceStats: TextSourceStats(
+        counts: [.accessibility: 5, .visionOCR: 2, .cachedOCR: 1]
+      ),
       eventCaptureStats: EventCaptureStats(
         enabled: true,
         triggerCounts: [.focusedWindow: 2, .idleFallback: 1],
@@ -77,6 +80,9 @@ final class DiagnosticsTests: XCTestCase {
     XCTAssertTrue(report.contains("OCR cache entries: 3"))
     XCTAssertTrue(report.contains("OCR cache hit rate: 0.88"))
     XCTAssertTrue(report.contains("OCR cache evictions: 2"))
+    XCTAssertTrue(report.contains("Text source accessibility: 5"))
+    XCTAssertTrue(report.contains("Text source visionOCR: 2"))
+    XCTAssertTrue(report.contains("Text source cachedOCR: 1"))
     XCTAssertTrue(report.contains("Event capture enabled: true"))
     XCTAssertTrue(report.contains("Event capture successes: 2"))
     XCTAssertTrue(report.contains("| focusedWindow | 2 |"))

--- a/Tests/agentdTests/EventCaptureSchedulerTests.swift
+++ b/Tests/agentdTests/EventCaptureSchedulerTests.swift
@@ -105,6 +105,20 @@ final class EventCaptureSchedulerTests: XCTestCase {
     XCTAssertFalse(scheduler.stats().enabled)
   }
 
+  func testNativeEventRequestsUseMinGapAndCounters() {
+    var scheduler = EventCaptureScheduler(config: Self.config())
+    let start = Date(timeIntervalSince1970: 100)
+
+    XCTAssertEqual(scheduler.request(.click, now: start), .click)
+    XCTAssertNil(scheduler.request(.typingPause, now: start.addingTimeInterval(0.1)))
+    XCTAssertEqual(scheduler.request(.scrollStop, now: start.addingTimeInterval(1.1)), .scrollStop)
+
+    let stats = scheduler.stats()
+    XCTAssertEqual(stats.triggerCounts[.click], 1)
+    XCTAssertEqual(stats.triggerCounts[.scrollStop], 1)
+    XCTAssertEqual(stats.triggersSuppressedByMinGap, 1)
+  }
+
   private static func config() -> AgentConfig {
     AgentConfig(
       deviceId: "device_1",

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -601,6 +601,56 @@ final class PipelineTests: XCTestCase {
     XCTAssertEqual(batch.droppedCounts.duplicate, 1)
   }
 
+  func testAccessibilityTextBypassesVisionOcr() async throws {
+    let recorder = BatchRecorder()
+    let ocr = CountingOCR(text: "vision text")
+    let pipeline = FramePipeline(config: Self.config(), ocr: ocr) { batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(
+      Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA),
+      context: Self.context(),
+      accessibilityText: AccessibilityTextResult(
+        text: "  accessibility\nvisible\ttext  ",
+        nodesVisited: 3,
+        truncated: false
+      )
+    )
+    await pipeline.flush()
+
+    let callCount = await ocr.callCount()
+    XCTAssertEqual(callCount, 0)
+    let stats = await pipeline.textSourceStats()
+    XCTAssertEqual(stats.counts[.accessibility], 1)
+    let batches = await recorder.snapshot()
+    let batch = try XCTUnwrap(batches.first)
+    XCTAssertEqual(batch.frames.first?.ocrText, "accessibility visible text")
+  }
+
+  func testEmptyAccessibilityTextFallsBackToVisionOcr() async throws {
+    let recorder = BatchRecorder()
+    let ocr = CountingOCR(text: "vision fallback")
+    let pipeline = FramePipeline(config: Self.config(), ocr: ocr) { batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(
+      Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA),
+      context: Self.context(),
+      accessibilityText: AccessibilityTextResult(text: "   ", nodesVisited: 1, truncated: false)
+    )
+    await pipeline.flush()
+
+    let callCount = await ocr.callCount()
+    XCTAssertEqual(callCount, 1)
+    let stats = await pipeline.textSourceStats()
+    XCTAssertEqual(stats.counts[.visionOCR], 1)
+    let batches = await recorder.snapshot()
+    let batch = try XCTUnwrap(batches.first)
+    XCTAssertEqual(batch.frames.first?.ocrText, "vision fallback")
+  }
+
   func testOcrCacheMissesWhenImageContentChanges() async throws {
     let recorder = BatchRecorder()
     let ocr = CountingOCR(text: "visible text")

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -13,6 +13,8 @@ The report includes:
   policy source;
 - in-memory frame pressure and queued local batch count/bytes;
 - OCR cache entry, hit-rate, miss, and eviction counters;
+- text-source counts for focused-window Accessibility text, fresh Vision OCR,
+  and cached OCR reuse;
 - event-capture trigger counts, debounce/min-gap suppressions, and one-shot
   capture success/failure counts;
 - sparse-frame visual-redaction enabled/disabled state;


### PR DESCRIPTION
## Summary
- add bounded focused-window Accessibility text extraction and prefer it before Vision OCR
- track local text-source diagnostics for AX text, fresh Vision OCR, and OCR cache reuse
- wire native click, typing-pause, and scroll-stop monitors into event-triggered one-shot capture
- feed AX text through diagnostic capture-once so local tooling exercises the same path
- add coverage for AX bypass, AX-empty OCR fallback, and native event min-gap counters

Completes the remaining #66 implementation slice.

## SOTA notes
- `gh` research found screenpipe/screenpipe's event-driven capture spec and AX-first text extraction direction:
  https://github.com/screenpipe/screenpipe/blob/d9ad0b8d1a50edcbee921c8e27cb4b01696092c6/docs/EVENT_DRIVEN_CAPTURE_SPEC.md

## Validation
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `git diff --check`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `scripts/package_app.sh`
- `timeout 10 .build/release/agentd selftest`
- `timeout 10 .build/release/agentd list-displays`
- Computer Use Safari accessibility-tree smoke confirmed local AX visibility