### PR TITLE
Fix capture worker supervisor CI flake

### DIFF
--- a/Sources/agentd/CaptureWorkerSupervisor.swift
+++ b/Sources/agentd/CaptureWorkerSupervisor.swift
@@ -117,11 +117,18 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
 
     let pid = target.processIdentifier
     Log.capture.info("terminating capture worker safely with TERM pid=\(pid, privacy: .public)")
-    target.terminate()
-    let exitedAfterTerm = Self.wait(for: target, timeoutSeconds: max(0, graceSeconds))
+    let termSent = Darwin.kill(pid, SIGTERM) == 0
+    let exitedAfterTerm =
+      termSent && Self.wait(for: target, timeoutSeconds: max(0, graceSeconds))
     if exitedAfterTerm {
       Log.capture.info("capture worker terminated safely with TERM pid=\(pid, privacy: .public)")
-      return recordTermination(process: target, pid: pid, killSent: false, exited: true)
+      return recordTermination(
+        process: target,
+        pid: pid,
+        termSent: termSent,
+        killSent: false,
+        exited: true
+      )
     }
 
     Log.capture.error(
@@ -133,7 +140,13 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
         "capture worker forcefully terminated pid=\(pid, privacy: .public)"
       )
     }
-    return recordTermination(process: target, pid: pid, killSent: true, exited: exitedAfterKill)
+    return recordTermination(
+      process: target,
+      pid: pid,
+      termSent: termSent,
+      killSent: true,
+      exited: exitedAfterKill
+    )
   }
 
   func waitForExit(timeoutSeconds: TimeInterval) -> CaptureWorkerTerminationResult? {
@@ -193,13 +206,13 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
   }
 
   private static func wait(for process: Process, timeoutSeconds: TimeInterval) -> Bool {
-    guard process.isRunning else { return true }
-    let group = DispatchGroup()
-    group.enter()
-    DispatchQueue.global(qos: .utility).async {
-      process.waitUntilExit()
-      group.leave()
+    let deadline = Date().addingTimeInterval(max(0, timeoutSeconds))
+    while process.isRunning {
+      let remaining = deadline.timeIntervalSinceNow
+      guard remaining > 0 else { return false }
+      Thread.sleep(forTimeInterval: min(0.01, remaining))
     }
-    return group.wait(timeout: .now() + timeoutSeconds) == .success
+    process.waitUntilExit()
+    return true
   }
 }

--- a/Sources/agentd/CaptureWorkerSupervisor.swift
+++ b/Sources/agentd/CaptureWorkerSupervisor.swift
@@ -117,9 +117,8 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
 
     let pid = target.processIdentifier
     Log.capture.info("terminating capture worker safely with TERM pid=\(pid, privacy: .public)")
-    let termSent = Darwin.kill(pid, SIGTERM) == 0
-    let exitedAfterTerm =
-      termSent && Self.wait(for: target, timeoutSeconds: max(0, graceSeconds))
+    let termSent = target.isRunning && Darwin.kill(pid, SIGTERM) == 0
+    let exitedAfterTerm = Self.wait(for: target, timeoutSeconds: max(0, graceSeconds))
     if exitedAfterTerm {
       Log.capture.info("capture worker terminated safely with TERM pid=\(pid, privacy: .public)")
       return recordTermination(


### PR DESCRIPTION
## Summary
- send capture-worker TERM through the same explicit POSIX signal path used for KILL
- make supervisor waits synchronous/polling instead of relying on a global queue waiter
- make signal fixture scripts install explicit TERM handlers before readiness

## Evidence
- live failing main run: https://github.com/evalops/agentd/actions/runs/25121032268 failed in `CaptureWorkerSupervisorTests.testTerminatesWorkerWithTermDuringGraceWindow`
- earlier PR run: https://github.com/evalops/agentd/actions/runs/25120714164 failed the paired force-kill signal fixture, showing the signal/wait harness was timing-sensitive

## Local verification
- `swift build -Xswiftc -warnings-as-errors`
- `swift test`
- `for i in {1..5}; do swift test; done`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `python3 scripts/macos_availability_audit.py`
- `scripts/package_app.sh`
- `git diff --check`