### PR TITLE
Surface permission status in menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ local inspection of the shipped arm64 `codex_chronicle` helper bundled with
 - Browser capture has Chronicle-style metadata hardening: private/incognito and
   meeting browser windows are denied, and browser frames with missing focused
   window titles fail closed instead of being treated as normal allowed windows.
-- Menu-bar UI: pause/resume (`⌃⌥⌘P`), flush now (`⌃⌥⌘F`), reveal batches dir,
-  diagnostics report (`⌃⌥⌘D`), delete queued batches, launch-at-login, quit.
+- Menu-bar UI: permission status with direct Screen Recording and Accessibility
+  settings actions, pause/resume (`⌃⌥⌘P`), flush now (`⌃⌥⌘F`), reveal batches
+  dir, diagnostics report (`⌃⌥⌘D`), delete queued batches, launch-at-login,
+  quit.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ local inspection of the shipped arm64 `codex_chronicle` helper bundled with
 - Browser capture has Chronicle-style metadata hardening: private/incognito and
   meeting browser windows are denied, and browser frames with missing focused
   window titles fail closed instead of being treated as normal allowed windows.
-- Menu-bar UI: permission status with direct Screen Recording and Accessibility
-  settings actions, pause/resume (`⌃⌥⌘P`), flush now (`⌃⌥⌘F`), reveal batches
-  dir, diagnostics report (`⌃⌥⌘D`), delete queued batches, launch-at-login,
-  quit.
+- Menu-bar UI: capture and permission status, direct Screen Recording and
+  Accessibility settings actions, permission refresh, relaunch, pause/resume
+  (`⌃⌥⌘P`), flush now (`⌃⌥⌘F`), reveal batches dir, diagnostics report
+  (`⌃⌥⌘D`), delete queued batches, launch-at-login, quit.
 
 ## Build
 
@@ -126,7 +126,8 @@ permission preflight or display discovery times out.
 First run will trigger the system Screen Recording and Accessibility prompts the
 first time the gated APIs are called. Grant both in System Settings → Privacy &
 Security. If capture starts before the grants are complete, agentd retries
-capture startup in the background so a full relaunch is not required.
+capture startup in the background; the menu also includes permission refresh,
+System Settings, and relaunch actions for TCC recovery.
 For ad-hoc local builds, approve the exact packaged app you are testing and use
 `./script/build_and_run.sh --tcc-verify`; rebuilding changes the CDHash and can
 make macOS treat it as a different TCC client.

