### PR TITLE
feat: restart stale capture streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ local inspection of the shipped arm64 `codex_chronicle` helper bundled with
   changes, clicks, typing pauses, scroll stops, clipboard updates, and idle
   fallback ticks behind `eventCaptureEnabled`, with debounce/min-gap counters in
   diagnostics.
+- Continuous capture has a local health watchdog that restarts ScreenCaptureKit
+  streams when active displays stop producing frames, with restart counts in
+  diagnostics.
 - Optional sparse-frame visual redaction masks OCR text boxes in local JPEG
   artifacts behind `sparseFrameVisualRedactionEnabled`; remote batch payloads are
   unchanged.

--- a/Sources/agentd/CaptureHealthWatchdog.swift
+++ b/Sources/agentd/CaptureHealthWatchdog.swift
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import Foundation
+
+struct CaptureHealthDecision: Sendable, Equatable {
+  let displayId: UInt32?
+  let reason: String
+}
+
+struct CaptureHealthStats: Sendable, Equatable {
+  let restartCount: Int
+  let lastRestartAt: Date?
+  let lastRestartDisplayId: UInt32?
+  let lastRestartReason: String?
+
+  static let empty = CaptureHealthStats(
+    restartCount: 0,
+    lastRestartAt: nil,
+    lastRestartDisplayId: nil,
+    lastRestartReason: nil
+  )
+}
+
+struct CaptureHealthWatchdog: Sendable {
+  private var runningSince: Date?
+  private var restartCount = 0
+  private var lastRestartAt: Date?
+  private var lastRestartDisplayId: UInt32?
+  private var lastRestartReason: String?
+
+  mutating func observeCaptureStarted(now: Date = Date()) {
+    runningSince = now
+  }
+
+  mutating func observeCaptureStopped() {
+    runningSince = nil
+  }
+
+  mutating func recordRestart(_ decision: CaptureHealthDecision, now: Date = Date()) {
+    restartCount += 1
+    lastRestartAt = now
+    lastRestartDisplayId = decision.displayId
+    lastRestartReason = decision.reason
+    runningSince = nil
+  }
+
+  func stats() -> CaptureHealthStats {
+    CaptureHealthStats(
+      restartCount: restartCount,
+      lastRestartAt: lastRestartAt,
+      lastRestartDisplayId: lastRestartDisplayId,
+      lastRestartReason: lastRestartReason
+    )
+  }
+
+  func evaluate(
+    now: Date = Date(),
+    captureRunning: Bool,
+    eventCaptureEnabled: Bool,
+    displayStats: [CaptureDisplayStats],
+    staleAfterSeconds: TimeInterval
+  ) -> CaptureHealthDecision? {
+    guard captureRunning, !eventCaptureEnabled else { return nil }
+    guard let runningSince else { return nil }
+    let staleAfterSeconds = max(1, staleAfterSeconds)
+    guard now.timeIntervalSince(runningSince) >= staleAfterSeconds else { return nil }
+    guard !displayStats.isEmpty else {
+      return CaptureHealthDecision(displayId: nil, reason: "no active display stats")
+    }
+
+    for display in displayStats.sorted(by: { $0.displayId < $1.displayId }) {
+      guard let lastFrameAt = display.lastFrameAt else {
+        return CaptureHealthDecision(displayId: display.displayId, reason: "no frames observed")
+      }
+      if now.timeIntervalSince(lastFrameAt) >= staleAfterSeconds {
+        return CaptureHealthDecision(displayId: display.displayId, reason: "stale frame stream")
+      }
+    }
+    return nil
+  }
+}

--- a/Sources/agentd/Diagnostics.swift
+++ b/Sources/agentd/Diagnostics.swift
@@ -18,6 +18,7 @@ struct DiagnosticsSnapshot: Sendable {
   let localBatchStats: LocalBatchStats
   let localBatches: [LocalBatchSummary]
   let captureDisplayStats: [CaptureDisplayStats]
+  let captureHealthStats: CaptureHealthStats
   let lastSubmitResult: String?
 }
 
