### PR TITLE
Fail closed on degraded browser capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ local inspection of the shipped arm64 `codex_chronicle` helper bundled with
 - The default local allowlist includes common developer surfaces, terminals,
   browsers, issue/chat tools, and LLM coding apps such as Codex, ChatGPT, and
   Claude Desktop.
+- Browser capture has Chronicle-style metadata hardening: private/incognito and
+  meeting browser windows are denied, and browser frames with missing focused
+  window titles fail closed instead of being treated as normal allowed windows.
 - Menu-bar UI: pause/resume (`⌃⌥⌘P`), flush now (`⌃⌥⌘F`), reveal batches dir,
   diagnostics report (`⌃⌥⌘D`), delete queued batches, launch-at-login, quit.
 

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -433,7 +433,11 @@ struct AgentConfig: Codable, Sendable {
     "com.anthropic.claudefordesktop",
     "company.thebrowser.Browser",  // Arc
     "com.google.Chrome",
+    "com.google.Chrome.beta",
+    "com.google.Chrome.canary",
+    "com.google.Chrome.dev",
     "com.apple.Safari",
+    "com.apple.SafariTechnologyPreview",
     "org.mozilla.firefox",
     "com.linear.LinearDesktop",
     "com.tinyspeck.slackmacgap",

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -547,6 +547,9 @@ struct PrivacyDecisionCache: Sendable {
     {
       return (false, "allowlist_miss", .deniedApp)
     }
+    if let browserReason = BrowserPrivacyObservation.reason(context: context) {
+      return (false, browserReason, .deniedApp)
+    }
     if signature.pathClass.hasPrefix("denied:") {
       return (false, "denied_path", .deniedPath)
     }
@@ -572,6 +575,64 @@ struct PrivacyDecisionCache: Sendable {
   }
 }
 
+enum BrowserPrivacyObservation {
+  static func reason(context: WindowContext) -> String? {
+    guard isBrowserBundle(context.bundleId) else { return nil }
+    let title = context.windowTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !title.isEmpty else { return "browser_window_missing_title" }
+
+    let titleLower = title.lowercased()
+    if privateWindowTitleFragments.contains(where: { titleLower.contains($0) }) {
+      return "browser_private_window"
+    }
+    if meetingTitleFragments.contains(where: { titleLower.contains($0) }) {
+      return "browser_meeting_window"
+    }
+    if isMeetingURL(context.documentPath) || isMeetingURL(title) {
+      return "browser_meeting_window"
+    }
+    return nil
+  }
+
+  private static func isBrowserBundle(_ bundleId: String) -> Bool {
+    browserBundleIds.contains(bundleId)
+  }
+
+  private static func isMeetingURL(_ value: String?) -> Bool {
+    guard let value, !value.isEmpty else { return false }
+    let lower = value.lowercased()
+    guard lower.contains("meet.google.com") else { return false }
+    guard lower.contains("://") else { return true }
+    guard let components = URLComponents(string: lower),
+      let host = components.host
+    else {
+      return true
+    }
+    return host == "meet.google.com" || host.hasSuffix(".meet.google.com")
+  }
+
+  private static let browserBundleIds: Set<String> = [
+    "company.thebrowser.Browser",
+    "com.apple.Safari",
+    "com.apple.SafariTechnologyPreview",
+    "com.google.Chrome",
+    "com.google.Chrome.beta",
+    "com.google.Chrome.canary",
+    "com.google.Chrome.dev",
+    "org.mozilla.firefox",
+  ]
+
+  private static let privateWindowTitleFragments = [
+    "private browsing",
+    "incognito",
+  ]
+
+  private static let meetingTitleFragments = [
+    "meet - ",
+    "google meet",
+  ]
+}
+
 struct PrivacyObservationSignature: Sendable, Hashable {
   let bundleId: String
   let pid: pid_t
@@ -589,7 +650,8 @@ struct PrivacyObservationSignature: Sendable, Hashable {
 
   static func titleClass(_ title: String, pausePatterns: [String]) -> String {
     guard !title.isEmpty else { return "missing" }
-    if let match = pausePatterns.first(where: { title.contains($0) }) {
+    let lowerTitle = title.lowercased()
+    if let match = pausePatterns.first(where: { lowerTitle.contains($0.lowercased()) }) {
       return "pause:\(stableClassHash(match))"
     }
     return "normal"

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -550,6 +550,62 @@ final class PipelineTests: XCTestCase {
     XCTAssertNotEqual(normal.observationId, privateWindow.observationId)
   }
 
+  func testPrivacyDecisionCacheTreatsPauseTitlePatternsCaseInsensitively() {
+    var cache = PrivacyDecisionCache()
+    let cfg = Self.config()
+
+    let decision = cache.decision(
+      for: Self.context(windowTitle: "chrome - INCOGNITO"),
+      config: cfg
+    )
+
+    XCTAssertFalse(decision.allowed)
+    XCTAssertEqual(decision.reasonCode, "pause_title_pattern")
+    XCTAssertEqual(decision.dropKind, .deniedApp)
+  }
+
+  func testBrowserPrivacyObservationFailsClosedOnMissingTitle() {
+    var cache = PrivacyDecisionCache()
+    var cfg = Self.config()
+    cfg.allowedBundleIds += ["com.google.Chrome"]
+
+    let decision = cache.decision(
+      for: Self.context(bundleId: "com.google.Chrome", windowTitle: ""),
+      config: cfg
+    )
+
+    XCTAssertFalse(decision.allowed)
+    XCTAssertEqual(decision.reasonCode, "browser_window_missing_title")
+    XCTAssertEqual(decision.dropKind, .deniedApp)
+  }
+
+  func testBrowserPrivacyObservationDeniesPrivateAndMeetWindows() {
+    var cache = PrivacyDecisionCache()
+    var cfg = Self.config()
+    cfg.allowedBundleIds += ["com.apple.SafariTechnologyPreview", "com.google.Chrome.canary"]
+
+    let privateDecision = cache.decision(
+      for: Self.context(
+        bundleId: "com.apple.SafariTechnologyPreview",
+        windowTitle: "Private Browsing - Docs"
+      ),
+      config: cfg
+    )
+    let meetDecision = cache.decision(
+      for: Self.context(
+        bundleId: "com.google.Chrome.canary",
+        windowTitle: "Sprint Review",
+        documentPath: "https://meet.google.com/abc-defg-hij"
+      ),
+      config: cfg
+    )
+
+    XCTAssertFalse(privateDecision.allowed)
+    XCTAssertEqual(privateDecision.reasonCode, "browser_private_window")
+    XCTAssertFalse(meetDecision.allowed)
+    XCTAssertEqual(meetDecision.reasonCode, "browser_meeting_window")
+  }
+
   func testPrivacyDecisionCachePolicyInvalidationChangesObservationId() {
     var cache = PrivacyDecisionCache()
     let cfg = Self.config()

--- a/docs/secret-scrub.md
+++ b/docs/secret-scrub.md
@@ -21,3 +21,8 @@ add allowlists or denylists, but the built-in password managers, keychain paths,
 private/incognito/meeting title pauses, denied paths, and content-aware secret
 scrub remain local fail-closed controls.
 
+Browser windows get an additional Chronicle-parity privacy check before OCR or
+content scrub. Supported browser bundle IDs fail closed when Accessibility
+cannot provide a focused-window title, and private/incognito or meeting browser
+windows are denied by browser-window observation even if the bundle is otherwise
+allowed. This keeps degraded browser metadata from becoming an accidental allow.


### PR DESCRIPTION
## Summary
- add a Chronicle-style browser observation privacy rail for allowed browser bundles
- fail closed when browser Accessibility metadata lacks a focused-window title
- deny browser private/incognito and Google Meet windows even when the browser bundle is otherwise allowed
- make cached pause-title matching case-insensitive and add Chrome beta/canary/dev plus Safari Technology Preview to default local browser coverage

Further #39 parity work from the refreshed `/Applications/Codex.app/Contents/Resources/codex_chronicle` binary pass. Chronicle carries explicit browser observation / private-window / missing-metadata concepts; this adds the equivalent fail-closed client-side rail while preserving agentd's stronger content scrub.

## Validation
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `git diff --check`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
