### PR TITLE
feat: add agentd permission setup panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ local inspection of the shipped arm64 `codex_chronicle` helper bundled with
 - Browser capture has Chronicle-style metadata hardening: private/incognito and
   meeting browser windows are denied, and browser frames with missing focused
   window titles fail closed instead of being treated as normal allowed windows.
-- Menu-bar UI: capture and permission status, direct Screen Recording and
-  Accessibility settings actions, permission refresh, relaunch, pause/resume
-  (`⌃⌥⌘P`), flush now (`⌃⌥⌘F`), reveal batches dir, diagnostics report
-  (`⌃⌥⌘D`), delete queued batches, launch-at-login, quit.
+- Menu-bar UI: capture and permission status, a permission setup window with
+  stable bundle identity, direct Screen Recording and Accessibility settings
+  actions, permission refresh, relaunch, pause/resume (`⌃⌥⌘P`), flush now
+  (`⌃⌥⌘F`), reveal batches dir, diagnostics report (`⌃⌥⌘D`), delete queued
+  batches, launch-at-login, quit.
 
 ## Build
 
@@ -126,8 +127,9 @@ permission preflight or display discovery times out.
 First run will trigger the system Screen Recording and Accessibility prompts the
 first time the gated APIs are called. Grant both in System Settings → Privacy &
 Security. If capture starts before the grants are complete, agentd retries
-capture startup in the background; the menu also includes permission refresh,
-System Settings, and relaunch actions for TCC recovery.
+capture startup in the background; the menu also includes a permission setup
+window, permission refresh, System Settings, and relaunch actions for TCC
+recovery.
 For ad-hoc local builds, approve the exact packaged app you are testing and use
 `./script/build_and_run.sh --tcc-verify`; rebuilding changes the CDHash and can
 make macOS treat it as a different TCC client.

