### PR TITLE
Run diagnostic capture through worker

### DIFF
--- a/Sources/agentd/CaptureWorkerProtocol.swift
+++ b/Sources/agentd/CaptureWorkerProtocol.swift
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+struct CaptureWorkerFramePayload: Codable, Sendable, Equatable {
+  let timestamp: Date
+  let displayId: UInt32
+  let displayScale: Double?
+  let mainDisplay: Bool
+  let jpegBase64: String
+}
+
+enum CaptureWorkerProtocolError: Error, LocalizedError, Equatable {
+  case imageEncodeFailed
+  case imageDecodeFailed
+
+  var errorDescription: String? {
+    switch self {
+    case .imageEncodeFailed:
+      return "capture worker could not encode frame image"
+    case .imageDecodeFailed:
+      return "capture worker could not decode frame image"
+    }
+  }
+}
+
+enum CaptureWorkerFrameCodec {
+  static func payload(for frame: CapturedFrame) throws -> CaptureWorkerFramePayload {
+    let data = NSMutableData()
+    guard
+      let destination = CGImageDestinationCreateWithData(
+        data,
+        UTType.jpeg.identifier as CFString,
+        1,
+        nil
+      )
+    else {
+      throw CaptureWorkerProtocolError.imageEncodeFailed
+    }
+    CGImageDestinationAddImage(destination, frame.cgImage, nil)
+    guard CGImageDestinationFinalize(destination) else {
+      throw CaptureWorkerProtocolError.imageEncodeFailed
+    }
+    return CaptureWorkerFramePayload(
+      timestamp: frame.timestamp,
+      displayId: frame.displayId,
+      displayScale: frame.displayScale,
+      mainDisplay: frame.mainDisplay,
+      jpegBase64: (data as Data).base64EncodedString()
+    )
+  }
+
+  static func frame(from payload: CaptureWorkerFramePayload) throws -> CapturedFrame {
+    guard
+      let data = Data(base64Encoded: payload.jpegBase64),
+      let source = CGImageSourceCreateWithData(data as CFData, nil),
+      let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+    else {
+      throw CaptureWorkerProtocolError.imageDecodeFailed
+    }
+    return CapturedFrame(
+      timestamp: payload.timestamp,
+      cgImage: image,
+      displayId: payload.displayId,
+      displayScale: payload.displayScale,
+      mainDisplay: payload.mainDisplay
+    )
+  }
+
+  static func encodePayload(_ payload: CaptureWorkerFramePayload) throws -> Data {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    return try encoder.encode(payload) + Data([0x0A])
+  }
+
+  static func decodePayload(_ data: Data) throws -> CaptureWorkerFramePayload {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try decoder.decode(CaptureWorkerFramePayload.self, from: data)
+  }
+}

--- a/Sources/agentd/CaptureWorkerSupervisor.swift
+++ b/Sources/agentd/CaptureWorkerSupervisor.swift
@@ -3,19 +3,25 @@
 import Darwin
 import Foundation
 
