### PR TITLE
Improve TCC artifact smoke diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ capture startup in the background so a full relaunch is not required.
 For ad-hoc local builds, approve the exact packaged app you are testing and use
 `./script/build_and_run.sh --tcc-verify`; rebuilding changes the CDHash and can
 make macOS treat it as a different TCC client.
+For a downloaded/notarized workflow artifact, verify the artifact in place with
+`AGENTD_APP_PATH="/path/to/EvalOps agentd.app" ./script/build_and_run.sh --tcc-verify`
+so the tested path/signature matches the System Settings grant.
 `--local-batch-verify` also relaunches without rebuilding, activates Codex by
 default, and prints only frame counts/metadata lengths so OCR text is not echoed
 into the terminal. Set `AGENTD_SMOKE_FOREGROUND_APP=Terminal` or another

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -6,10 +6,12 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 app_name="EvalOps agentd"
 process_name="agentd"
 bundle_id="dev.evalops.agentd"
-app_bundle="$root/dist/$app_name.app"
+default_app_bundle="$root/dist/$app_name.app"
+app_bundle="${AGENTD_APP_PATH:-"$default_app_bundle"}"
 
 usage() {
   echo "usage: $0 [run|--debug|--logs|--telemetry|--verify|--reuse|--tcc-verify|--local-batch-verify|--permission-smoke]" >&2
+  echo "       set AGENTD_APP_PATH to verify a downloaded/notarized app bundle without copying it into dist/" >&2
   exit 2
 }
 
@@ -24,9 +26,22 @@ build_app() {
 require_existing_app() {
   if [[ ! -x "$app_bundle/Contents/MacOS/$process_name" ]]; then
     echo "Missing packaged app: $app_bundle" >&2
-    echo "Run $0 once before no-rebuild verification." >&2
+    echo "Run $0 once before no-rebuild verification, or set AGENTD_APP_PATH to an existing app bundle." >&2
     exit 66
   fi
+}
+
+describe_app_identity() {
+  echo "App bundle: $app_bundle" >&2
+  if codesign_details="$(codesign -dvvv "$app_bundle" 2>&1)"; then
+    printf '%s\n' "$codesign_details" \
+      | sed -n 's/^Authority=/Codesign authority: /p; s/^CDHash=/Codesign CDHash: /p; s/^TeamIdentifier=/Team identifier: /p; s/^Notarization Ticket=/Notarization ticket: /p' >&2
+  else
+    printf '%s\n' "$codesign_details" >&2
+  fi
+  codesign -d -r- "$app_bundle" 2>&1 \
+    | sed -n 's/^# designated => /Designated requirement: /p; s/^designated => /Designated requirement: /p' >&2 || true
+  spctl -a -vv "$app_bundle" >&2 || true
 }
 
 open_app() {
@@ -89,7 +104,10 @@ case "$mode" in
     if grep -q 'capture started' <<<"$recent_logs"; then
       echo "TCC verification passed: capture started."
     elif grep -q 'capture start failed' <<<"$recent_logs"; then
-      echo "TCC verification failed: capture did not start. If this app is ad-hoc signed, approve this exact packaged copy and rerun --tcc-verify without rebuilding." >&2
+      describe_app_identity
+      echo "TCC verification failed: capture did not start." >&2
+      echo "Approve this exact app bundle in Screen & System Audio Recording and Accessibility, then rerun with the same AGENTD_APP_PATH without rebuilding or moving the app." >&2
+      echo "If System Settings already shows EvalOps agentd.app enabled, the visible row may be a stale path/signature entry; remove it and re-add this exact app bundle before rerunning." >&2
       exit 78
     else
       echo "TCC verification inconclusive: no capture start/failure log found." >&2

--- a/scripts/permission_smoke.sh
+++ b/scripts/permission_smoke.sh
@@ -50,7 +50,10 @@ codesign_summary="$(
     | sed -n 's/^Authority=//p' \
     | awk 'NF { if (seen++) printf ", "; printf "%s", $0 } END { if (seen) print "" }'
 )"
-codesign_requirement="$(codesign -d -r- "$app_path" 2>&1 | sed -n 's/^# designated => //p')"
+codesign_requirement="$(
+  codesign -d -r- "$app_path" 2>&1 \
+    | sed -n 's/^# designated => //p; s/^designated => //p'
+)"
 codesign_cdhash="$(
   printf '%s\n' "$codesign_details" \
     | sed -n 's/^CDHash=//p; s/^CandidateCDHash sha256=//p' \
@@ -79,8 +82,14 @@ approval to the exact CDHash above. Do not rebuild between granting permissions
 and verification. After approving this exact packaged app, relaunch it with:
 
 \`\`\`
-./script/build_and_run.sh --tcc-verify
+AGENTD_APP_PATH="${app_path}" ./script/build_and_run.sh --tcc-verify
 \`\`\`
+
+If System Settings shows "EvalOps agentd.app" enabled but capture still fails
+with a TCC denial, remove the existing Screen & System Audio Recording and
+Accessibility rows and re-add the exact app path above. macOS can retain a
+stale path/signature row with the same display name after ad-hoc or downloaded
+artifact changes.
 
 ## Checks
 
@@ -101,7 +110,7 @@ echo "Wrote $report_path"
 if [[ "$launch" == "1" ]]; then
   open "$app_path"
   echo "Opened $app_path"
-  echo "Grant Screen Recording and Accessibility in System Settings, then run ./script/build_and_run.sh --tcc-verify without rebuilding."
+  echo "Grant Screen Recording and Accessibility in System Settings, then run AGENTD_APP_PATH=\"$app_path\" ./script/build_and_run.sh --tcc-verify without rebuilding or moving the app."
 else
   echo "Skipped launch because --no-launch was supplied."
 fi


### PR DESCRIPTION
## Summary
- let `script/build_and_run.sh` verify a downloaded/notarized app in place via `AGENTD_APP_PATH`
- print app path, CDHash, codesign authorities, designated requirement, notarization/Gatekeeper evidence when TCC capture startup fails
- update permission-smoke docs for stale System Settings rows with the same `EvalOps agentd.app` display name

Follows #25 after reproducing a notarized-artifact TCC denial where System Settings showed an enabled `EvalOps agentd.app` row but ScreenCaptureKit still rejected the exact downloaded artifact.

## Validation
- `shellcheck script/build_and_run.sh scripts/permission_smoke.sh scripts/package_app.sh`
- `AGENTD_APP_PATH='/tmp/agentd-notarized-smoke-25095755314/EvalOps agentd.app' AGENTD_SMOKE_REPORT=/tmp/agentd-notarized-smoke-25095755314/permission-smoke-report-v3.md scripts/permission_smoke.sh --no-launch`
- `AGENTD_APP_PATH='/tmp/agentd-notarized-smoke-25095755314/EvalOps agentd.app' ./script/build_and_run.sh --tcc-verify` (expected local TCC denial; now prints stable identity diagnostics and stale-row remediation)
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `python3 scripts/chronicle_parity_audit.py --strict`
- `git diff --check`