--- a/Sources/agentd/MenuBarController.swift
+++ b/Sources/agentd/MenuBarController.swift
@@ -7,6 +7,8 @@ import Foundation
 final class MenuBarController: NSObject {
   private let statusItem: NSStatusItem
   private let menu = NSMenu()
+  private var captureStateItem: NSMenuItem?
+  private var pauseItem: NSMenuItem?
   private var permissionItem: NSMenuItem?
   private var screenRecordingItem: NSMenuItem?
   private var accessibilityItem: NSMenuItem?
@@ -19,8 +21,10 @@ final class MenuBarController: NSObject {
   private let onOpenBatchesDir: @Sendable () -> Void
   private let onOpenDiagnostics: @Sendable () -> Void
   private let onDeleteQueuedBatches: @Sendable () -> Void
+  private let onRefreshPermissions: @Sendable () -> Void
   private let onOpenScreenRecordingSettings: @Sendable () -> Void
   private let onOpenAccessibilitySettings: @Sendable () -> Void
+  private let onRelaunch: @Sendable () -> Void
   private let onLaunchAtLoginToggle: @Sendable (Bool) -> Void
   private let onQuit: @Sendable () -> Void
 
@@ -30,8 +34,10 @@ final class MenuBarController: NSObject {
     onOpenBatchesDir: @escaping @Sendable () -> Void,
     onOpenDiagnostics: @escaping @Sendable () -> Void,
     onDeleteQueuedBatches: @escaping @Sendable () -> Void,
+    onRefreshPermissions: @escaping @Sendable () -> Void,
     onOpenScreenRecordingSettings: @escaping @Sendable () -> Void,
     onOpenAccessibilitySettings: @escaping @Sendable () -> Void,
+    onRelaunch: @escaping @Sendable () -> Void,
     onLaunchAtLoginToggle: @escaping @Sendable (Bool) -> Void,
     onQuit: @escaping @Sendable () -> Void
   ) {
@@ -40,8 +46,10 @@ final class MenuBarController: NSObject {
     self.onOpenBatchesDir = onOpenBatchesDir
     self.onOpenDiagnostics = onOpenDiagnostics
     self.onDeleteQueuedBatches = onDeleteQueuedBatches
+    self.onRefreshPermissions = onRefreshPermissions
     self.onOpenScreenRecordingSettings = onOpenScreenRecordingSettings
     self.onOpenAccessibilitySettings = onOpenAccessibilitySettings
+    self.onRelaunch = onRelaunch
     self.onLaunchAtLoginToggle = onLaunchAtLoginToggle
     self.onQuit = onQuit
     self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -57,10 +65,18 @@ final class MenuBarController: NSObject {
       button.toolTip = "agentd — capturing"
     }
 
+    let captureStateItem = NSMenuItem(title: "Status: Starting…", action: nil, keyEquivalent: "")
+    captureStateItem.isEnabled = false
+    self.captureStateItem = captureStateItem
+    menu.addItem(captureStateItem)
+
+    menu.addItem(.separator())
+
     let pauseItem = NSMenuItem(
       title: "Pause Capture", action: #selector(togglePause), keyEquivalent: "p")
     pauseItem.keyEquivalentModifierMask = [.command, .option, .control]
     pauseItem.target = self
+    self.pauseItem = pauseItem
     menu.addItem(pauseItem)
 
     let flushItem = NSMenuItem(
@@ -95,6 +111,11 @@ final class MenuBarController: NSObject {
     self.permissionItem = permissionItem
     menu.addItem(permissionItem)
 
+    let refreshPermissionsItem = NSMenuItem(
+      title: "Check Permission Status", action: #selector(refreshPermissions), keyEquivalent: "")
+    refreshPermissionsItem.target = self
+    menu.addItem(refreshPermissionsItem)
+
     let screenRecordingItem = NSMenuItem(
       title: "Open Screen & System Audio Recording Settings",
       action: #selector(openScreenRecordingSettings),
@@ -112,6 +133,11 @@ final class MenuBarController: NSObject {
     accessibilityItem.target = self
     self.accessibilityItem = accessibilityItem
     menu.addItem(accessibilityItem)
+
+    let relaunchItem = NSMenuItem(
+      title: "Relaunch agentd", action: #selector(relaunch), keyEquivalent: "")
+    relaunchItem.target = self
+    menu.addItem(relaunchItem)
 
     menu.addItem(.separator())
 
@@ -141,9 +167,7 @@ final class MenuBarController: NSObject {
   @objc private func togglePause() {
     paused.toggle()
     updateStatusButton(detail: paused ? "paused" : "capturing")
-    if let item = menu.items.first {
-      item.title = paused ? "Resume Capture" : "Pause Capture"
-    }
+    pauseItem?.title = paused ? "Resume Capture" : "Pause Capture"
     onPauseToggle(paused)
   }
 
@@ -151,8 +175,10 @@ final class MenuBarController: NSObject {
   @objc private func reveal() { onOpenBatchesDir() }
   @objc private func openDiagnostics() { onOpenDiagnostics() }
   @objc private func deleteQueuedBatches() { onDeleteQueuedBatches() }
+  @objc private func refreshPermissions() { onRefreshPermissions() }
   @objc private func openScreenRecordingSettings() { onOpenScreenRecordingSettings() }
   @objc private func openAccessibilitySettings() { onOpenAccessibilitySettings() }
+  @objc private func relaunch() { onRelaunch() }
   @objc private func toggleLaunchAtLogin() {
     let next = !(launchAtLoginItem?.state == .on)
     launchAtLoginItem?.state = next ? .on : .off
@@ -170,9 +196,8 @@ final class MenuBarController: NSObject {
     self.paused = paused
     needsPermission = !permissions.allTrusted
     updateStatusButton(detail: detail)
-    if let item = menu.items.first {
-      item.title = paused ? "Resume Capture" : "Pause Capture"
-    }
+    pauseItem?.title = paused ? "Resume Capture" : "Pause Capture"
+    captureStateItem?.title = "Status: \(detail)"
     permissionItem?.title = "Permissions: \(permissions.menuSummary)"
     screenRecordingItem?.isEnabled = !permissions.screenCaptureTrusted
     accessibilityItem?.isEnabled = !permissions.accessibilityTrusted

--- a/Sources/agentd/MenuBarController.swift
+++ b/Sources/agentd/MenuBarController.swift
@@ -7,6 +7,9 @@ import Foundation
 final class MenuBarController: NSObject {
   private let statusItem: NSStatusItem
   private let menu = NSMenu()
+  private var permissionItem: NSMenuItem?
+  private var screenRecordingItem: NSMenuItem?
+  private var accessibilityItem: NSMenuItem?
   private var aboutItem: NSMenuItem?
   private var launchAtLoginItem: NSMenuItem?
   private var paused: Bool = false
@@ -15,6 +18,8 @@ final class MenuBarController: NSObject {
   private let onOpenBatchesDir: @Sendable () -> Void
   private let onOpenDiagnostics: @Sendable () -> Void
   private let onDeleteQueuedBatches: @Sendable () -> Void
+  private let onOpenScreenRecordingSettings: @Sendable () -> Void
+  private let onOpenAccessibilitySettings: @Sendable () -> Void
   private let onLaunchAtLoginToggle: @Sendable (Bool) -> Void
   private let onQuit: @Sendable () -> Void
 
@@ -24,6 +29,8 @@ final class MenuBarController: NSObject {
     onOpenBatchesDir: @escaping @Sendable () -> Void,
     onOpenDiagnostics: @escaping @Sendable () -> Void,
     onDeleteQueuedBatches: @escaping @Sendable () -> Void,
+    onOpenScreenRecordingSettings: @escaping @Sendable () -> Void,
+    onOpenAccessibilitySettings: @escaping @Sendable () -> Void,
     onLaunchAtLoginToggle: @escaping @Sendable (Bool) -> Void,
     onQuit: @escaping @Sendable () -> Void
   ) {
@@ -32,6 +39,8 @@ final class MenuBarController: NSObject {
     self.onOpenBatchesDir = onOpenBatchesDir
     self.onOpenDiagnostics = onOpenDiagnostics
     self.onDeleteQueuedBatches = onDeleteQueuedBatches
+    self.onOpenScreenRecordingSettings = onOpenScreenRecordingSettings
+    self.onOpenAccessibilitySettings = onOpenAccessibilitySettings
     self.onLaunchAtLoginToggle = onLaunchAtLoginToggle
     self.onQuit = onQuit
     self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -79,6 +88,32 @@ final class MenuBarController: NSObject {
 
     menu.addItem(.separator())
 
+    let permissionItem = NSMenuItem(
+      title: "Permissions: Checking…", action: nil, keyEquivalent: "")
+    permissionItem.isEnabled = false
+    self.permissionItem = permissionItem
+    menu.addItem(permissionItem)
+
+    let screenRecordingItem = NSMenuItem(
+      title: "Open Screen & System Audio Recording Settings",
+      action: #selector(openScreenRecordingSettings),
+      keyEquivalent: ""
+    )
+    screenRecordingItem.target = self
+    self.screenRecordingItem = screenRecordingItem
+    menu.addItem(screenRecordingItem)
+
+    let accessibilityItem = NSMenuItem(
+      title: "Open Accessibility Settings",
+      action: #selector(openAccessibilitySettings),
+      keyEquivalent: ""
+    )
+    accessibilityItem.target = self
+    self.accessibilityItem = accessibilityItem
+    menu.addItem(accessibilityItem)
+
+    menu.addItem(.separator())
+
     let launchItem = NSMenuItem(
       title: "Launch at Login", action: #selector(toggleLaunchAtLogin), keyEquivalent: "")
     launchItem.target = self
@@ -122,6 +157,8 @@ final class MenuBarController: NSObject {
   @objc private func reveal() { onOpenBatchesDir() }
   @objc private func openDiagnostics() { onOpenDiagnostics() }
   @objc private func deleteQueuedBatches() { onDeleteQueuedBatches() }
+  @objc private func openScreenRecordingSettings() { onOpenScreenRecordingSettings() }
+  @objc private func openAccessibilitySettings() { onOpenAccessibilitySettings() }
   @objc private func toggleLaunchAtLogin() {
     let next = !(launchAtLoginItem?.state == .on)
     launchAtLoginItem?.state = next ? .on : .off
@@ -129,23 +166,44 @@ final class MenuBarController: NSObject {
   }
   @objc private func quit() { onQuit() }
 
-  func setStatus(paused: Bool, detail: String, localOnly: Bool, policyVersion: String?) {
+  func setStatus(
+    paused: Bool,
+    detail: String,
+    permissions: PermissionSnapshot,
+    localOnly: Bool,
+    policyVersion: String?
+  ) {
     self.paused = paused
+    let needsPermission = !permissions.allTrusted
     if let button = statusItem.button {
       button.image = NSImage(
-        systemSymbolName: paused ? "pause.circle" : "circle.fill",
-        accessibilityDescription: paused ? "agentd paused" : "agentd recording"
+        systemSymbolName: statusSymbol(paused: paused, needsPermission: needsPermission),
+        accessibilityDescription: accessibilityDescription(
+          paused: paused, needsPermission: needsPermission)
       )
       button.image?.isTemplate = true
-      button.toolTip = "agentd — \(detail)"
+      button.toolTip = needsPermission ? "agentd — permissions needed" : "agentd — \(detail)"
     }
     if let item = menu.items.first {
       item.title = paused ? "Resume Capture" : "Pause Capture"
     }
+    permissionItem?.title = "Permissions: \(permissions.menuSummary)"
+    screenRecordingItem?.isEnabled = !permissions.screenCaptureTrusted
+    accessibilityItem?.isEnabled = !permissions.accessibilityTrusted
     let mode = localOnly ? "local-only" : "managed"
     let policy = policyVersion.map { " policy \($0)" } ?? ""
     aboutItem?.title = "agentd \(Bundle.main.appVersion) — \(mode)\(policy)"
     launchAtLoginItem?.state = LaunchAtLoginController.isEnabled ? .on : .off
+  }
+
+  private func statusSymbol(paused: Bool, needsPermission: Bool) -> String {
+    if needsPermission { return "exclamationmark.triangle.fill" }
+    return paused ? "pause.circle" : "circle.fill"
+  }
+
+  private func accessibilityDescription(paused: Bool, needsPermission: Bool) -> String {
+    if needsPermission { return "agentd permissions needed" }
+    return paused ? "agentd paused" : "agentd recording"
   }
 }
 

--- a/Sources/agentd/MenuBarController.swift
+++ b/Sources/agentd/MenuBarController.swift
@@ -13,6 +13,7 @@ final class MenuBarController: NSObject {
   private var aboutItem: NSMenuItem?
   private var launchAtLoginItem: NSMenuItem?
   private var paused: Bool = false
+  private var needsPermission: Bool = false
   private let onPauseToggle: @Sendable (Bool) -> Void
   private let onFlushNow: @Sendable () -> Void
   private let onOpenBatchesDir: @Sendable () -> Void
@@ -139,14 +140,7 @@ final class MenuBarController: NSObject {
 
   @objc private func togglePause() {
     paused.toggle()
-    if let button = statusItem.button {
-      button.image = NSImage(
-        systemSymbolName: paused ? "pause.circle" : "circle.fill",
-        accessibilityDescription: paused ? "agentd paused" : "agentd recording"
-      )
-      button.image?.isTemplate = true
-      button.toolTip = paused ? "agentd — paused" : "agentd — capturing"
-    }
+    updateStatusButton(detail: paused ? "paused" : "capturing")
     if let item = menu.items.first {
       item.title = paused ? "Resume Capture" : "Pause Capture"
     }
@@ -174,16 +168,8 @@ final class MenuBarController: NSObject {
     policyVersion: String?
   ) {
     self.paused = paused
-    let needsPermission = !permissions.allTrusted
-    if let button = statusItem.button {
-      button.image = NSImage(
-        systemSymbolName: statusSymbol(paused: paused, needsPermission: needsPermission),
-        accessibilityDescription: accessibilityDescription(
-          paused: paused, needsPermission: needsPermission)
-      )
-      button.image?.isTemplate = true
-      button.toolTip = needsPermission ? "agentd — permissions needed" : "agentd — \(detail)"
-    }
+    needsPermission = !permissions.allTrusted
+    updateStatusButton(detail: detail)
     if let item = menu.items.first {
       item.title = paused ? "Resume Capture" : "Pause Capture"
     }
@@ -204,6 +190,18 @@ final class MenuBarController: NSObject {
   private func accessibilityDescription(paused: Bool, needsPermission: Bool) -> String {
     if needsPermission { return "agentd permissions needed" }
     return paused ? "agentd paused" : "agentd recording"
+  }
+
+  private func updateStatusButton(detail: String) {
+    if let button = statusItem.button {
+      button.image = NSImage(
+        systemSymbolName: statusSymbol(paused: paused, needsPermission: needsPermission),
+        accessibilityDescription: accessibilityDescription(
+          paused: paused, needsPermission: needsPermission)
+      )
+      button.image?.isTemplate = true
+      button.toolTip = needsPermission ? "agentd — permissions needed" : "agentd — \(detail)"
+    }
   }
 }
 

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -137,6 +137,9 @@ final class AppController {
       onDeleteQueuedBatches: { [weak self] in
         Task { @MainActor in await self?.deleteQueuedBatches() }
       },
+      onRefreshPermissions: { [weak self] in
+        Task { @MainActor in self?.updateMenuStatus() }
+      },
       onOpenScreenRecordingSettings: {
         Task { @MainActor in
           AppController.openSystemSettingsPane("Privacy_ScreenCapture")
@@ -145,6 +148,11 @@ final class AppController {
       onOpenAccessibilitySettings: {
         Task { @MainActor in
           AppController.openSystemSettingsPane("Privacy_Accessibility")
+        }
+      },
+      onRelaunch: {
+        Task { @MainActor in
+          AppController.relaunchApplication()
         }
       },
       onLaunchAtLoginToggle: { enabled in
@@ -667,6 +675,22 @@ final class AppController {
         string: "x-apple.systempreferences:com.apple.preference.security?\(pane)")
     else { return }
     NSWorkspace.shared.open(url)
+  }
+
+  private static func relaunchApplication() {
+    guard Bundle.main.bundleURL.pathExtension == "app" else {
+      NSApp.terminate(nil)
+      return
+    }
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+    process.arguments = ["-n", Bundle.main.bundleURL.path]
+    do {
+      try process.run()
+    } catch {
+      Log.app.error("relaunch failed: \(error.localizedDescription, privacy: .public)")
+    }
+    NSApp.terminate(nil)
   }
 }
 

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -137,6 +137,16 @@ final class AppController {
       onDeleteQueuedBatches: { [weak self] in
         Task { @MainActor in await self?.deleteQueuedBatches() }
       },
+      onOpenScreenRecordingSettings: {
+        Task { @MainActor in
+          AppController.openSystemSettingsPane("Privacy_ScreenCapture")
+        }
+      },
+      onOpenAccessibilitySettings: {
+        Task { @MainActor in
+          AppController.openSystemSettingsPane("Privacy_Accessibility")
+        }
+      },
       onLaunchAtLoginToggle: { enabled in
         do {
           try LaunchAtLoginController.setEnabled(enabled)
@@ -645,15 +655,44 @@ final class AppController {
     menuBar?.setStatus(
       paused: pauseState.paused || !captureRunning,
       detail: detail,
+      permissions: PermissionSnapshot.current(promptForAccessibility: false),
       localOnly: config.localOnly,
       policyVersion: controlState.lastPolicyVersion
     )
+  }
+
+  private static func openSystemSettingsPane(_ pane: String) {
+    guard
+      let url = URL(
+        string: "x-apple.systempreferences:com.apple.preference.security?\(pane)")
+    else { return }
+    NSWorkspace.shared.open(url)
   }
 }
 
 struct PermissionSnapshot: Sendable, Equatable, Codable {
   let accessibilityTrusted: Bool
   let screenCaptureTrusted: Bool
+
+  var allTrusted: Bool {
+    accessibilityTrusted && screenCaptureTrusted
+  }
+
+  var menuSummary: String {
+    if allTrusted { return "Ready" }
+    return "Needs \(missingPermissionNames.joined(separator: " + "))"
+  }
+
+  private var missingPermissionNames: [String] {
+    var names: [String] = []
+    if !screenCaptureTrusted {
+      names.append("Screen Recording")
+    }
+    if !accessibilityTrusted {
+      names.append("Accessibility")
+    }
+    return names
+  }
 
   @MainActor
   static func current(promptForAccessibility: Bool) -> PermissionSnapshot {

--- a/Tests/agentdTests/CaptureWorkerSupervisorTests.swift
+++ b/Tests/agentdTests/CaptureWorkerSupervisorTests.swift
@@ -8,12 +8,15 @@ import XCTest
 final class CaptureWorkerSupervisorTests: XCTestCase {
   func testTerminatesWorkerWithTermDuringGraceWindow() throws {
     let supervisor = CaptureWorkerSupervisor()
+    let output = Pipe()
     let pid = try supervisor.start(
       CaptureWorkerProcessSpec(
-        executableURL: URL(fileURLWithPath: "/bin/sleep"),
-        arguments: ["30"]
+        executableURL: URL(fileURLWithPath: "/usr/bin/perl"),
+        arguments: ["-e", "$|=1; print \"ready\\n\"; sleep 30"],
+        standardOutput: output
       )
     )
+    XCTAssertTrue(waitForReadyLine(from: output))
 
     let result = supervisor.terminate(graceSeconds: 2)
 
@@ -28,12 +31,15 @@ final class CaptureWorkerSupervisorTests: XCTestCase {
 
   func testEscalatesToKillWhenWorkerIgnoresTerm() throws {
     let supervisor = CaptureWorkerSupervisor()
+    let output = Pipe()
     let pid = try supervisor.start(
       CaptureWorkerProcessSpec(
-        executableURL: URL(fileURLWithPath: "/bin/sh"),
-        arguments: ["-c", "trap '' TERM; sleep 30"]
+        executableURL: URL(fileURLWithPath: "/usr/bin/perl"),
+        arguments: ["-e", "$|=1; $SIG{TERM}=sub{}; print \"ready\\n\"; sleep 30"],
+        standardOutput: output
       )
     )
+    XCTAssertTrue(waitForReadyLine(from: output))
 
     let result = supervisor.terminate(graceSeconds: 0.05)
 
@@ -65,6 +71,33 @@ final class CaptureWorkerSupervisorTests: XCTestCase {
       )
     ) { error in
       XCTAssertEqual(error as? CaptureWorkerSupervisorError, .alreadyRunning(pid: pid))
+    }
+  }
+
+  private func waitForReadyLine(from pipe: Pipe, timeoutSeconds: TimeInterval = 2) -> Bool {
+    let semaphore = DispatchSemaphore(value: 0)
+    let buffer = ReadyLineBuffer()
+    pipe.fileHandleForReading.readabilityHandler = { handle in
+      let data = handle.availableData
+      guard !data.isEmpty else { return }
+      if buffer.appendAndContainsReadyLine(data) {
+        semaphore.signal()
+      }
+    }
+    let ready = semaphore.wait(timeout: .now() + timeoutSeconds) == .success
+    pipe.fileHandleForReading.readabilityHandler = nil
+    return ready
+  }
+}
+
+private final class ReadyLineBuffer: @unchecked Sendable {
+  private let lock = NSLock()
+  private var buffer = Data()
+
+  func appendAndContainsReadyLine(_ data: Data) -> Bool {
+    lock.withLock {
+      buffer.append(data)
+      return String(data: buffer, encoding: .utf8)?.contains("ready\n") == true
     }
   }
 }

--- a/Tests/agentdTests/DiagnosticsTests.swift
+++ b/Tests/agentdTests/DiagnosticsTests.swift
@@ -6,6 +6,25 @@ import XCTest
 @testable import agentd
 
 final class DiagnosticsTests: XCTestCase {
+  func testPermissionSnapshotMenuSummary() {
+    XCTAssertEqual(
+      PermissionSnapshot(accessibilityTrusted: true, screenCaptureTrusted: true).menuSummary,
+      "Ready"
+    )
+    XCTAssertEqual(
+      PermissionSnapshot(accessibilityTrusted: true, screenCaptureTrusted: false).menuSummary,
+      "Needs Screen Recording"
+    )
+    XCTAssertEqual(
+      PermissionSnapshot(accessibilityTrusted: false, screenCaptureTrusted: true).menuSummary,
+      "Needs Accessibility"
+    )
+    XCTAssertEqual(
+      PermissionSnapshot(accessibilityTrusted: false, screenCaptureTrusted: false).menuSummary,
+      "Needs Screen Recording + Accessibility"
+    )
+  }
+
   func testDiagnosticsReportRedactsSecretsAndPathsButKeepsQueueSummary() {
     let cfg = AgentConfig(
       deviceId: "device_1",


### PR DESCRIPTION
## Summary
- surface capture state and permission state directly in the menu bar menu
- add direct Screen & System Audio Recording / Accessibility settings actions, a permission refresh action, and a relaunch action for TCC recovery
- keep the status item warning icon/tooltip permission-aware while toggling pause/resume

## Research notes
- Apple's macOS menu bar guidance favors lightweight status/action menus for menu bar extras.
- Apple's ScreenCaptureKit sample notes first-run Screen Recording permission flow and app restart behavior after granting capture access.

## Validation
- swift test
- swift build -Xswiftc -warnings-as-errors
- xcrun swift-format lint --strict --recursive Sources Tests Package.swift
- python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
- python3 scripts/chronicle_parity_audit.py --strict
- scripts/package_app.sh
- git diff --check