-struct CaptureWorkerProcessSpec: Sendable, Equatable {
+struct CaptureWorkerProcessSpec {
   let executableURL: URL
   let arguments: [String]
   let environment: [String: String]?
+  let standardOutput: Pipe?
+  let standardError: Pipe?
 
   init(
     executableURL: URL,
     arguments: [String] = [],
-    environment: [String: String]? = nil
+    environment: [String: String]? = nil,
+    standardOutput: Pipe? = nil,
+    standardError: Pipe? = nil
   ) {
     self.executableURL = executableURL
     self.arguments = arguments
     self.environment = environment
+    self.standardOutput = standardOutput
+    self.standardError = standardError
   }
 }
 
@@ -71,6 +77,12 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
     process.executableURL = spec.executableURL
     process.arguments = spec.arguments
     process.environment = spec.environment
+    if let standardOutput = spec.standardOutput {
+      process.standardOutput = standardOutput
+    }
+    if let standardError = spec.standardError {
+      process.standardError = standardError
+    }
 
     return try lock.withLock {
       if let current = self.process, current.isRunning {
@@ -124,6 +136,25 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
     return recordTermination(process: target, pid: pid, killSent: true, exited: exitedAfterKill)
   }
 
+  func waitForExit(timeoutSeconds: TimeInterval) -> CaptureWorkerTerminationResult? {
+    guard let target = lock.withLock({ self.process }) else { return nil }
+    let pid = target.processIdentifier
+    let exited = Self.wait(for: target, timeoutSeconds: max(0, timeoutSeconds))
+    guard exited else { return nil }
+    lock.withLock {
+      if self.process === target {
+        self.process = nil
+      }
+    }
+    return recordTermination(
+      process: target,
+      pid: pid,
+      termSent: false,
+      killSent: false,
+      exited: true
+    )
+  }
+
   func stats() -> CaptureWorkerSupervisorStats {
     lock.withLock {
       CaptureWorkerSupervisorStats(
@@ -139,6 +170,7 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
   private func recordTermination(
     process: Process,
     pid: Int32,
+    termSent: Bool = true,
     killSent: Bool,
     exited: Bool
   ) -> CaptureWorkerTerminationResult {
@@ -153,7 +185,7 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
     }
     return CaptureWorkerTerminationResult(
       pid: pid,
-      termSent: true,
+      termSent: termSent,
       killSent: killSent,
       exited: exited,
       terminationStatus: status

--- a/Sources/agentd/DiagnosticCLI.swift
+++ b/Sources/agentd/DiagnosticCLI.swift
@@ -108,7 +108,7 @@ enum DiagnosticProbeRunner {
 
 enum DiagnosticCLI {
   static let handledCommands = [
-    "list-displays", "capture-once", "selftest", "help", "--help", "-h",
+    "list-displays", "capture-once", "capture-worker-once", "selftest", "help", "--help", "-h",
   ]
 
   static func shouldHandle(_ arguments: [String]) -> Bool {
@@ -136,6 +136,9 @@ enum DiagnosticCLI {
       case .selftest:
         let payload = await SelftestDiagnostics.run()
         try writeJSON(payload, to: nil)
+      case .captureWorkerOnce(let options):
+        let payload = try await CaptureWorkerDiagnostics.run(options: options)
+        try writeJSON(payload, to: options.out)
       }
       return 0
     } catch let error as DiagnosticCLIError {
@@ -181,6 +184,7 @@ enum DiagnosticCommand: Equatable {
   case help
   case listDisplays
   case captureOnce(CaptureOnceOptions)
+  case captureWorkerOnce(CaptureOnceOptions)
   case selftest
 
   static func parse(_ arguments: [String]) throws -> DiagnosticCommand {
@@ -194,6 +198,8 @@ enum DiagnosticCommand: Equatable {
       return .listDisplays
     case "capture-once":
       return .captureOnce(try CaptureOnceOptions.parse(tail))
+    case "capture-worker-once":
+      return .captureWorkerOnce(try CaptureOnceOptions.parse(tail))
     case "selftest":
       guard tail.isEmpty else { throw DiagnosticCLIError.usage("selftest takes no flags") }
       return .selftest
@@ -248,6 +254,7 @@ enum DiagnosticCLIError: Error, LocalizedError {
   case noWindowContext
   case noBatchProduced
   case displayProbeFailed(String)
+  case captureWorkerFailed(String)
   case unscrubbedCaptureUnavailable
 
   var errorDescription: String? {
@@ -261,6 +268,8 @@ enum DiagnosticCLIError: Error, LocalizedError {
     case .noBatchProduced:
       return "capture produced no batch; privacy filters may have dropped the frame"
     case .displayProbeFailed(let message):
+      return message
+    case .captureWorkerFailed(let message):
       return message
     case .unscrubbedCaptureUnavailable:
       return
@@ -433,8 +442,10 @@ enum CaptureOnceDiagnostics {
       await recorder.append(batch)
       return .submitted(nil)
     }
-    let frame = try await captureOneFrame(
-      displayId: options.displayId, timeoutSeconds: 6)
+    let frame = try await CaptureWorkerClient.captureOneFrame(
+      displayId: options.displayId,
+      timeoutSeconds: 6
+    )
     let context = try await MainActor.run {
       guard let context = WindowContextProbe.current() else {
         throw DiagnosticCLIError.noWindowContext
@@ -459,7 +470,7 @@ enum CaptureOnceDiagnostics {
     )
   }
 
-  private static func captureOneFrame(
+  static func captureOneFrame(
     displayId: UInt32?,
     timeoutSeconds: UInt64
   ) async throws -> CapturedFrame {
@@ -482,6 +493,79 @@ enum CaptureOnceDiagnostics {
     } catch {
       throw error
     }
+  }
+}
+
+enum CaptureWorkerDiagnostics {
+  static func run(options: CaptureOnceOptions) async throws -> CaptureWorkerFramePayload {
+    if options.noScrub {
+      throw DiagnosticCLIError.unscrubbedCaptureUnavailable
+    }
+    let frame = try await CaptureOnceDiagnostics.captureOneFrame(
+      displayId: options.displayId,
+      timeoutSeconds: 6
+    )
+    return try CaptureWorkerFrameCodec.payload(for: frame)
+  }
+}
+
+enum CaptureWorkerClient {
+  static func captureOneFrame(displayId: UInt32?, timeoutSeconds: TimeInterval) async throws
+    -> CapturedFrame
+  {
+    let executable = URL(fileURLWithPath: CommandLine.arguments[0])
+    return try await captureOneFrame(
+      executable: executable,
+      displayId: displayId,
+      timeoutSeconds: timeoutSeconds
+    )
+  }
+
+  static func captureOneFrame(
+    executable: URL,
+    displayId: UInt32?,
+    timeoutSeconds: TimeInterval
+  ) async throws -> CapturedFrame {
+    let outputURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("agentd-capture-worker-\(UUID().uuidString).json")
+    defer { try? FileManager.default.removeItem(at: outputURL) }
+
+    var arguments = ["capture-worker-once", "--no-ocr", "--out", outputURL.path]
+    if let displayId {
+      arguments += ["--display-id", String(displayId)]
+    }
+    let stderr = Pipe()
+    let supervisor = CaptureWorkerSupervisor()
+    _ = try supervisor.start(
+      CaptureWorkerProcessSpec(
+        executableURL: executable,
+        arguments: arguments,
+        standardError: stderr
+      )
+    )
+    guard
+      let result = supervisor.waitForExit(timeoutSeconds: timeoutSeconds + 2),
+      result.exited
+    else {
+      let termination = supervisor.terminate(graceSeconds: 1)
+      throw DiagnosticCLIError.captureWorkerFailed(
+        "capture worker timed out killSent=\(termination.killSent)")
+    }
+
+    let errorOutput = stderr.fileHandleForReading.readDataToEndOfFile()
+    guard result.terminationStatus == 0 else {
+      let message = String(data: errorOutput, encoding: .utf8)?.trimmingCharacters(
+        in: .whitespacesAndNewlines
+      )
+      throw DiagnosticCLIError.captureWorkerFailed(
+        message?.isEmpty == false
+          ? message!
+          : "capture worker exited with status \(result.terminationStatus ?? -1)"
+      )
+    }
+    let output = try Data(contentsOf: outputURL)
+    let payload = try CaptureWorkerFrameCodec.decodePayload(output)
+    return try CaptureWorkerFrameCodec.frame(from: payload)
   }
 }
 

--- a/Tests/agentdTests/CaptureWorkerProtocolTests.swift
+++ b/Tests/agentdTests/CaptureWorkerProtocolTests.swift
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import CoreGraphics
+import Foundation
+import XCTest
+
+@testable import agentd
+
+final class CaptureWorkerProtocolTests: XCTestCase {
+  func testFramePayloadRoundTripsThroughJpegJson() throws {
+    let frame = CapturedFrame(
+      timestamp: Date(timeIntervalSince1970: 123),
+      cgImage: try Self.image(),
+      displayId: 42,
+      displayScale: 2,
+      mainDisplay: true
+    )
+
+    let payload = try CaptureWorkerFrameCodec.payload(for: frame)
+    let data = try CaptureWorkerFrameCodec.encodePayload(payload)
+    let decodedPayload = try CaptureWorkerFrameCodec.decodePayload(data)
+    let decodedFrame = try CaptureWorkerFrameCodec.frame(from: decodedPayload)
+
+    XCTAssertEqual(decodedFrame.timestamp, frame.timestamp)
+    XCTAssertEqual(decodedFrame.displayId, 42)
+    XCTAssertEqual(decodedFrame.displayScale, 2)
+    XCTAssertEqual(decodedFrame.mainDisplay, true)
+    XCTAssertEqual(decodedFrame.cgImage.width, frame.cgImage.width)
+    XCTAssertEqual(decodedFrame.cgImage.height, frame.cgImage.height)
+  }
+
+  func testCaptureWorkerClientSurfacesNonZeroExit() async {
+    do {
+      _ = try await CaptureWorkerClient.captureOneFrame(
+        executable: URL(fileURLWithPath: "/usr/bin/false"),
+        displayId: nil,
+        timeoutSeconds: 0.5
+      )
+      XCTFail("expected worker failure")
+    } catch let error as DiagnosticCLIError {
+      XCTAssertTrue(error.localizedDescription.contains("exited with status"))
+    } catch {
+      XCTFail("unexpected error: \(error)")
+    }
+  }
+
+  private static func image() throws -> CGImage {
+    let width = 4
+    let height = 4
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    guard
+      let context = CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: colorSpace,
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    else {
+      throw CaptureWorkerProtocolError.imageEncodeFailed
+    }
+    context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    guard let image = context.makeImage() else {
+      throw CaptureWorkerProtocolError.imageEncodeFailed
+    }
+    return image
+  }
+}

--- a/Tests/agentdTests/DiagnosticCLITests.swift
+++ b/Tests/agentdTests/DiagnosticCLITests.swift
@@ -10,6 +10,7 @@ final class DiagnosticCLITests: XCTestCase {
     XCTAssertFalse(DiagnosticCLI.shouldHandle(["agentd"]))
     XCTAssertTrue(DiagnosticCLI.shouldHandle(["agentd", "list-displays"]))
     XCTAssertTrue(DiagnosticCLI.shouldHandle(["agentd", "capture-once"]))
+    XCTAssertTrue(DiagnosticCLI.shouldHandle(["agentd", "capture-worker-once"]))
     XCTAssertTrue(DiagnosticCLI.shouldHandle(["agentd", "selftest"]))
     XCTAssertFalse(DiagnosticCLI.shouldHandle(["agentd", "--local-only"]))
   }
@@ -34,6 +35,18 @@ final class DiagnosticCLITests: XCTestCase {
       return XCTFail("expected capture-once")
     }
     XCTAssertTrue(options.noScrub)
+  }
+
+  func testCaptureWorkerOnceParserReusesCaptureOnceSafeFlags() throws {
+    let command = try DiagnosticCommand.parse([
+      "capture-worker-once", "--display-id", "7", "--no-ocr",
+    ])
+
+    guard case .captureWorkerOnce(let options) = command else {
+      return XCTFail("expected capture-worker-once")
+    }
+    XCTAssertEqual(options.displayId, 7)
+    XCTAssertTrue(options.noOCR)
   }
 
   func testCaptureOnceParserRejectsUnknownFlags() {

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -57,6 +57,11 @@ writes a redacted batch JSON object to stdout or an `0o600` `--out` path. It
 refuses to run while another agentd daemon or diagnostic capture holds the
 runtime lock, which avoids ScreenCaptureKit contention during support sessions.
 
-`--no-ocr` keeps the capture and scrubber path intact but records an empty OCR
-result. `--no-scrub` is recognized for operator muscle memory but deliberately
-refused; local diagnostics should not bypass the scrubber.
+`capture-once` launches a same-binary `capture-worker-once` subprocess for the
+ScreenCaptureKit one-shot and decodes the worker's frame payload in the parent
+before policy, scrubber, OCR, and batch generation run. This exercises the
+out-of-process capture boundary used by the larger worker-supervision roadmap
+while keeping privacy decisions in the parent process. `--no-ocr` keeps the
+capture and scrubber path intact but records an empty OCR result. `--no-scrub`
+is recognized for operator muscle memory but deliberately refused; local
+diagnostics should not bypass the scrubber.


### PR DESCRIPTION
## Summary
- add a same-binary `capture-worker-once` hidden worker command that emits a JPEG-backed frame payload
- route diagnostic `capture-once` through `CaptureWorkerSupervisor` so ScreenCaptureKit one-shot capture runs out-of-process
- keep policy, Accessibility text, scrubber, OCR, and batch generation in the parent process
- avoid stdout pipe backpressure by writing worker payloads to a temporary JSON file
- add codec/client/parser tests for the worker frame protocol

Further #53 progress. This moves diagnostic one-shot ScreenCaptureKit through the worker boundary; long-running menu-bar streaming remains in-process until the next slice.

## Validation
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `git diff --check`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `scripts/package_app.sh`
- `timeout 10 .build/release/agentd selftest`
- `timeout 10 .build/release/agentd list-displays`
- `timeout 20 .build/release/agentd capture-once --no-ocr --out /tmp/agentd-worker-capture-once.json`
- `timeout 20 .build/release/agentd capture-worker-once --no-ocr --out /tmp/agentd-capture-worker-payload.json`
