### PR TITLE
Install permission smoke app to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,12 @@ capture startup in the background so a full relaunch is not required.
 For ad-hoc local builds, approve the exact packaged app you are testing and use
 `./script/build_and_run.sh --tcc-verify`; rebuilding changes the CDHash and can
 make macOS treat it as a different TCC client.
-For a downloaded/notarized workflow artifact, verify the artifact in place with
-`AGENTD_APP_PATH="/path/to/EvalOps agentd.app" ./script/build_and_run.sh --tcc-verify`
-so the tested path/signature matches the System Settings grant.
+For a downloaded/notarized workflow artifact, run
+`AGENTD_APP_PATH="/path/to/EvalOps agentd.app" scripts/permission_smoke.sh`.
+The smoke helper installs that artifact to `/Applications/EvalOps agentd.app`
+before launch so the System Settings grant binds to a stable path/signature.
+Then verify the same installed bundle with
+`AGENTD_APP_PATH="/Applications/EvalOps agentd.app" ./script/build_and_run.sh --tcc-verify`.
 `--local-batch-verify` also relaunches without rebuilding, activates Codex by
 default, and prints only frame counts/metadata lengths so OCR text is not echoed
 into the terminal. Set `AGENTD_SMOKE_FOREGROUND_APP=Terminal` or another
@@ -158,10 +161,13 @@ it:
 - `AGENTD_NOTARY_TEAM_ID`
 - `AGENTD_NOTARY_PASSWORD`: app-specific password for notarization.
 
-`scripts/permission_smoke.sh` packages the app when needed, records macOS
+`scripts/permission_smoke.sh` packages the app when needed, installs the tested
+bundle to `/Applications/EvalOps agentd.app` by default, records macOS
 version/checksum/codesign evidence in `dist/permission-smoke-report.md`, and
-opens the app unless `--no-launch` is supplied. Use it for the hardware-backed
-Screen Recording and Accessibility permission smoke.
+opens the installed app unless `--no-launch` is supplied. Use it for the
+hardware-backed Screen Recording and Accessibility permission smoke. Set
+`AGENTD_APPLICATIONS_DIR` for tests or `AGENTD_INSTALL_APPLICATIONS=0` to skip
+the install.
 `scripts/multi_display_smoke.sh` records repeatable `list-displays` snapshots
 for before-attach, after-attach, capture-all, and after-detach phases. It writes
 bounded JSON and a Markdown report without screenshots or OCR text, and

--- a/scripts/permission_smoke.sh
+++ b/scripts/permission_smoke.sh
@@ -3,31 +3,70 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/permission_smoke.sh [--no-launch]
+Usage: scripts/permission_smoke.sh [--no-launch] [--no-install-applications]
 
 Packages EvalOps agentd if needed, records local evidence, writes a permission
-smoke report template, and opens the app unless --no-launch is supplied.
+smoke report template, installs the tested app to /Applications by default, and
+opens the installed app unless --no-launch is supplied.
+
+Environment:
+  AGENTD_APP_PATH               Source app bundle to test.
+  AGENTD_APPLICATIONS_DIR       Applications directory, default /Applications.
+  AGENTD_INSTALL_APPLICATIONS   Set to 0 to skip the Applications install.
 USAGE
 }
 
 launch=1
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
-  usage
-  exit 0
-elif [[ "${1:-}" == "--no-launch" ]]; then
-  launch=0
-elif [[ $# -gt 0 ]]; then
-  usage >&2
-  exit 64
-fi
+install_applications="${AGENTD_INSTALL_APPLICATIONS:-1}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --no-launch)
+      launch=0
+      shift
+      ;;
+    --no-install-applications)
+      install_applications=0
+      shift
+      ;;
+    *)
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-app_path="${AGENTD_APP_PATH:-"$root/dist/EvalOps agentd.app"}"
+source_app_path="${AGENTD_APP_PATH:-"$root/dist/EvalOps agentd.app"}"
+applications_dir="${AGENTD_APPLICATIONS_DIR:-/Applications}"
+installed_app_path="$applications_dir/EvalOps agentd.app"
+app_path="$source_app_path"
 report_path="${AGENTD_SMOKE_REPORT:-"$root/dist/permission-smoke-report.md"}"
 batch_dir="${AGENTD_BATCH_DIR:-"$HOME/.evalops/agentd/batches"}"
 
