### PR TITLE
Stream capture through worker process

### DIFF
--- a/Sources/agentd/CaptureService.swift
+++ b/Sources/agentd/CaptureService.swift
@@ -56,7 +56,87 @@ enum CaptureOneShotError: LocalizedError {
   }
 }
 
-actor CaptureService: NSObject {
+actor CaptureService {
+  private let workerClient: CaptureWorkerStreamClient
+  private var runningScope: RunningCaptureScope?
+
+  init(
+    onFrame: @escaping @Sendable (CapturedFrame) async -> Void,
+    onFrameDropped: @escaping @Sendable (CGDirectDisplayID) async -> Void = { _ in }
+  ) {
+    self.workerClient = CaptureWorkerStreamClient(
+      onFrame: onFrame,
+      onFrameDropped: onFrameDropped
+    )
+  }
+
+  func start(
+    targetFps: Double,
+    captureAllDisplays: Bool = false,
+    selectedDisplayIds: [UInt32] = []
+  ) async throws {
+    await stop()
+    let scope = RunningCaptureScope(
+      targetFps: targetFps,
+      captureAllDisplays: captureAllDisplays,
+      selectedDisplayIds: selectedDisplayIds
+    )
+    try await workerClient.start(scope: scope)
+    runningScope = scope
+  }
+
+  func stop() async {
+    await workerClient.stop()
+    runningScope = nil
+  }
+
+  func updateFps(_ fps: Double) async {
+    guard let current = runningScope else { return }
+    let next = RunningCaptureScope(
+      targetFps: fps,
+      captureAllDisplays: current.captureAllDisplays,
+      selectedDisplayIds: current.selectedDisplayIds
+    )
+    do {
+      try await workerClient.start(scope: next)
+      runningScope = next
+    } catch {
+      Log.capture.error(
+        "capture worker fps update failed: \(error.localizedDescription, privacy: .public)"
+      )
+    }
+  }
+
+  func displayStats() async -> [CaptureDisplayStats] {
+    await workerClient.displayStats()
+  }
+
+  static func captureOneFrame(
+    targetFps: Double,
+    captureAllDisplays: Bool,
+    selectedDisplayIds: [UInt32],
+    timeoutSeconds: Double,
+    onFrameDropped: @escaping @Sendable (CGDirectDisplayID) async -> Void = { _ in }
+  ) async throws -> CapturedFrame {
+    do {
+      return try await CaptureWorkerClient.captureOneFrame(
+        displayId: selectedDisplayIds.first,
+        timeoutSeconds: timeoutSeconds
+      )
+    } catch {
+      await onFrameDropped(selectedDisplayIds.first ?? CGMainDisplayID())
+      throw error
+    }
+  }
+}
+
+struct RunningCaptureScope: Sendable, Equatable {
+  let targetFps: Double
+  let captureAllDisplays: Bool
+  let selectedDisplayIds: [UInt32]
+}
+
+actor ScreenCaptureService: NSObject {
   private var captures: [CGDirectDisplayID: DisplayCapture] = [:]
   private let onFrame: @Sendable (CapturedFrame) async -> Void
   private let onFrameDropped: @Sendable (CGDirectDisplayID) async -> Void
@@ -168,7 +248,7 @@ actor CaptureService: NSObject {
     onFrameDropped: @escaping @Sendable (CGDirectDisplayID) async -> Void = { _ in }
   ) async throws -> CapturedFrame {
     let receiver = OneShotFrameReceiver()
-    let service = CaptureService { frame in
+    let service = ScreenCaptureService { frame in
       await receiver.record(frame)
     } onFrameDropped: { displayId in
       await onFrameDropped(displayId)
@@ -228,6 +308,232 @@ actor CaptureService: NSObject {
     let boundsWidth = CGDisplayBounds(displayId).width
     guard boundsWidth > 0 else { return nil }
     return Double(pixelWidth) / Double(boundsWidth)
+  }
+}
+
+actor CaptureWorkerStreamClient {
+  private let executable: URL
+  private let onFrame: @Sendable (CapturedFrame) async -> Void
+  private let onFrameDropped: @Sendable (CGDirectDisplayID) async -> Void
+  private var streams: [CGDirectDisplayID: CaptureWorkerStream] = [:]
+
+  init(
+    executable: URL = URL(fileURLWithPath: CommandLine.arguments[0]),
+    onFrame: @escaping @Sendable (CapturedFrame) async -> Void,
+    onFrameDropped: @escaping @Sendable (CGDirectDisplayID) async -> Void
+  ) {
+    self.executable = executable
+    self.onFrame = onFrame
+    self.onFrameDropped = onFrameDropped
+  }
+
+  func start(scope: RunningCaptureScope) async throws {
+    stop()
+    let displays = try await MainActor.run { try SystemDisplayDiagnosticsProbe.systemDisplays() }
+    let selectedIds = DisplaySelection.selectedDisplayIds(
+      available: displays.map(\.displayId),
+      captureAllDisplays: scope.captureAllDisplays,
+      selectedDisplayIds: scope.selectedDisplayIds
+    )
+    guard !selectedIds.isEmpty else {
+      throw NSError(domain: "agentd", code: 1, userInfo: [NSLocalizedDescriptionKey: "no display"])
+    }
+    let byId = Dictionary(uniqueKeysWithValues: displays.map { ($0.displayId, $0) })
+    var started: [CGDirectDisplayID: CaptureWorkerStream] = [:]
+    do {
+      for displayId in selectedIds {
+        guard let display = byId[displayId] else { continue }
+        let stream = CaptureWorkerStream(
+          display: display,
+          onFrame: onFrame,
+          onFrameDropped: onFrameDropped
+        )
+        try stream.start(executable: executable, fps: scope.targetFps)
+        started[displayId] = stream
+      }
+    } catch {
+      for stream in started.values {
+        stream.stop()
+      }
+      throw error
+    }
+    streams = started
+    Log.capture.info(
+      "capture worker stream started fps=\(scope.targetFps, privacy: .public) displays=\(selectedIds.map(String.init).joined(separator: ","), privacy: .public)"
+    )
+  }
+
+  func stop() {
+    for stream in streams.values {
+      stream.stop()
+    }
+    streams.removeAll()
+    Log.capture.info("capture worker stream stopped")
+  }
+
+  func displayStats() -> [CaptureDisplayStats] {
+    streams.values.map { $0.stats() }.sorted { $0.displayId < $1.displayId }
+  }
+}
+
+final class CaptureWorkerStream: @unchecked Sendable {
+  private let display: DisplayDiagnostic
+  private let supervisor = CaptureWorkerSupervisor()
+  private let stdout = Pipe()
+  private let stderr = Pipe()
+  private let reader: CaptureWorkerStreamLineReader
+  private let statsRecorder: CaptureWorkerStreamStatsRecorder
+  private let dispatcher: BufferedFrameDispatcher
+
+  init(
+    display: DisplayDiagnostic,
+    onFrame: @escaping @Sendable (CapturedFrame) async -> Void,
+    onFrameDropped: @escaping @Sendable (CGDirectDisplayID) async -> Void
+  ) {
+    self.display = display
+    self.statsRecorder = CaptureWorkerStreamStatsRecorder(display: display)
+    self.dispatcher = BufferedFrameDispatcher(
+      onFrame: onFrame,
+      onDropped: { await onFrameDropped(display.displayId) }
+    )
+    self.reader = CaptureWorkerStreamLineReader { [statsRecorder, dispatcher] payload in
+      do {
+        let frame = try CaptureWorkerFrameCodec.frame(from: payload)
+        if dispatcher.yield(frame) {
+          statsRecorder.recordEnqueued(frame)
+        } else {
+          statsRecorder.recordDropped()
+        }
+      } catch {
+        statsRecorder.recordDropped()
+        Log.capture.error(
+          "capture worker frame decode failed display=\(payload.displayId, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+        )
+      }
+    } onDecodeError: { [statsRecorder, display] message in
+      statsRecorder.recordDropped()
+      Log.capture.error(
+        "capture worker stream decode failed display=\(display.displayId, privacy: .public) error=\(message, privacy: .public)"
+      )
+    }
+  }
+
+  func start(executable: URL, fps: Double) throws {
+    stdout.fileHandleForReading.readabilityHandler = { @Sendable [reader] handle in
+      let data = handle.availableData
+      guard !data.isEmpty else { return }
+      reader.append(data)
+    }
+    stderr.fileHandleForReading.readabilityHandler = { @Sendable [display] handle in
+      let data = handle.availableData
+      guard !data.isEmpty, let message = String(data: data, encoding: .utf8) else { return }
+      Log.capture.warning(
+        "capture worker stderr display=\(display.displayId, privacy: .public) \(message, privacy: .public)"
+      )
+    }
+    _ = try supervisor.start(
+      CaptureWorkerProcessSpec(
+        executableURL: executable,
+        arguments: [
+          "capture-worker-stream",
+          "--display-id", String(display.displayId),
+          "--fps", String(max(0.2, fps)),
+        ],
+        standardOutput: stdout,
+        standardError: stderr
+      )
+    )
+  }
+
+  func stop() {
+    stdout.fileHandleForReading.readabilityHandler = nil
+    stderr.fileHandleForReading.readabilityHandler = nil
+    _ = supervisor.terminate(graceSeconds: 2)
+    dispatcher.finish()
+  }
+
+  func stats() -> CaptureDisplayStats {
+    statsRecorder.snapshot()
+  }
+}
+
+final class CaptureWorkerStreamLineReader: @unchecked Sendable {
+  private let lock = NSLock()
+  private var buffer = Data()
+  private let onPayload: @Sendable (CaptureWorkerFramePayload) -> Void
+  private let onDecodeError: @Sendable (String) -> Void
+
+  init(
+    onPayload: @escaping @Sendable (CaptureWorkerFramePayload) -> Void,
+    onDecodeError: @escaping @Sendable (String) -> Void
+  ) {
+    self.onPayload = onPayload
+    self.onDecodeError = onDecodeError
+  }
+
+  func append(_ data: Data) {
+    let lines = lock.withLock { () -> [Data] in
+      buffer.append(data)
+      var lines: [Data] = []
+      while let newline = buffer.firstIndex(of: 0x0A) {
+        lines.append(buffer[..<newline])
+        buffer.removeSubrange(...newline)
+      }
+      return lines
+    }
+    for line in lines where !line.isEmpty {
+      do {
+        onPayload(try CaptureWorkerFrameCodec.decodePayload(line))
+      } catch {
+        onDecodeError(error.localizedDescription)
+      }
+    }
+  }
+}
+
+final class CaptureWorkerStreamStatsRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private let display: DisplayDiagnostic
+  private var widthPx: Int
+  private var heightPx: Int
+  private var framesEnqueued = 0
+  private var framesDropped = 0
+  private var lastFrameAt: Date?
+
+  init(display: DisplayDiagnostic) {
+    self.display = display
+    self.widthPx = display.width
+    self.heightPx = display.height
+  }
+
+  func recordEnqueued(_ frame: CapturedFrame) {
+    lock.lock()
+    framesEnqueued += 1
+    widthPx = frame.cgImage.width
+    heightPx = frame.cgImage.height
+    lastFrameAt = frame.timestamp
+    lock.unlock()
+  }
+
+  func recordDropped() {
+    lock.lock()
+    framesDropped += 1
+    lock.unlock()
+  }
+
+  func snapshot() -> CaptureDisplayStats {
+    lock.lock()
+    defer { lock.unlock() }
+    return CaptureDisplayStats(
+      displayId: display.displayId,
+      widthPx: widthPx,
+      heightPx: heightPx,
+      displayScale: display.scale,
+      mainDisplay: display.isMain,
+      framesEnqueued: framesEnqueued,
+      framesDropped: framesDropped,
+      lastFrameAt: lastFrameAt
+    )
   }
 }
 

--- a/Sources/agentd/DiagnosticCLI.swift
+++ b/Sources/agentd/DiagnosticCLI.swift
@@ -108,7 +108,8 @@ enum DiagnosticProbeRunner {
 
 enum DiagnosticCLI {
   static let handledCommands = [
-    "list-displays", "capture-once", "capture-worker-once", "selftest", "help", "--help", "-h",
+    "list-displays", "capture-once", "capture-worker-once", "capture-worker-stream", "selftest",
+    "help", "--help", "-h",
   ]
 
   static func shouldHandle(_ arguments: [String]) -> Bool {
@@ -139,6 +140,8 @@ enum DiagnosticCLI {
       case .captureWorkerOnce(let options):
         let payload = try await CaptureWorkerDiagnostics.run(options: options)
         try writeJSON(payload, to: options.out)
+      case .captureWorkerStream(let options):
+        try await CaptureWorkerDiagnostics.runStream(options: options)
       }
       return 0
     } catch let error as DiagnosticCLIError {
@@ -185,6 +188,7 @@ enum DiagnosticCommand: Equatable {
   case listDisplays
   case captureOnce(CaptureOnceOptions)
   case captureWorkerOnce(CaptureOnceOptions)
+  case captureWorkerStream(CaptureStreamOptions)
   case selftest
 
   static func parse(_ arguments: [String]) throws -> DiagnosticCommand {
@@ -200,6 +204,8 @@ enum DiagnosticCommand: Equatable {
       return .captureOnce(try CaptureOnceOptions.parse(tail))
     case "capture-worker-once":
       return .captureWorkerOnce(try CaptureOnceOptions.parse(tail))
+    case "capture-worker-stream":
+      return .captureWorkerStream(try CaptureStreamOptions.parse(tail))
     case "selftest":
       guard tail.isEmpty else { throw DiagnosticCLIError.usage("selftest takes no flags") }
       return .selftest
@@ -245,6 +251,43 @@ struct CaptureOnceOptions: Equatable {
       index += 1
     }
     return options
+  }
+}
+
+struct CaptureStreamOptions: Equatable {
+  let displayId: UInt32
+  let fps: Double
+
+  static func parse(_ arguments: [String]) throws -> CaptureStreamOptions {
+    var displayId: UInt32?
+    var fps = 1.0
+    var index = 0
+    while index < arguments.count {
+      let flag = arguments[index]
+      switch flag {
+      case "--display-id":
+        index += 1
+        guard index < arguments.count, let value = UInt32(arguments[index]) else {
+          throw DiagnosticCLIError.usage("--display-id requires a UInt32 display id")
+        }
+        displayId = value
+      case "--fps":
+        index += 1
+        guard index < arguments.count, let value = Double(arguments[index]), value > 0 else {
+          throw DiagnosticCLIError.usage("--fps requires a positive number")
+        }
+        fps = value
+      case "--help", "-h":
+        throw DiagnosticCLIError.usage("")
+      default:
+        throw DiagnosticCLIError.usage("unknown capture-worker-stream flag '\(flag)'")
+      }
+      index += 1
+    }
+    guard let displayId else {
+      throw DiagnosticCLIError.usage("capture-worker-stream requires --display-id")
+    }
+    return CaptureStreamOptions(displayId: displayId, fps: fps)
   }
 }
 
@@ -482,7 +525,7 @@ enum CaptureOnceDiagnostics {
       }
     }
     do {
-      return try await CaptureService.captureOneFrame(
+      return try await ScreenCaptureService.captureOneFrame(
         targetFps: 2,
         captureAllDisplays: false,
         selectedDisplayIds: displayId.map { [$0] } ?? [],
@@ -506,6 +549,43 @@ enum CaptureWorkerDiagnostics {
       timeoutSeconds: 6
     )
     return try CaptureWorkerFrameCodec.payload(for: frame)
+  }
+
+  static func runStream(options: CaptureStreamOptions) async throws {
+    let available = try await DisplayDiagnostics.availableDisplayIds()
+    guard available.contains(options.displayId) else {
+      throw DiagnosticCLIError.usage(
+        "display id \(options.displayId) is not available; run agentd list-displays")
+    }
+    let writer = CaptureWorkerFrameWriter()
+    let service = ScreenCaptureService { frame in
+      do {
+        let payload = try CaptureWorkerFrameCodec.payload(for: frame)
+        let data = try CaptureWorkerFrameCodec.encodePayload(payload)
+        await writer.write(data)
+      } catch {
+        FileHandle.standardError.writeString(
+          "agentd: capture worker stream encode failed: \(error.localizedDescription)\n")
+      }
+    } onFrameDropped: { displayId in
+      FileHandle.standardError.writeString(
+        "agentd: capture worker stream dropped frame display=\(displayId)\n")
+    }
+    try await service.start(
+      targetFps: options.fps,
+      captureAllDisplays: false,
+      selectedDisplayIds: [options.displayId]
+    )
+    while !Task.isCancelled {
+      try await Task.sleep(nanoseconds: 60_000_000_000)
+    }
+    await service.stop()
+  }
+}
+
+actor CaptureWorkerFrameWriter {
+  func write(_ data: Data) {
+    FileHandle.standardOutput.write(data)
   }
 }
 

--- a/Tests/agentdTests/CaptureWorkerProtocolTests.swift
+++ b/Tests/agentdTests/CaptureWorkerProtocolTests.swift
@@ -44,6 +44,48 @@ final class CaptureWorkerProtocolTests: XCTestCase {
     }
   }
 
+  func testStreamLineReaderDecodesChunkedPayloads() throws {
+    let frame = CapturedFrame(
+      timestamp: Date(timeIntervalSince1970: 456),
+      cgImage: try Self.image(),
+      displayId: 99,
+      displayScale: 1,
+      mainDisplay: false
+    )
+    let payload = try CaptureWorkerFrameCodec.payload(for: frame)
+    let data = try CaptureWorkerFrameCodec.encodePayload(payload)
+    let split = data.index(data.startIndex, offsetBy: data.count / 2)
+    let recorder = PayloadRecorder()
+    let reader = CaptureWorkerStreamLineReader { payload in
+      recorder.append(payload)
+    } onDecodeError: { error in
+      recorder.fail(error)
+    }
+
+    reader.append(data[..<split])
+    XCTAssertEqual(recorder.payloads().count, 0)
+    reader.append(data[split...])
+
+    let payloads = recorder.payloads()
+    XCTAssertEqual(payloads.count, 1)
+    XCTAssertEqual(payloads.first?.displayId, 99)
+    XCTAssertEqual(recorder.errors(), [])
+  }
+
+  func testStreamLineReaderReportsMalformedLines() {
+    let recorder = PayloadRecorder()
+    let reader = CaptureWorkerStreamLineReader { payload in
+      recorder.append(payload)
+    } onDecodeError: { error in
+      recorder.fail(error)
+    }
+
+    reader.append(Data("not-json\n".utf8))
+
+    XCTAssertEqual(recorder.payloads().count, 0)
+    XCTAssertEqual(recorder.errors().count, 1)
+  }
+
   private static func image() throws -> CGImage {
     let width = 4
     let height = 4
@@ -67,5 +109,35 @@ final class CaptureWorkerProtocolTests: XCTestCase {
       throw CaptureWorkerProtocolError.imageEncodeFailed
     }
     return image
+  }
+}
+
+private final class PayloadRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var seenPayloads: [CaptureWorkerFramePayload] = []
+  private var seenErrors: [String] = []
+
+  func append(_ payload: CaptureWorkerFramePayload) {
+    lock.lock()
+    seenPayloads.append(payload)
+    lock.unlock()
+  }
+
+  func fail(_ error: String) {
+    lock.lock()
+    seenErrors.append(error)
+    lock.unlock()
+  }
+
+  func payloads() -> [CaptureWorkerFramePayload] {
+    lock.lock()
+    defer { lock.unlock() }
+    return seenPayloads
+  }
+
+  func errors() -> [String] {
+    lock.lock()
+    defer { lock.unlock() }
+    return seenErrors
   }
 }

--- a/Tests/agentdTests/DiagnosticCLITests.swift
+++ b/Tests/agentdTests/DiagnosticCLITests.swift
@@ -11,6 +11,7 @@ final class DiagnosticCLITests: XCTestCase {
     XCTAssertTrue(DiagnosticCLI.shouldHandle(["agentd", "list-displays"]))
     XCTAssertTrue(DiagnosticCLI.shouldHandle(["agentd", "capture-once"]))
     XCTAssertTrue(DiagnosticCLI.shouldHandle(["agentd", "capture-worker-once"]))
+    XCTAssertTrue(DiagnosticCLI.shouldHandle(["agentd", "capture-worker-stream"]))
     XCTAssertTrue(DiagnosticCLI.shouldHandle(["agentd", "selftest"]))
     XCTAssertFalse(DiagnosticCLI.shouldHandle(["agentd", "--local-only"]))
   }
@@ -47,6 +48,28 @@ final class DiagnosticCLITests: XCTestCase {
     }
     XCTAssertEqual(options.displayId, 7)
     XCTAssertTrue(options.noOCR)
+  }
+
+  func testCaptureWorkerStreamParserRequiresDisplayAndAcceptsFps() throws {
+    let command = try DiagnosticCommand.parse([
+      "capture-worker-stream", "--display-id", "7", "--fps", "0.5",
+    ])
+
+    guard case .captureWorkerStream(let options) = command else {
+      return XCTFail("expected capture-worker-stream")
+    }
+    XCTAssertEqual(options.displayId, 7)
+    XCTAssertEqual(options.fps, 0.5)
+  }
+
+  func testCaptureWorkerStreamParserRequiresDisplayId() {
+    XCTAssertThrowsError(try DiagnosticCommand.parse(["capture-worker-stream", "--fps", "1"])) {
+      error in
+      guard let cliError = error as? DiagnosticCLIError else {
+        return XCTFail("unexpected error: \(error)")
+      }
+      XCTAssertTrue(cliError.localizedDescription.contains("requires --display-id"))
+    }
   }
 
   func testCaptureOnceParserRejectsUnknownFlags() {

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -65,3 +65,8 @@ while keeping privacy decisions in the parent process. `--no-ocr` keeps the
 capture and scrubber path intact but records an empty OCR result. `--no-scrub`
 is recognized for operator muscle memory but deliberately refused; local
 diagnostics should not bypass the scrubber.
+
+Continuous menu-bar capture uses the same boundary: the parent starts one
+same-binary `capture-worker-stream` subprocess per selected display, reads
+newline-delimited frame payloads over stdout, and keeps policy, scrubber, OCR,
+batching, health checks, and TERM -> KILL supervision in the parent process.


### PR DESCRIPTION
## Summary
- route continuous `CaptureService` through supervised same-binary `capture-worker-stream` subprocesses, one per selected display
- keep ScreenCaptureKit frame production in the worker and keep policy, Accessibility text, scrubber, OCR, batching, diagnostics, and health restarts in the parent
- decode newline-delimited worker frame payloads in the parent with bounded buffering/backpressure accounting
- keep the direct ScreenCaptureKit implementation behind `ScreenCaptureService` for worker-owned capture and one-shot internals
- document the continuous worker boundary and add parser/stream decoder tests

Closes #53. This finishes the Codex Chronicle-style split: diagnostic one-shot and continuous menu-bar capture now both cross the supervised worker boundary; the parent still owns TERM -> KILL lifecycle and stale-stream restarts.

## Validation
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `git diff --check`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `scripts/package_app.sh`
- `timeout 10 .build/release/agentd selftest`
- `timeout 10 .build/release/agentd list-displays`
- live debug stream smoke: `.build/debug/agentd capture-worker-stream --display-id 1 --fps 1` emitted a frame payload over stdout
- live release stream smoke: `.build/release/agentd capture-worker-stream --display-id 1 --fps 1` emitted a frame payload over stdout
- `timeout 20 .build/release/agentd capture-once --no-ocr --out /tmp/agentd-stream-worker-capture-once.json`