@@ -58,6 +59,16 @@ enum DiagnosticsReport {
       "- Event capture debounced triggers: \(snapshot.eventCaptureStats.triggersDebounced)")
     lines.append(
       "- Event capture min-gap suppressions: \(snapshot.eventCaptureStats.triggersSuppressedByMinGap)"
+    )
+    lines.append("- Capture health restarts: \(snapshot.captureHealthStats.restartCount)")
+    lines.append(
+      "- Last capture health restart: \(snapshot.captureHealthStats.lastRestartAt.map(iso) ?? "none")"
+    )
+    lines.append(
+      "- Last capture health restart display: \(snapshot.captureHealthStats.lastRestartDisplayId.map(String.init) ?? "none")"
+    )
+    lines.append(
+      "- Last capture health restart reason: \(redact(snapshot.captureHealthStats.lastRestartReason ?? "none"))"
     )
     lines.append("- Queued local batches: \(snapshot.localBatchStats.fileCount)")
     lines.append("- Queued local bytes: \(snapshot.localBatchStats.bytes)")

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -25,11 +25,13 @@ final class AppController {
   private var captureRetryTimer: Timer?
   private var foregroundPrivacyTimer: Timer?
   private var eventCaptureTimer: Timer?
+  private var captureHealthTimer: Timer?
   private var eventMonitors: [Any] = []
   private var typingPauseTimer: Timer?
   private var scrollStopTimer: Timer?
   private var foregroundPrivacyPauseReason: String?
   private var eventCaptureScheduler: EventCaptureScheduler
+  private var captureHealthWatchdog = CaptureHealthWatchdog()
   private var eventCaptureInFlight = false
   private var idleMode = false
 
@@ -165,6 +167,10 @@ final class AppController {
       Task { @MainActor in await self?.pollIdleState() }
     }
     scheduleEventCaptureInfrastructure()
+    captureHealthTimer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) {
+      [weak self] _ in
+      Task { @MainActor in await self?.pollCaptureHealth() }
+    }
     if controlClient != nil {
       heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
         Task { @MainActor in await self?.sendHeartbeat() }
@@ -356,11 +362,13 @@ final class AppController {
       } else {
         await capture.stop()
       }
+      captureHealthWatchdog.observeCaptureStopped()
       captureRunning = false
       idleMode = false
     } else if !shouldPause, !captureRunning {
       if config.eventCaptureEnabled {
         captureRunning = true
+        captureHealthWatchdog.observeCaptureStopped()
         scheduleEventCaptureInfrastructure()
         schedulePauseWindowTimer()
         updateMenuStatus()
@@ -373,6 +381,7 @@ final class AppController {
           selectedDisplayIds: config.selectedDisplayIds
         )
         captureRunning = true
+        captureHealthWatchdog.observeCaptureStarted()
         captureRetryTimer?.invalidate()
         captureRetryTimer = nil
       } catch {
@@ -383,6 +392,28 @@ final class AppController {
     }
     schedulePauseWindowTimer()
     updateMenuStatus()
+  }
+
+  private func pollCaptureHealth() async {
+    let displayStats = await capture.displayStats()
+    let staleAfter = max(30, config.batchIntervalSeconds * 2)
+    guard
+      let decision = captureHealthWatchdog.evaluate(
+        captureRunning: captureRunning,
+        eventCaptureEnabled: config.eventCaptureEnabled,
+        displayStats: displayStats,
+        staleAfterSeconds: staleAfter
+      )
+    else { return }
+
+    captureHealthWatchdog.recordRestart(decision)
+    Log.capture.error(
+      "capture health restart display=\(decision.displayId.map(String.init) ?? "none", privacy: .public) reason=\(decision.reason, privacy: .public)"
+    )
+    await capture.stop()
+    captureRunning = false
+    idleMode = false
+    await reconcileCaptureState()
   }
 
   private func scheduleCaptureRetry() {
@@ -435,6 +466,7 @@ final class AppController {
     let localBatches = await submitter.localBatchSummaries()
     let lastSubmitResult = await submitter.lastSubmitResult()
     let captureDisplayStats = await capture.displayStats()
+    let captureHealthStats = captureHealthWatchdog.stats()
     let snapshot = DiagnosticsSnapshot(
       generatedAt: Date(),
       appVersion: Bundle.main.appVersion,
@@ -451,6 +483,7 @@ final class AppController {
       localBatchStats: localStats,
       localBatches: localBatches,
       captureDisplayStats: captureDisplayStats,
+      captureHealthStats: captureHealthStats,
       lastSubmitResult: lastSubmitResult
     )
     do {

--- a/Tests/agentdTests/CaptureHealthWatchdogTests.swift
+++ b/Tests/agentdTests/CaptureHealthWatchdogTests.swift
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import Foundation
+import XCTest
+
+@testable import agentd
+
+final class CaptureHealthWatchdogTests: XCTestCase {
+  func testIgnoresEventCaptureMode() {
+    var watchdog = CaptureHealthWatchdog()
+    let started = Date(timeIntervalSince1970: 100)
+    watchdog.observeCaptureStarted(now: started)
+
+    let decision = watchdog.evaluate(
+      now: started.addingTimeInterval(120),
+      captureRunning: true,
+      eventCaptureEnabled: true,
+      displayStats: [Self.display(lastFrameAt: nil)],
+      staleAfterSeconds: 30
+    )
+
+    XCTAssertNil(decision)
+  }
+
+  func testRestartsWhenRunningStreamHasNoFrames() {
+    var watchdog = CaptureHealthWatchdog()
+    let started = Date(timeIntervalSince1970: 100)
+    watchdog.observeCaptureStarted(now: started)
+
+    let decision = watchdog.evaluate(
+      now: started.addingTimeInterval(31),
+      captureRunning: true,
+      eventCaptureEnabled: false,
+      displayStats: [Self.display(lastFrameAt: nil)],
+      staleAfterSeconds: 30
+    )
+
+    XCTAssertEqual(decision?.displayId, 42)
+    XCTAssertEqual(decision?.reason, "no frames observed")
+  }
+
+  func testRestartsWhenLastFrameIsStaleAndRecordsStats() {
+    var watchdog = CaptureHealthWatchdog()
+    let started = Date(timeIntervalSince1970: 100)
+    let now = started.addingTimeInterval(90)
+    watchdog.observeCaptureStarted(now: started)
+
+    let decision = watchdog.evaluate(
+      now: now,
+      captureRunning: true,
+      eventCaptureEnabled: false,
+      displayStats: [Self.display(lastFrameAt: started.addingTimeInterval(10))],
+      staleAfterSeconds: 30
+    )
+
+    let unwrapped = try! XCTUnwrap(decision)
+    watchdog.recordRestart(unwrapped, now: now)
+
+    XCTAssertEqual(unwrapped.reason, "stale frame stream")
+    XCTAssertEqual(watchdog.stats().restartCount, 1)
+    XCTAssertEqual(watchdog.stats().lastRestartDisplayId, 42)
+  }
+
+  private static func display(lastFrameAt: Date?) -> CaptureDisplayStats {
+    CaptureDisplayStats(
+      displayId: 42,
+      widthPx: 1800,
+      heightPx: 1169,
+      displayScale: 1,
+      mainDisplay: true,
+      framesEnqueued: lastFrameAt == nil ? 0 : 3,
+      framesDropped: 0,
+      lastFrameAt: lastFrameAt
+    )
+  }
+}

--- a/Tests/agentdTests/DiagnosticsTests.swift
+++ b/Tests/agentdTests/DiagnosticsTests.swift
@@ -71,6 +71,12 @@ final class DiagnosticsTests: XCTestCase {
           lastFrameAt: Date(timeIntervalSince1970: 3)
         )
       ],
+      captureHealthStats: CaptureHealthStats(
+        restartCount: 1,
+        lastRestartAt: Date(timeIntervalSince1970: 4),
+        lastRestartDisplayId: 42,
+        lastRestartReason: "stale frame stream"
+      ),
       lastSubmitResult: "persisted local fallback batch batch_1"
     )
 
@@ -85,6 +91,9 @@ final class DiagnosticsTests: XCTestCase {
     XCTAssertTrue(report.contains("Text source cachedOCR: 1"))
     XCTAssertTrue(report.contains("Event capture enabled: true"))
     XCTAssertTrue(report.contains("Event capture successes: 2"))
+    XCTAssertTrue(report.contains("Capture health restarts: 1"))
+    XCTAssertTrue(report.contains("Last capture health restart display: 42"))
+    XCTAssertTrue(report.contains("Last capture health restart reason: stale frame stream"))
     XCTAssertTrue(report.contains("| focusedWindow | 2 |"))
     XCTAssertTrue(report.contains("| batch_1 |"))
     XCTAssertTrue(

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -17,6 +17,7 @@ The report includes:
   and cached OCR reuse;
 - event-capture trigger counts, debounce/min-gap suppressions, and one-shot
   capture success/failure counts;
+- capture health restart counts and the last stale-stream restart reason;
 - sparse-frame visual-redaction enabled/disabled state;
 - queued batch id, modification time, size, and encryption state.
 


### PR DESCRIPTION
## Summary
- add a continuous-capture health watchdog that detects active displays with no/stale frames
- restart in-process ScreenCaptureKit streams when the watchdog trips, while ignoring event-triggered capture mode
- expose watchdog restart count, display id, timestamp, and reason in diagnostics
- document the watchdog as the first resilience slice toward #53

This does not close #53; it lands the in-process watchdog fallback called out there before the larger worker-process split.

## Validation
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `git diff --check`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `scripts/package_app.sh`
- `timeout 10 .build/release/agentd selftest`
- `timeout 10 .build/release/agentd list-displays`