-if [[ ! -d "$app_path" ]]; then
+if [[ ! -d "$source_app_path" && -n "${AGENTD_APP_PATH:-}" ]]; then
+  echo "Missing source app bundle: $source_app_path" >&2
+  exit 66
+elif [[ ! -d "$source_app_path" ]]; then
   "$root/scripts/package_app.sh"
+fi
+
+if [[ "$install_applications" != "0" ]]; then
+  if [[ "$installed_app_path" != "$applications_dir/"*"EvalOps agentd.app" ]]; then
+    echo "Refusing unsafe Applications install path: $installed_app_path" >&2
+    exit 64
+  fi
+  mkdir -p "$applications_dir"
+  if [[ "$source_app_path" != "$installed_app_path" ]]; then
+    rm -rf "$installed_app_path"
+    ditto "$source_app_path" "$installed_app_path"
+  fi
+  app_path="$installed_app_path"
+  echo "Installed $source_app_path -> $installed_app_path"
 fi
 
 binary="$app_path/Contents/MacOS/agentd"
@@ -67,6 +106,7 @@ cat > "$report_path" <<REPORT
 - Date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
 - macOS: ${macos_version} (${build_version})
 - App: ${app_path}
+- Source app: ${source_app_path}
 - App SHA-256: ${app_sha}
 - Zip SHA-256: ${zip_sha:-not generated}
 - Codesign authorities: ${codesign_summary:-ad-hoc}
@@ -77,9 +117,10 @@ cat > "$report_path" <<REPORT
 
 ## TCC Stability
 
-If the app is ad-hoc signed, macOS can bind Screen Recording and Accessibility
-approval to the exact CDHash above. Do not rebuild between granting permissions
-and verification. After approving this exact packaged app, relaunch it with:
+This smoke installs the tested app to a stable Applications path before launch,
+because macOS TCC approvals can bind to both app identity and path. Do not move,
+rebuild, or replace this exact app between granting permissions and
+verification. After approving it, relaunch it with:
 
 \`\`\`
 AGENTD_APP_PATH="${app_path}" ./script/build_and_run.sh --tcc-verify


### PR DESCRIPTION
## Summary
- make `scripts/permission_smoke.sh` install the tested app bundle to `/Applications/EvalOps agentd.app` by default before launch/reporting
- generate verification instructions against the installed Applications path so TCC grants bind to a stable path/signature
- keep test/custom escape hatches via `AGENTD_APPLICATIONS_DIR`, `AGENTD_INSTALL_APPLICATIONS=0`, and `--no-install-applications`

Follows #25. This avoids granting Screen Recording/Accessibility to transient `/tmp` or `dist/` bundles.

## Validation
- `shellcheck scripts/permission_smoke.sh script/build_and_run.sh scripts/package_app.sh scripts/multi_display_smoke.sh`
- `AGENTD_APPLICATIONS_DIR=/tmp/agentd-applications-dir-test AGENTD_SMOKE_REPORT=/tmp/agentd-applications-smoke-report.md scripts/permission_smoke.sh --no-launch`
- `AGENTD_APP_PATH='/tmp/agentd-notarized-smoke-25095755314/EvalOps agentd.app' AGENTD_SMOKE_REPORT=/tmp/agentd-notarized-smoke-25095755314/permission-smoke-applications-report.md scripts/permission_smoke.sh --no-launch`
- Verified `/Applications/EvalOps agentd.app` has Developer ID `Jonathan Haas (7BPHA88333)`, stapled notarization ticket, and CDHash `1447fc64b8db3f47437086d303e82974e32812b8`
- `AGENTD_APP_PATH='/Applications/EvalOps agentd.app' ./script/build_and_run.sh --tcc-verify` (expected local TCC denial until stale Privacy & Security rows are removed/re-added for this stable path)
- `swift test`
- `swift build -Xswiftc -warnings-as-errors`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `python3 scripts/chronicle_parity_audit.py --strict`
- `git diff --check`
