### PR TITLE
Add multi-display smoke helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ swift run agentd -- capture-once --no-ocr
 swift test
 python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
 python3 scripts/chronicle_parity_audit.py # compare installed Codex Chronicle helper
+scripts/multi_display_smoke.sh --phase before-attach # capture #34 display evidence
 scripts/package_app.sh # release .app bundle with hardened runtime signing
 scripts/permission_smoke.sh --no-launch # generate permission-smoke evidence template
 ./script/build_and_run.sh --verify # package, launch, and verify the menu app process
@@ -161,6 +162,11 @@ it:
 version/checksum/codesign evidence in `dist/permission-smoke-report.md`, and
 opens the app unless `--no-launch` is supplied. Use it for the hardware-backed
 Screen Recording and Accessibility permission smoke.
+`scripts/multi_display_smoke.sh` records repeatable `list-displays` snapshots
+for before-attach, after-attach, capture-all, and after-detach phases. It writes
+bounded JSON and a Markdown report without screenshots or OCR text, and
+`--require-multiple` fails when the attached-display phase still sees fewer
+than two displays.
 
 Launch-at-login uses native `SMAppService.mainApp` from the menu bar; agentd
 does not install LaunchAgent plists.

--- a/scripts/multi_display_smoke.sh
+++ b/scripts/multi_display_smoke.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/multi_display_smoke.sh [--phase NAME] [--require-multiple] [--no-build]
+
+Records a bounded multi-display smoke snapshot for evalops/agentd#34.
+
+Examples:
+  scripts/multi_display_smoke.sh --phase before-attach
+  scripts/multi_display_smoke.sh --phase after-attach --require-multiple
+  scripts/multi_display_smoke.sh --phase after-detach
+
+Environment:
+  AGENTD_AGENTD_BIN               Existing agentd binary to use.
+  AGENTD_MULTI_DISPLAY_REPORT     Markdown report path.
+USAGE
+}
+
+phase="snapshot"
+require_multiple=0
+build=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --phase)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        usage >&2
+        exit 64
+      fi
+      phase="$2"
+      shift 2
+      ;;
+    --require-multiple)
+      require_multiple=1
+      shift
+      ;;
+    --no-build)
+      build=0
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+report_path="${AGENTD_MULTI_DISPLAY_REPORT:-"$root/dist/multi-display-smoke-report.md"}"
+snapshot_dir="$(dirname "$report_path")/multi-display-smoke"
+bin="${AGENTD_AGENTD_BIN:-"$root/.build/debug/agentd"}"
+timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+safe_phase="$(printf '%s' "$phase" | tr -c 'A-Za-z0-9._-' '-')"
+json_path="$snapshot_dir/${timestamp}-${safe_phase}.json"
+
+if [[ "$build" == "1" && -z "${AGENTD_AGENTD_BIN:-}" ]]; then
+  (cd "$root" && swift build)
+fi
+
+if [[ ! -x "$bin" ]]; then
+  echo "Missing agentd binary: $bin" >&2
+  echo "Run swift build, or set AGENTD_AGENTD_BIN." >&2
+  exit 66
+fi
+
+mkdir -p "$snapshot_dir"
+"$bin" list-displays > "$json_path"
+
+display_count="$(
+  python3 - "$json_path" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+print(len(payload.get("displays", [])))
+PY
+)"
+
+summary="$(
+  python3 - "$json_path" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+permissions = payload.get("permissions", {})
+print(f"- Accessibility trusted: {permissions.get('accessibilityTrusted')}")
+print(f"- Screen capture trusted: {permissions.get('screenCaptureTrusted')}")
+print(f"- Display count: {len(payload.get('displays', []))}")
+for display in payload.get("displays", []):
+    bounds = display.get("bounds", {})
+    print(
+        "- Display {display_id}: {name}, {width}x{height}, scale={scale}, "
+        "main={main}, bounds=({x},{y},{bw}x{bh})".format(
+            display_id=display.get("displayId"),
+            name=display.get("name", "unknown"),
+            width=display.get("width"),
+            height=display.get("height"),
+            scale=display.get("scale"),
+            main=display.get("isMain"),
+            x=bounds.get("x"),
+            y=bounds.get("y"),
+            bw=bounds.get("width"),
+            bh=bounds.get("height"),
+        )
+    )
+PY
+)"
+
+if [[ ! -f "$report_path" ]]; then
+  mkdir -p "$(dirname "$report_path")"
+  cat > "$report_path" <<'REPORT'
+# agentd Multi-Display Smoke Report
+
+Use this report for evalops/agentd#34. Recommended phases:
+
+1. `before-attach`: run with the normal desktop display setup.
+2. `after-attach`: attach the external display, wait for macOS display
+   arrangement to settle, then run with `--require-multiple`.
+3. `capture-all`: enable `captureAllDisplays` through local config or managed
+   policy, run agentd long enough to capture at least one batch, then attach
+   diagnostics/batch metadata counts without raw OCR.
+4. `after-detach`: detach the external display and rerun to confirm diagnostics
+   return to the expected single-display shape without restarting the machine.
+
+Do not paste raw OCR text or screenshots into this report.
+
+REPORT
+fi
+
+cat >> "$report_path" <<REPORT
+## ${phase} (${timestamp})
+
+- Snapshot JSON: ${json_path}
+- agentd binary: ${bin}
+${summary}
+
+\`\`\`json
+$(cat "$json_path")
+\`\`\`
+
+REPORT
+
+echo "Wrote $json_path"
+echo "Updated $report_path"
+
+if [[ "$require_multiple" == "1" && "$display_count" -lt 2 ]]; then
+  echo "Expected at least two displays for phase '$phase', found $display_count." >&2
+  exit 78
+fi


### PR DESCRIPTION
## Summary
- add `scripts/multi_display_smoke.sh` to record bounded `list-displays` snapshots for #34 hardware phases
- generate a Markdown report plus per-phase JSON without screenshots or OCR text
- support `--require-multiple` so after-attach runs fail loudly when only one display is visible

This does not close #34 by itself; it makes the remaining manual multi-monitor pass reproducible and harder to accidentally satisfy from a single-display machine.

## Validation
- `shellcheck scripts/multi_display_smoke.sh script/build_and_run.sh scripts/permission_smoke.sh scripts/package_app.sh`
- `scripts/multi_display_smoke.sh --help`
- `AGENTD_MULTI_DISPLAY_REPORT=/tmp/agentd-multi-display-smoke.md scripts/multi_display_smoke.sh --phase single-display-baseline`
- `AGENTD_MULTI_DISPLAY_REPORT=/tmp/agentd-multi-display-smoke-require.md scripts/multi_display_smoke.sh --phase after-attach --require-multiple --no-build` (expected exit 78 on this one-display machine)
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `python3 scripts/chronicle_parity_audit.py --strict`
- `git diff --check`

Local baseline saw one display: Built-in Retina Display, display id 1, 1800x1169, accessibility and screen-capture probes trusted.