--- a/Sources/agentd/MenuBarController.swift
+++ b/Sources/agentd/MenuBarController.swift
@@ -10,6 +10,7 @@ final class MenuBarController: NSObject {
   private var captureStateItem: NSMenuItem?
   private var pauseItem: NSMenuItem?
   private var permissionItem: NSMenuItem?
+  private var permissionSetupItem: NSMenuItem?
   private var screenRecordingItem: NSMenuItem?
   private var accessibilityItem: NSMenuItem?
   private var aboutItem: NSMenuItem?
@@ -22,6 +23,7 @@ final class MenuBarController: NSObject {
   private let onOpenDiagnostics: @Sendable () -> Void
   private let onDeleteQueuedBatches: @Sendable () -> Void
   private let onRefreshPermissions: @Sendable () -> Void
+  private let onOpenPermissionSetup: @Sendable () -> Void
   private let onOpenScreenRecordingSettings: @Sendable () -> Void
   private let onOpenAccessibilitySettings: @Sendable () -> Void
   private let onRelaunch: @Sendable () -> Void
@@ -35,6 +37,7 @@ final class MenuBarController: NSObject {
     onOpenDiagnostics: @escaping @Sendable () -> Void,
     onDeleteQueuedBatches: @escaping @Sendable () -> Void,
     onRefreshPermissions: @escaping @Sendable () -> Void,
+    onOpenPermissionSetup: @escaping @Sendable () -> Void,
     onOpenScreenRecordingSettings: @escaping @Sendable () -> Void,
     onOpenAccessibilitySettings: @escaping @Sendable () -> Void,
     onRelaunch: @escaping @Sendable () -> Void,
@@ -47,6 +50,7 @@ final class MenuBarController: NSObject {
     self.onOpenDiagnostics = onOpenDiagnostics
     self.onDeleteQueuedBatches = onDeleteQueuedBatches
     self.onRefreshPermissions = onRefreshPermissions
+    self.onOpenPermissionSetup = onOpenPermissionSetup
     self.onOpenScreenRecordingSettings = onOpenScreenRecordingSettings
     self.onOpenAccessibilitySettings = onOpenAccessibilitySettings
     self.onRelaunch = onRelaunch
@@ -116,6 +120,12 @@ final class MenuBarController: NSObject {
     refreshPermissionsItem.target = self
     menu.addItem(refreshPermissionsItem)
 
+    let permissionSetupItem = NSMenuItem(
+      title: "Open Permission Setup", action: #selector(openPermissionSetup), keyEquivalent: "")
+    permissionSetupItem.target = self
+    self.permissionSetupItem = permissionSetupItem
+    menu.addItem(permissionSetupItem)
+
     let screenRecordingItem = NSMenuItem(
       title: "Open Screen & System Audio Recording Settings",
       action: #selector(openScreenRecordingSettings),
@@ -176,6 +186,7 @@ final class MenuBarController: NSObject {
   @objc private func openDiagnostics() { onOpenDiagnostics() }
   @objc private func deleteQueuedBatches() { onDeleteQueuedBatches() }
   @objc private func refreshPermissions() { onRefreshPermissions() }
+  @objc private func openPermissionSetup() { onOpenPermissionSetup() }
   @objc private func openScreenRecordingSettings() { onOpenScreenRecordingSettings() }
   @objc private func openAccessibilitySettings() { onOpenAccessibilitySettings() }
   @objc private func relaunch() { onRelaunch() }

--- a/Sources/agentd/MenuBarController.swift
+++ b/Sources/agentd/MenuBarController.swift
@@ -10,7 +10,6 @@ final class MenuBarController: NSObject {
   private var captureStateItem: NSMenuItem?
   private var pauseItem: NSMenuItem?
   private var permissionItem: NSMenuItem?
-  private var permissionSetupItem: NSMenuItem?
   private var screenRecordingItem: NSMenuItem?
   private var accessibilityItem: NSMenuItem?
   private var aboutItem: NSMenuItem?
@@ -123,7 +122,6 @@ final class MenuBarController: NSObject {
     let permissionSetupItem = NSMenuItem(
       title: "Open Permission Setup", action: #selector(openPermissionSetup), keyEquivalent: "")
     permissionSetupItem.target = self
-    self.permissionSetupItem = permissionSetupItem
     menu.addItem(permissionSetupItem)
 
     let screenRecordingItem = NSMenuItem(

--- a/Sources/agentd/PermissionSetupWindowController.swift
+++ b/Sources/agentd/PermissionSetupWindowController.swift
@@ -54,7 +54,6 @@ final class PermissionSetupWindowController: NSWindowController {
 
   private func makeContentView() -> NSView {
     let root = NSView()
-    root.translatesAutoresizingMaskIntoConstraints = false
 
     let title = NSTextField(labelWithString: "Permission Setup")
     title.font = .systemFont(ofSize: 17, weight: .semibold)

--- a/Sources/agentd/PermissionSetupWindowController.swift
+++ b/Sources/agentd/PermissionSetupWindowController.swift
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import AppKit
+import Foundation
+
+@MainActor
+final class PermissionSetupWindowController: NSWindowController {
+  private let currentPermissions: @MainActor @Sendable () -> PermissionSnapshot
+  private let onOpenScreenRecordingSettings: @MainActor @Sendable () -> Void
+  private let onOpenAccessibilitySettings: @MainActor @Sendable () -> Void
+  private let onRelaunch: @MainActor @Sendable () -> Void
+
+  private let screenStatus = NSTextField(labelWithString: "")
+  private let accessibilityStatus = NSTextField(labelWithString: "")
+  private let bundlePath = NSTextField(labelWithString: Bundle.main.bundleURL.path)
+  private let recheckButton = NSButton(title: "Recheck", target: nil, action: nil)
+
+  init(
+    currentPermissions: @escaping @MainActor @Sendable () -> PermissionSnapshot,
+    onOpenScreenRecordingSettings: @escaping @MainActor @Sendable () -> Void,
+    onOpenAccessibilitySettings: @escaping @MainActor @Sendable () -> Void,
+    onRelaunch: @escaping @MainActor @Sendable () -> Void
+  ) {
+    self.currentPermissions = currentPermissions
+    self.onOpenScreenRecordingSettings = onOpenScreenRecordingSettings
+    self.onOpenAccessibilitySettings = onOpenAccessibilitySettings
+    self.onRelaunch = onRelaunch
+
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 520, height: 248),
+      styleMask: [.titled, .closable],
+      backing: .buffered,
+      defer: false
+    )
+    window.title = "agentd Permissions"
+    window.isReleasedWhenClosed = false
+    window.center()
+
+    super.init(window: window)
+    window.contentView = makeContentView()
+    refresh()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  func show() {
+    refresh()
+    window?.center()
+    window?.makeKeyAndOrderFront(nil)
+    NSApp.activate(ignoringOtherApps: true)
+  }
+
+  private func makeContentView() -> NSView {
+    let root = NSView()
+    root.translatesAutoresizingMaskIntoConstraints = false
+
+    let title = NSTextField(labelWithString: "Permission Setup")
+    title.font = .systemFont(ofSize: 17, weight: .semibold)
+
+    let subtitle = NSTextField(labelWithString: "Bundle identity")
+    subtitle.font = .systemFont(ofSize: 11, weight: .medium)
+    subtitle.textColor = .secondaryLabelColor
+
+    bundlePath.lineBreakMode = .byTruncatingMiddle
+    bundlePath.toolTip = Bundle.main.bundleURL.path
+    bundlePath.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+
+    let screenButton = makeActionButton(
+      title: "Open Screen Recording",
+      action: #selector(openScreenRecordingSettings)
+    )
+    let accessibilityButton = makeActionButton(
+      title: "Open Accessibility",
+      action: #selector(openAccessibilitySettings)
+    )
+    let relaunchButton = makeActionButton(title: "Relaunch", action: #selector(relaunch))
+    recheckButton.target = self
+    recheckButton.action = #selector(recheck)
+
+    let screenRow = makePermissionRow(
+      name: "Screen Recording",
+      status: screenStatus,
+      action: screenButton
+    )
+    let accessibilityRow = makePermissionRow(
+      name: "Accessibility",
+      status: accessibilityStatus,
+      action: accessibilityButton
+    )
+
+    let pathStack = NSStackView(views: [subtitle, bundlePath])
+    pathStack.orientation = .vertical
+    pathStack.alignment = .leading
+    pathStack.spacing = 4
+
+    let buttonStack = NSStackView(views: [recheckButton, relaunchButton])
+    buttonStack.orientation = .horizontal
+    buttonStack.alignment = .centerY
+    buttonStack.spacing = 8
+
+    let stack = NSStackView(views: [title, screenRow, accessibilityRow, pathStack, buttonStack])
+    stack.translatesAutoresizingMaskIntoConstraints = false
+    stack.orientation = .vertical
+    stack.alignment = .leading
+    stack.spacing = 16
+    root.addSubview(stack)
+
+    NSLayoutConstraint.activate([
+      stack.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 22),
+      stack.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -22),
+      stack.topAnchor.constraint(equalTo: root.topAnchor, constant: 22),
+      stack.bottomAnchor.constraint(lessThanOrEqualTo: root.bottomAnchor, constant: -22),
+      bundlePath.widthAnchor.constraint(equalTo: stack.widthAnchor),
+    ])
+
+    return root
+  }
+
+  private func makePermissionRow(name: String, status: NSTextField, action: NSButton) -> NSView {
+    let label = NSTextField(labelWithString: name)
+    label.font = .systemFont(ofSize: 13, weight: .medium)
+    label.widthAnchor.constraint(equalToConstant: 142).isActive = true
+
+    status.font = .systemFont(ofSize: 13)
+    status.widthAnchor.constraint(equalToConstant: 96).isActive = true
+
+    let spacer = NSView()
+    spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+    let row = NSStackView(views: [label, status, spacer, action])
+    row.orientation = .horizontal
+    row.alignment = .centerY
+    row.spacing = 12
+    row.widthAnchor.constraint(equalToConstant: 476).isActive = true
+    return row
+  }
+
+  private func makeActionButton(title: String, action: Selector) -> NSButton {
+    let button = NSButton(title: title, target: self, action: action)
+    button.bezelStyle = .rounded
+    return button
+  }
+
+  @objc private func recheck() {
+    refresh()
+  }
+
+  @objc private func openScreenRecordingSettings() {
+    onOpenScreenRecordingSettings()
+  }
+
+  @objc private func openAccessibilitySettings() {
+    onOpenAccessibilitySettings()
+  }
+
+  @objc private func relaunch() {
+    onRelaunch()
+  }
+
+  private func refresh() {
+    let permissions = currentPermissions()
+    update(status: screenStatus, trusted: permissions.screenCaptureTrusted)
+    update(status: accessibilityStatus, trusted: permissions.accessibilityTrusted)
+    recheckButton.toolTip = permissions.menuSummary
+  }
+
+  private func update(status: NSTextField, trusted: Bool) {
+    status.stringValue = trusted ? "Ready" : "Needs access"
+    status.textColor = trusted ? .systemGreen : .systemOrange
+  }
+}

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -13,6 +13,7 @@ final class AppController {
   private var runtimeLock: AgentdRuntimeLock?
   private var capture: CaptureService!
   private var menuBar: MenuBarController!
+  private var permissionSetupWindow: PermissionSetupWindowController?
   private var userPaused = false
   private var captureRunning = false
   private var controlState = ChronicleControlState()
@@ -139,6 +140,9 @@ final class AppController {
       },
       onRefreshPermissions: { [weak self] in
         Task { @MainActor in self?.updateMenuStatus() }
+      },
+      onOpenPermissionSetup: { [weak self] in
+        Task { @MainActor in self?.openPermissionSetupWindow() }
       },
       onOpenScreenRecordingSettings: {
         Task { @MainActor in
@@ -667,6 +671,27 @@ final class AppController {
       localOnly: config.localOnly,
       policyVersion: controlState.lastPolicyVersion
     )
+  }
+
+  private func openPermissionSetupWindow() {
+    if permissionSetupWindow == nil {
+      permissionSetupWindow = PermissionSetupWindowController(
+        currentPermissions: {
+          PermissionSnapshot.current(promptForAccessibility: false)
+        },
+        onOpenScreenRecordingSettings: {
+          AppController.openSystemSettingsPane("Privacy_ScreenCapture")
+        },
+        onOpenAccessibilitySettings: {
+          AppController.openSystemSettingsPane("Privacy_Accessibility")
+        },
+        onRelaunch: {
+          AppController.relaunchApplication()
+        }
+      )
+    }
+    updateMenuStatus()
+    permissionSetupWindow?.show()
   }
 
   private static func openSystemSettingsPane(_ pane: String) {

--- a/Tests/agentdTests/CaptureWorkerSupervisorTests.swift
+++ b/Tests/agentdTests/CaptureWorkerSupervisorTests.swift
@@ -12,7 +12,10 @@ final class CaptureWorkerSupervisorTests: XCTestCase {
     let pid = try supervisor.start(
       CaptureWorkerProcessSpec(
         executableURL: URL(fileURLWithPath: "/usr/bin/perl"),
-        arguments: ["-e", "$|=1; print \"ready\\n\"; sleep 30"],
+        arguments: [
+          "-e",
+          "$|=1; $SIG{TERM}=sub{exit 0}; print \"ready\\n\"; while (1) { select undef, undef, undef, 0.1 }",
+        ],
         standardOutput: output
       )
     )
@@ -35,7 +38,10 @@ final class CaptureWorkerSupervisorTests: XCTestCase {
     let pid = try supervisor.start(
       CaptureWorkerProcessSpec(
         executableURL: URL(fileURLWithPath: "/usr/bin/perl"),
-        arguments: ["-e", "$|=1; $SIG{TERM}=sub{}; print \"ready\\n\"; sleep 30"],
+        arguments: [
+          "-e",
+          "$|=1; $SIG{TERM}=sub{}; print \"ready\\n\"; while (1) { select undef, undef, undef, 0.1 }",
+        ],
         standardOutput: output
       )
     )

--- a/Tests/agentdTests/PermissionSetupWindowControllerTests.swift
+++ b/Tests/agentdTests/PermissionSetupWindowControllerTests.swift
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import AppKit
+import XCTest
+
+@testable import agentd
+
+@MainActor
+final class PermissionSetupWindowControllerTests: XCTestCase {
+  func testBuildsPermissionSetupWindowWithoutTriggeringActions() throws {
+    var actionsOpened = 0
+    let controller = PermissionSetupWindowController(
+      currentPermissions: {
+        PermissionSnapshot(accessibilityTrusted: true, screenCaptureTrusted: false)
+      },
+      onOpenScreenRecordingSettings: {
+        actionsOpened += 1
+      },
+      onOpenAccessibilitySettings: {
+        actionsOpened += 1
+      },
+      onRelaunch: {
+        actionsOpened += 1
+      }
+    )
+
+    let window = try XCTUnwrap(controller.window)
+    XCTAssertEqual(window.title, "agentd Permissions")
+    XCTAssertNotNil(window.contentView)
+    XCTAssertEqual(actionsOpened, 0)
+    controller.close()
+  }
+}


### PR DESCRIPTION
## Summary
- add a native permission setup window from the menu bar with current Screen Recording and Accessibility status, stable bundle identity, direct Settings links, recheck, and relaunch
- document the new TCC recovery surface in the README
- harden capture worker supervisor tests with explicit TERM handlers and cover the new AppKit setup window construction

## Validation
- swift test
- swift build -Xswiftc -warnings-as-errors
- xcrun swift-format lint --strict --recursive Sources Tests Package.swift
- python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
- python3 scripts/chronicle_parity_audit.py --strict
- scripts/package_app.sh
- git diff --check
- AGENTD_APP_PATH="/Applications/EvalOps agentd.app" ./script/build_and_run.sh --tcc-verify
- AGENTD_APP_PATH="/Applications/EvalOps agentd.app" AGENTD_SMOKE_FOREGROUND_APP="Safari" ./script/build_and_run.sh --local-batch-verify

## Notes
- I re-granted Screen & System Audio Recording and Accessibility for /Applications/EvalOps agentd.app before the hardware-backed TCC verification.
- Apple documents Accessibility grants as a Privacy & Security setting that may require manually adding the app when it is not listed; this panel keeps that exact bundle path visible during recovery.