### PR TITLE
Add Chronicle parity audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is the desktop component of the work tracked in
 | Evidence model | LLM-summarized markdown memories under `$CODEX_HOME/memories_extensions/chronicle/` plus temporary sparse frames | Frame batches with OCR, window/path metadata, pHash dedupe, drop counts, and optional sparse local frame artifacts |
 | Privacy filter | Window-identity filters for browser private/incognito and meeting surfaces | Window identity, app/path policy, pause windows, and content scrub for AWS/GCP/SSH/JWT/GitHub/Anthropic/OpenAI/Slack/Stripe-style secrets |
 | Encryption at rest | Temporary JPEG/OCR sidecars and plaintext markdown memories on local disk | `.agentdbatch` AES-GCM by default in remote or Secret Broker mode, Keychain-managed keys, and local-only opt-in encryption |
-| Crash isolation | ScreenCaptureKit capture work runs through child-process paths with termination handling | In-process ScreenCaptureKit today; out-of-process capture supervisor tracked in [#53](https://github.com/evalops/agentd/issues/53) |
+| Crash isolation | ScreenCaptureKit capture work runs through child-process paths with termination handling | Continuous and one-shot ScreenCaptureKit capture run through supervised same-binary worker subprocesses with TERM -> KILL shutdown |
 | Prompt-injection exposure | Observed screen content is summarized by an LLM with prompt-level untrusted-input framing | Observed content is not fed to an on-device LLM by default; any future summarizer belongs in the controlled server pipeline |
 | Distribution | Notarized `Codex.app` bundle | Notarized `EvalOps agentd.app` release workflow and permission-smoke evidence |
 
@@ -107,6 +107,7 @@ swift run agentd -- list-displays
 swift run agentd -- capture-once --no-ocr
 swift test
 python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
+python3 scripts/chronicle_parity_audit.py # compare installed Codex Chronicle helper
 scripts/package_app.sh # release .app bundle with hardened runtime signing
 scripts/permission_smoke.sh --no-launch # generate permission-smoke evidence template
 ./script/build_and_run.sh --verify # package, launch, and verify the menu app process

--- a/docs/chronicle-parity-audit.md
+++ b/docs/chronicle-parity-audit.md
@@ -1,0 +1,26 @@
+# Chronicle Parity Audit
+
+`scripts/chronicle_parity_audit.py` compares the installed Codex Chronicle
+helper against this repo. It is intentionally local because Codex.app can update
+outside agentd release cadence.
+
+Run it after Codex.app updates or before a Chronicle-parity planning pass:
+
+```sh
+python3 scripts/chronicle_parity_audit.py
+python3 scripts/chronicle_parity_audit.py --json
+python3 scripts/chronicle_parity_audit.py --strict
+```
+
+By default it reads
+`/Applications/Codex.app/Contents/Resources/codex_chronicle`, mines stable
+binary strings, and maps observed Chronicle capabilities to agentd source,
+tests, or docs evidence. `--strict` exits non-zero when an observed Chronicle
+capability is only partial or missing locally.
+
+The audit is not a substitute for source review. It is a drift tripwire for the
+specific Chronicle traits we care about: worker isolation, termination behavior,
+display diagnostics, sparse local artifacts, material-text-change sampling,
+browser-window privacy handling, meeting exclusion, safe-to-persist semantics,
+summarizer prompt-injection posture, macOS API availability, and the deliberate
+choice to keep audio capture out of scope.

--- a/docs/macos-availability.md
+++ b/docs/macos-availability.md
@@ -4,8 +4,8 @@ agentd's supported deployment floor is macOS 14.0. The Swift package declares
 `.macOS(.v14)` in `Package.swift`, and the packaged app declares
 `LSMinimumSystemVersion` as `14.0` in `support/Info.plist`.
 
-This audit covers the macOS framework APIs that gate capture, OCR, permissions,
-window context, and launch-at-login.
+This audit covers the macOS framework APIs that gate ScreenCaptureKit capture,
+OCR, permissions, window context, and launch-at-login.
 
 | API | Call site | SDK availability | agentd posture |
 | --- | --- | --- | --- |

--- a/scripts/chronicle_parity_audit.py
+++ b/scripts/chronicle_parity_audit.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BUSL-1.1
+"""Audit local agentd parity against the installed Codex Chronicle binary.
+
+The Codex app updates independently of agentd. This script mines stable strings
+from the local `codex_chronicle` binary, then checks whether agentd still has
+the corresponding implementation or documented stronger alternative.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_BINARY = Path("/Applications/Codex.app/Contents/Resources/codex_chronicle")
+
+
+@dataclass(frozen=True)
+class Probe:
+    path: str
+    needles: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Capability:
+    name: str
+    chronicle_needles: tuple[str, ...]
+    agentd_probes: tuple[Probe, ...]
+    note: str
+
+
+CAPABILITIES: tuple[Capability, ...] = (
+    Capability(
+        name="single-instance runtime lock",
+        chronicle_needles=("codex_chronicle.lock", "acquired single-instance lock"),
+        agentd_probes=(Probe("Sources/agentd/AgentdRuntimeLock.swift", ("AgentdRuntimeLock",)),),
+        note="Prevents competing capture processes from fighting ScreenCaptureKit.",
+    ),
+    Capability(
+        name="out-of-process ScreenCaptureKit worker",
+        chronicle_needles=(
+            "capture-screenshot-child",
+            "ScreenCaptureKit child",
+            "child_termination_guard",
+        ),
+        agentd_probes=(
+            Probe("Sources/agentd/CaptureWorkerSupervisor.swift", ("CaptureWorkerSupervisor",)),
+            Probe("Sources/agentd/DiagnosticCLI.swift", ("capture-worker-stream",)),
+            Probe("Sources/agentd/CaptureService.swift", ("CaptureWorkerStreamClient",)),
+        ),
+        note="Keeps ScreenCaptureKit crashes/leaks outside the menu-bar parent.",
+    ),
+    Capability(
+        name="bounded child termination",
+        chronicle_needles=("failed to terminate", "and killed process", "SIGTERM"),
+        agentd_probes=(
+            Probe("Sources/agentd/CaptureWorkerSupervisor.swift", ("SIGKILL", "terminate")),
+            Probe("Tests/agentdTests/CaptureWorkerSupervisorTests.swift", ("testEscalatesToKill",)),
+        ),
+        note="TERM first, then force kill when a capture child ignores shutdown.",
+    ),
+    Capability(
+        name="display-list diagnostic child",
+        chronicle_needles=("list-displays-child", "display-list child"),
+        agentd_probes=(
+            Probe("Sources/agentd/DiagnosticCLI.swift", ("list-displays", "DisplayDiagnostics")),
+            Probe("Tests/agentdTests/DiagnosticCLITests.swift", ("testListDisplays",)),
+        ),
+        note="Support path for display ids and permission/display probe state.",
+    ),
+    Capability(
+        name="per-display sparse artifacts",
+        chronicle_needles=(".capture.json", ".ocr.jsonl", "-display-"),
+        agentd_probes=(
+            Probe("Sources/agentd/SparseFrameStore.swift", ("SparseFrameStore", ".ocr.jsonl")),
+            Probe("Tests/agentdTests/PipelineTests.swift", ("testSparseFrameStore",)),
+        ),
+        note="Local opt-in artifacts mirror Chronicle shape after agentd privacy gates pass.",
+    ),
+    Capability(
+        name="material text change sampler",
+        chronicle_needles=("one JSON object per material text change", ".ocr.jsonl"),
+        agentd_probes=(
+            Probe("Sources/agentd/Pipeline.swift", ("OcrDiffSampler",)),
+            Probe("Tests/agentdTests/PipelineTests.swift", ("testOcrDiffSampler",)),
+        ),
+        note="Optional OCR-diff override catches material text changes after pHash dedupe.",
+    ),
+    Capability(
+        name="browser private and missing-title handling",
+        chronicle_needles=(
+            "BrowserWindowObservation",
+            "Private Browsing",
+            "Incognito",
+            "browser_observations",
+        ),
+        agentd_probes=(
+            Probe("Sources/agentd/Pipeline.swift", ("BrowserPrivacyObservation",)),
+            Probe("Tests/agentdTests/PipelineTests.swift", ("testBrowserPrivacyObservation",)),
+        ),
+        note="Agentd keeps content scrub and adds fail-closed browser metadata handling.",
+    ),
+    Capability(
+        name="meeting surface exclusion",
+        chronicle_needles=("meet.google.com", "Google Meet"),
+        agentd_probes=(
+            Probe("Sources/agentd/Config.swift", ("meet.google.com", "Google Meet")),
+            Probe("Sources/agentd/Pipeline.swift", ("browser_meeting_window",)),
+        ),
+        note="Meeting windows are denied via pause patterns and browser observation.",
+    ),
+    Capability(
+        name="safe-to-persist audit semantics",
+        chronicle_needles=("safe_to_persist", "privacy_filter"),
+        agentd_probes=(
+            Probe("Sources/agentd/Pipeline.swift", ("DropCounts", "reasonCode")),
+            Probe("docs/secret-scrub.md", ("fail-closed",)),
+        ),
+        note="Agentd exposes deny/drop counts locally; proto-level per-frame flags live server-side.",
+    ),
+    Capability(
+        name="prompt-injection-aware summarizer posture",
+        chronicle_needles=(
+            "UNTRUSTED OBSERVED INPUT",
+            "--ephemeral",
+            "--sandbox",
+            "read-only",
+        ),
+        agentd_probes=(
+            Probe("README.md", ("Prompt-injection",)),
+            Probe("docs/chronicle-comparison.md", ("Prompt-injection",)),
+        ),
+        note="Agentd does not run a local LLM summarizer; docs preserve the architectural boundary.",
+    ),
+    Capability(
+        name="macOS ScreenCaptureKit availability guard",
+        chronicle_needles=(
+            "captureImageInRect requires macOS 15.2+",
+            "captureScreenshot requires macOS 26.0+",
+        ),
+        agentd_probes=(
+            Probe("scripts/macos_availability_audit.py", ("ScreenCaptureKit",)),
+            Probe("docs/macos-availability.md", ("ScreenCaptureKit",)),
+        ),
+        note="Availability inventory keeps post-floor APIs out of agentd by default.",
+    ),
+    Capability(
+        name="audio capture intentionally out of scope",
+        chronicle_needles=("Failed to start audio capture", "Failed to start microphone capture"),
+        agentd_probes=(
+            Probe("docs/chronicle-comparison.md", ("audio capture", "should not copy")),
+        ),
+        note="Chronicle has audio strings; agentd intentionally remains screen-only.",
+    ),
+)
+
+
+def run_strings(binary: Path) -> str:
+    try:
+        output = subprocess.check_output(["strings", "-a", str(binary)], text=True)
+    except FileNotFoundError:
+        raise SystemExit("strings(1) is required") from None
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(f"failed to read strings from {binary}: {exc}") from None
+    return output
+
+
+def read_repo_text(root: Path, probe: Probe) -> str:
+    path = root / probe.path
+    if not path.exists():
+        return ""
+    return path.read_text(errors="replace")
+
+
+def all_present(haystack: str, needles: tuple[str, ...]) -> bool:
+    return all(needle in haystack for needle in needles)
+
+
+def evaluate(binary_strings: str, root: Path) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for capability in CAPABILITIES:
+        chronicle_present = all_present(binary_strings, capability.chronicle_needles)
+        agentd_evidence = [
+            probe.path
+            for probe in capability.agentd_probes
+            if all_present(read_repo_text(root, probe), probe.needles)
+        ]
+        if not chronicle_present:
+            status = "not_observed"
+        elif len(agentd_evidence) == len(capability.agentd_probes):
+            status = "covered"
+        elif agentd_evidence:
+            status = "partial"
+        else:
+            status = "gap"
+        rows.append(
+            {
+                "name": capability.name,
+                "status": status,
+                "chronicleEvidence": list(capability.chronicle_needles),
+                "agentdEvidence": agentd_evidence,
+                "note": capability.note,
+            }
+        )
+    return rows
+
+
+def print_markdown(rows: list[dict[str, object]]) -> None:
+    print("| Capability | Status | Agentd evidence | Note |")
+    print("| --- | --- | --- | --- |")
+    for row in rows:
+        evidence = ", ".join(row["agentdEvidence"]) if row["agentdEvidence"] else "none"
+        print(f"| {row['name']} | {row['status']} | {evidence} | {row['note']} |")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", type=Path, default=DEFAULT_BINARY)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of Markdown")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit non-zero when an observed Chronicle capability is not fully covered",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.binary.exists():
+        raise SystemExit(f"Chronicle binary not found: {args.binary}")
+    if not (args.repo_root / "Package.swift").exists():
+        raise SystemExit(f"repo root does not look like agentd: {args.repo_root}")
+
+    rows = evaluate(run_strings(args.binary), args.repo_root)
+    if args.json:
+        print(json.dumps(rows, indent=2, sort_keys=True))
+    else:
+        print_markdown(rows)
+    if args.strict and any(row["status"] in {"gap", "partial"} for row in rows):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add a local `scripts/chronicle_parity_audit.py` drift checker for the installed Codex Chronicle binary
- map mined Chronicle strings to agentd source/test/docs evidence for worker isolation, sparse artifacts, OCR diff, browser privacy, safe-to-persist, API availability, and intentional no-audio posture
- update README/docs so the comparison reflects the merged worker subprocess architecture

Further #39 parity tooling. This gives us a repeatable way to re-check parity when Codex.app updates.

## Validation
- `python3 -m py_compile scripts/chronicle_parity_audit.py`
- `python3 scripts/chronicle_parity_audit.py`
- `python3 scripts/chronicle_parity_audit.py --strict`
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `git diff --check`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
