### PR TITLE
Add Sparkle updater release path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Validate macOS availability floor
         run: python3 scripts/macos_availability_audit.py
 
+      - name: Validate Sparkle appcast tooling
+        run: python3 scripts/sparkle_appcast.py self-test
+
       - name: Lint Swift formatting
         run: xcrun swift-format lint --strict --recursive Sources Tests Package.swift
 

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -11,6 +11,9 @@ on:
         description: Swift build configuration
         required: false
         default: release
+      sparkle_download_url:
+        description: HTTPS URL where the notarized agentd.zip update archive will be hosted
+        required: true
 
 permissions:
   contents: read
@@ -47,6 +50,9 @@ jobs:
           AGENTD_NOTARY_APPLE_ID: ${{ secrets.AGENTD_NOTARY_APPLE_ID }}
           AGENTD_NOTARY_TEAM_ID: ${{ secrets.AGENTD_NOTARY_TEAM_ID }}
           AGENTD_NOTARY_PASSWORD: ${{ secrets.AGENTD_NOTARY_PASSWORD }}
+          AGENTD_SPARKLE_FEED_URL: ${{ secrets.AGENTD_SPARKLE_FEED_URL }}
+          AGENTD_SPARKLE_PUBLIC_ED_KEY: ${{ secrets.AGENTD_SPARKLE_PUBLIC_ED_KEY }}
+          AGENTD_SPARKLE_PRIVATE_ED_KEY: ${{ secrets.AGENTD_SPARKLE_PRIVATE_ED_KEY }}
         run: |
           set -euo pipefail
           missing=0
@@ -56,13 +62,20 @@ jobs:
             AGENTD_CODESIGN_IDENTITY \
             AGENTD_NOTARY_APPLE_ID \
             AGENTD_NOTARY_TEAM_ID \
-            AGENTD_NOTARY_PASSWORD
+            AGENTD_NOTARY_PASSWORD \
+            AGENTD_SPARKLE_FEED_URL \
+            AGENTD_SPARKLE_PUBLIC_ED_KEY \
+            AGENTD_SPARKLE_PRIVATE_ED_KEY
           do
             if [ -z "${!name:-}" ]; then
               echo "::error::Missing required secret $name"
               missing=1
             fi
           done
+          if [ -z "${{ inputs.sparkle_download_url }}" ]; then
+            echo "::error::Missing required workflow input sparkle_download_url"
+            missing=1
+          fi
           exit "$missing"
 
       - name: Import Developer ID certificate
@@ -86,6 +99,14 @@ jobs:
           security list-keychains -d user -s "$keychain" login.keychain-db
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$keychain"
 
+      - name: Write Sparkle signing key
+        env:
+          AGENTD_SPARKLE_PRIVATE_ED_KEY: ${{ secrets.AGENTD_SPARKLE_PRIVATE_ED_KEY }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$AGENTD_SPARKLE_PRIVATE_ED_KEY" > "$RUNNER_TEMP/sparkle-ed25519.key"
+          chmod 0600 "$RUNNER_TEMP/sparkle-ed25519.key"
+
       - name: Build, sign, notarize, and staple
         env:
           CONFIGURATION: ${{ inputs.configuration }}
@@ -93,6 +114,11 @@ jobs:
           AGENTD_NOTARY_APPLE_ID: ${{ secrets.AGENTD_NOTARY_APPLE_ID }}
           AGENTD_NOTARY_TEAM_ID: ${{ secrets.AGENTD_NOTARY_TEAM_ID }}
           AGENTD_NOTARY_PASSWORD: ${{ secrets.AGENTD_NOTARY_PASSWORD }}
+          AGENTD_SPARKLE_FEED_URL: ${{ secrets.AGENTD_SPARKLE_FEED_URL }}
+          AGENTD_SPARKLE_PUBLIC_ED_KEY: ${{ secrets.AGENTD_SPARKLE_PUBLIC_ED_KEY }}
+          AGENTD_SPARKLE_DOWNLOAD_URL: ${{ inputs.sparkle_download_url }}
+          AGENTD_SPARKLE_ED_KEY_FILE: ${{ runner.temp }}/sparkle-ed25519.key
+          AGENTD_SPARKLE_REQUIRE_SIGNED_FEED: "1"
         run: scripts/package_app.sh
 
       - name: Record checksums
@@ -100,7 +126,11 @@ jobs:
           set -euo pipefail
           (
             cd dist
-            shasum -a 256 "EvalOps agentd.app/Contents/MacOS/agentd" "agentd.zip" "update-channel.json" | tee SHA256SUMS
+            files=("EvalOps agentd.app/Contents/MacOS/agentd" "agentd.zip" "update-channel.json")
+            if [ -f appcast.xml ]; then
+              files+=("appcast.xml")
+            fi
+            shasum -a 256 "${files[@]}" | tee SHA256SUMS
           )
           codesign -dvvv --entitlements :- "dist/EvalOps agentd.app" > dist/codesign.txt 2>&1
           spctl -a -t exec -vv "dist/EvalOps agentd.app" > dist/spctl.txt 2>&1
@@ -114,6 +144,7 @@ jobs:
             dist/agentd.zip
             dist/SHA256SUMS
             dist/update-channel.json
+            dist/appcast.xml
             dist/codesign.txt
             dist/spctl.txt
           if-no-files-found: error

--- a/Package.swift
+++ b/Package.swift
@@ -8,9 +8,15 @@ let package = Package(
   products: [
     .executable(name: "agentd", targets: ["agentd"])
   ],
+  dependencies: [
+    .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.1")
+  ],
   targets: [
     .executableTarget(
       name: "agentd",
+      dependencies: [
+        .product(name: "Sparkle", package: "Sparkle")
+      ],
       path: "Sources/agentd",
       linkerSettings: [
         .unsafeFlags([
@@ -18,6 +24,8 @@ let package = Package(
           "-Xlinker", "__TEXT",
           "-Xlinker", "__info_plist",
           "-Xlinker", "support/Info.plist",
+          "-Xlinker", "-rpath",
+          "-Xlinker", "@executable_path/../Frameworks",
         ])
       ]
     ),

--- a/README.md
+++ b/README.md
@@ -146,11 +146,23 @@ allowed app to probe a different foreground surface.
 
 `scripts/package_app.sh` creates `dist/EvalOps agentd.app` and
 `dist/agentd.zip`. By default CI uses ad-hoc signing with hardened runtime so
-the bundle shape and entitlements are continuously checked. For release signing,
-set `AGENTD_CODESIGN_IDENTITY` to a Developer ID Application identity. To
-notarize and staple the bundle, either set `AGENTD_NOTARY_PROFILE` for a
-notarytool keychain profile or set `AGENTD_NOTARY_APPLE_ID`,
-`AGENTD_NOTARY_TEAM_ID`, and `AGENTD_NOTARY_PASSWORD`.
+the bundle shape, embedded Sparkle framework, and entitlements are continuously
+checked. Release builds inject `AGENTD_SPARKLE_FEED_URL` and
+`AGENTD_SPARKLE_PUBLIC_ED_KEY` so the menu bar's "Check for Updates..." action
+can use Sparkle. When `AGENTD_SPARKLE_DOWNLOAD_URL` is set, the package script
+signs the final zip with Sparkle EdDSA, writes `dist/appcast.xml`, and verifies
+that the appcast enclosure URL, signature, version, and archive length match the
+packaged artifact. Release workflow builds also enable Sparkle signed-feed
+validation so compromised update metadata cannot redirect users to a different
+archive. To dry-run Sparkle's update discovery against a packaged bundle, use
+`scripts/sparkle_update_probe.sh` with `AGENTD_SPARKLE_PROBE_FEED_URL` or a
+local `dist/appcast.xml`.
+
+For release signing, set `AGENTD_CODESIGN_IDENTITY` to a Developer ID
+Application identity. To notarize and staple the bundle, either set
+`AGENTD_NOTARY_PROFILE` for a notarytool keychain profile or set
+`AGENTD_NOTARY_APPLE_ID`, `AGENTD_NOTARY_TEAM_ID`, and
+`AGENTD_NOTARY_PASSWORD`.
 
 The `package-release` GitHub Actions workflow performs the credential-backed
 release path and uploads the stapled app, archive, checksums, codesign details,
@@ -165,6 +177,14 @@ it:
 - `AGENTD_NOTARY_APPLE_ID`
 - `AGENTD_NOTARY_TEAM_ID`
 - `AGENTD_NOTARY_PASSWORD`: app-specific password for notarization.
+- `AGENTD_SPARKLE_FEED_URL`
+- `AGENTD_SPARKLE_PUBLIC_ED_KEY`
+- `AGENTD_SPARKLE_PRIVATE_ED_KEY`: the private key text exported with Sparkle's
+  `generate_keys -x`; store it as a secret and rotate it if exposed.
+
+The workflow also requires a `sparkle_download_url` dispatch input. It must be
+the final HTTPS URL where the uploaded `agentd.zip` will be served, because
+Sparkle validates the appcast enclosure URL before downloading the update.
 
 `scripts/permission_smoke.sh` packages the app when needed, installs the tested
 bundle to `/Applications/EvalOps agentd.app` by default, records macOS

--- a/Sources/agentd/MenuBarController.swift
+++ b/Sources/agentd/MenuBarController.swift
@@ -12,6 +12,7 @@ final class MenuBarController: NSObject {
   private var permissionItem: NSMenuItem?
   private var screenRecordingItem: NSMenuItem?
   private var accessibilityItem: NSMenuItem?
+  private var checkForUpdatesItem: NSMenuItem?
   private var aboutItem: NSMenuItem?
   private var launchAtLoginItem: NSMenuItem?
   private var paused: Bool = false
@@ -27,6 +28,7 @@ final class MenuBarController: NSObject {
   private let onOpenAccessibilitySettings: @Sendable () -> Void
   private let onRelaunch: @Sendable () -> Void
   private let onLaunchAtLoginToggle: @Sendable (Bool) -> Void
+  private let configureUpdatesMenuItem: @MainActor (NSMenuItem) -> Void
   private let onQuit: @Sendable () -> Void
 
   init(
@@ -41,6 +43,7 @@ final class MenuBarController: NSObject {
     onOpenAccessibilitySettings: @escaping @Sendable () -> Void,
     onRelaunch: @escaping @Sendable () -> Void,
     onLaunchAtLoginToggle: @escaping @Sendable (Bool) -> Void,
+    configureUpdatesMenuItem: @escaping @MainActor (NSMenuItem) -> Void,
     onQuit: @escaping @Sendable () -> Void
   ) {
     self.onPauseToggle = onPauseToggle
@@ -54,6 +57,7 @@ final class MenuBarController: NSObject {
     self.onOpenAccessibilitySettings = onOpenAccessibilitySettings
     self.onRelaunch = onRelaunch
     self.onLaunchAtLoginToggle = onLaunchAtLoginToggle
+    self.configureUpdatesMenuItem = configureUpdatesMenuItem
     self.onQuit = onQuit
     self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     super.init()
@@ -155,6 +159,12 @@ final class MenuBarController: NSObject {
     launchAtLoginItem = launchItem
     menu.addItem(launchItem)
 
+    let checkForUpdatesItem = NSMenuItem(
+      title: "Check for Updates…", action: nil, keyEquivalent: "")
+    configureUpdatesMenuItem(checkForUpdatesItem)
+    self.checkForUpdatesItem = checkForUpdatesItem
+    menu.addItem(checkForUpdatesItem)
+
     menu.addItem(.separator())
 
     let about = NSMenuItem(
@@ -214,6 +224,9 @@ final class MenuBarController: NSObject {
     let policy = policyVersion.map { " policy \($0)" } ?? ""
     aboutItem?.title = "agentd \(Bundle.main.appVersion) — \(mode)\(policy)"
     launchAtLoginItem?.state = LaunchAtLoginController.isEnabled ? .on : .off
+    if let checkForUpdatesItem {
+      configureUpdatesMenuItem(checkForUpdatesItem)
+    }
   }
 
   private func statusSymbol(paused: Bool, needsPermission: Bool) -> String {

--- a/Sources/agentd/SparkleSoftwareUpdater.swift
+++ b/Sources/agentd/SparkleSoftwareUpdater.swift
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import AppKit
+import Foundation
+import Sparkle
+
+struct SparkleUpdaterConfiguration: Equatable {
+  let feedURL: URL?
+  let publicEDKey: String
+
+  var isConfigured: Bool {
+    feedURL != nil && !publicEDKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+
+  var disabledReason: String {
+    let missingFeed = feedURL == nil
+    let missingKey = publicEDKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    switch (missingFeed, missingKey) {
+    case (true, true):
+      return "Sparkle update feed and public key are not configured for this build."
+    case (true, false):
+      return "Sparkle update feed is not configured for this build."
+    case (false, true):
+      return "Sparkle public key is not configured for this build."
+    case (false, false):
+      return ""
+    }
+  }
+
+  static func read(from infoDictionary: [String: Any]) -> SparkleUpdaterConfiguration {
+    let feed = (infoDictionary["SUFeedURL"] as? String)
+      .flatMap { URL(string: $0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+    let publicKey = infoDictionary["SUPublicEDKey"] as? String ?? ""
+    return SparkleUpdaterConfiguration(feedURL: feed, publicEDKey: publicKey)
+  }
+}
+
+@MainActor
+final class SparkleSoftwareUpdater {
+  private let configuration: SparkleUpdaterConfiguration
+  private let updaterController: SPUStandardUpdaterController?
+
+  init(bundle: Bundle = .main) {
+    let configuration = SparkleUpdaterConfiguration.read(from: bundle.infoDictionary ?? [:])
+    self.configuration = configuration
+    if configuration.isConfigured {
+      self.updaterController = SPUStandardUpdaterController(
+        startingUpdater: true,
+        updaterDelegate: nil,
+        userDriverDelegate: nil
+      )
+    } else {
+      self.updaterController = nil
+    }
+  }
+
+  func configure(menuItem: NSMenuItem) {
+    guard let updaterController else {
+      menuItem.target = nil
+      menuItem.action = nil
+      menuItem.isEnabled = false
+      menuItem.toolTip = configuration.disabledReason
+      return
+    }
+
+    menuItem.target = updaterController
+    menuItem.action = #selector(SPUStandardUpdaterController.checkForUpdates(_:))
+    menuItem.isEnabled = updaterController.updater.canCheckForUpdates
+    menuItem.toolTip = "Check for a signed EvalOps agentd update."
+  }
+}

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -13,6 +13,7 @@ final class AppController {
   private var runtimeLock: AgentdRuntimeLock?
   private var capture: CaptureService!
   private var menuBar: MenuBarController!
+  private var softwareUpdater: SparkleSoftwareUpdater?
   private var permissionSetupWindow: PermissionSetupWindowController?
   private var userPaused = false
   private var captureRunning = false
@@ -116,6 +117,8 @@ final class AppController {
       await pipeline.recordBackpressureDrop()
     }
 
+    let softwareUpdater = SparkleSoftwareUpdater()
+    self.softwareUpdater = softwareUpdater
     menuBar = MenuBarController(
       onPauseToggle: { [weak self] paused in
         Task { @MainActor in await self?.applyPause(paused) }
@@ -167,6 +170,9 @@ final class AppController {
             "launch-at-login update failed: \(error.localizedDescription, privacy: .public)"
           )
         }
+      },
+      configureUpdatesMenuItem: { menuItem in
+        softwareUpdater.configure(menuItem: menuItem)
       },
       onQuit: {
         Task { @MainActor in NSApp.terminate(nil) }

--- a/Tests/agentdTests/SparkleUpdaterConfigurationTests.swift
+++ b/Tests/agentdTests/SparkleUpdaterConfigurationTests.swift
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import XCTest
+
+@testable import agentd
+
+final class SparkleUpdaterConfigurationTests: XCTestCase {
+  func testConfiguredWhenFeedAndPublicKeyArePresent() {
+    let cfg = SparkleUpdaterConfiguration.read(from: [
+      "SUFeedURL": "https://updates.example.invalid/agentd/appcast.xml",
+      "SUPublicEDKey": "public-key",
+    ])
+
+    XCTAssertTrue(cfg.isConfigured)
+    XCTAssertEqual(
+      cfg.feedURL?.absoluteString,
+      "https://updates.example.invalid/agentd/appcast.xml"
+    )
+    XCTAssertEqual(cfg.publicEDKey, "public-key")
+  }
+
+  func testDisabledWithoutFeedOrPublicKey() {
+    let cfg = SparkleUpdaterConfiguration.read(from: [:])
+
+    XCTAssertFalse(cfg.isConfigured)
+    XCTAssertEqual(
+      cfg.disabledReason,
+      "Sparkle update feed and public key are not configured for this build."
+    )
+  }
+
+  func testDisabledWhenPublicKeyIsBlank() {
+    let cfg = SparkleUpdaterConfiguration.read(from: [
+      "SUFeedURL": "https://updates.example.invalid/agentd/appcast.xml",
+      "SUPublicEDKey": "   ",
+    ])
+
+    XCTAssertFalse(cfg.isConfigured)
+    XCTAssertEqual(cfg.disabledReason, "Sparkle public key is not configured for this build.")
+  }
+}

--- a/docs/release-update-channel.md
+++ b/docs/release-update-channel.md
@@ -10,14 +10,49 @@ The signed update-channel path is intentionally evidence-first:
 3. Notarize with `notarytool`.
 4. Staple with `xcrun stapler`.
 5. Validate with `spctl -a -t exec -vv`.
-6. Publish `dist/agentd.zip`, `dist/SHA256SUMS`, `dist/codesign.txt`, and
-   `dist/spctl.txt` as release evidence.
-7. Publish update metadata only after the artifact checksum, signing identity,
-   notarization request id, and Gatekeeper output are recorded.
+6. Sign the final `dist/agentd.zip` with Sparkle EdDSA and generate
+   `dist/appcast.xml`.
+7. Publish `dist/agentd.zip`, `dist/appcast.xml`, `dist/SHA256SUMS`,
+   `dist/update-channel.json`, `dist/codesign.txt`, and `dist/spctl.txt` as
+   release evidence.
+8. Publish update metadata only after the archive checksum, Sparkle signature,
+   signing identity, notarization request id, and Gatekeeper output are recorded.
 
-Sparkle remains the preferred full auto-update framework once product policy
-allows automatic delivery. Until then, the update channel is a signed manual
-feed: publish checksummed artifacts and metadata from the notarized workflow,
-and never advance update metadata for an artifact that has not passed the same
-sign, notarize, staple, and Gatekeeper checks.
+Sparkle is now the release update framework. Local and ad-hoc packages keep the
+menu item disabled unless the package step injects both `SUFeedURL` and
+`SUPublicEDKey`; this prevents a developer build from pointing at production
+updates by accident. A release package that sets `AGENTD_SPARKLE_DOWNLOAD_URL`
+must also be notarized and must produce a signed appcast.
 
+Sparkle release configuration is injected at package time:
+
+- `AGENTD_SPARKLE_FEED_URL`: hosted appcast URL embedded as `SUFeedURL`.
+- `AGENTD_SPARKLE_PUBLIC_ED_KEY`: base64 public EdDSA key embedded as
+  `SUPublicEDKey`.
+- `AGENTD_SPARKLE_DOWNLOAD_URL`: hosted HTTPS URL for the final `agentd.zip`;
+  when set, `scripts/package_app.sh` writes and verifies `dist/appcast.xml`.
+- `AGENTD_SPARKLE_ED_KEY_FILE`: path to an exported Sparkle private EdDSA key
+  for `sign_update --ed-key-file`. Local fixture testing may set
+  `AGENTD_SPARKLE_ED_SIGNATURE` instead, but releases should sign the final
+  zip after notarization/stapling.
+- `AGENTD_SPARKLE_REQUIRE_SIGNED_FEED=1`: signs `dist/appcast.xml` with
+  Sparkle and embeds `SURequireSignedFeed`. The release workflow enables this
+  by default.
+- `AGENTD_SPARKLE_RELEASE_NOTES_URL`: optional hosted release notes URL.
+- `AGENTD_SPARKLE_CHANNEL`: optional Sparkle channel, for example `beta`.
+- `AGENTD_SPARKLE_PHASED_ROLLOUT_INTERVAL`: optional rollout interval in
+  seconds. Sparkle rolls phased releases across seven groups.
+- `AGENTD_SPARKLE_MINIMUM_AUTOUPDATE_VERSION`: optional lower bound for silent
+  automatic installation of major upgrades.
+- `AGENTD_SPARKLE_CRITICAL_UPDATE=1`: marks the release as critical.
+
+For local appcast fixture testing without notarization, set
+`AGENTD_SPARKLE_ALLOW_UNNOTARIZED=1`; do not use that override in release
+automation.
+
+To probe an already packaged app without installing an update, run
+`scripts/sparkle_update_probe.sh`. It uses Sparkle's optional `sparkle` CLI
+from `AGENTD_SPARKLE_BIN_DIR` or any local artifact path where the CLI is
+present, uses `AGENTD_SPARKLE_PROBE_FEED_URL` when set, and falls back to
+`dist/appcast.xml` as a local file URL. A zero exit means Sparkle found an
+available update; non-zero exits preserve Sparkle's CLI result for debugging.

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -10,6 +10,19 @@ app_path="$dist_dir/$app_name.app"
 zip_path="$dist_dir/$product.zip"
 identity="${AGENTD_CODESIGN_IDENTITY:--}"
 entitlements="${AGENTD_ENTITLEMENTS:-"$root/support/agentd.entitlements"}"
+sparkle_feed_url="${AGENTD_SPARKLE_FEED_URL:-}"
+sparkle_public_ed_key="${AGENTD_SPARKLE_PUBLIC_ED_KEY:-}"
+sparkle_download_url="${AGENTD_SPARKLE_DOWNLOAD_URL:-}"
+sparkle_release_notes_url="${AGENTD_SPARKLE_RELEASE_NOTES_URL:-}"
+sparkle_channel="${AGENTD_SPARKLE_CHANNEL:-}"
+sparkle_phased_rollout_interval="${AGENTD_SPARKLE_PHASED_ROLLOUT_INTERVAL:-}"
+sparkle_minimum_autoupdate_version="${AGENTD_SPARKLE_MINIMUM_AUTOUPDATE_VERSION:-}"
+sparkle_critical_update="${AGENTD_SPARKLE_CRITICAL_UPDATE:-0}"
+sparkle_appcast_path="$dist_dir/appcast.xml"
+sparkle_ed_signature="${AGENTD_SPARKLE_ED_SIGNATURE:-}"
+sparkle_ed_key_file="${AGENTD_SPARKLE_ED_KEY_FILE:-}"
+sparkle_require_signed_feed="${AGENTD_SPARKLE_REQUIRE_SIGNED_FEED:-0}"
+sparkle_bin_dir="${AGENTD_SPARKLE_BIN_DIR:-}"
 
 mkdir -p "$dist_dir"
 
@@ -18,16 +31,201 @@ create_zip() {
   ditto -c -k --keepParent "$app_path" "$zip_path"
 }
 
+plist_set_or_add() {
+  local key="$1"
+  local type="$2"
+  local value="$3"
+  local plist="$4"
+  if /usr/libexec/PlistBuddy -c "Print :$key" "$plist" >/dev/null 2>&1; then
+    /usr/libexec/PlistBuddy -c "Set :$key $value" "$plist"
+  else
+    /usr/libexec/PlistBuddy -c "Add :$key $type $value" "$plist"
+  fi
+}
+
+require_matching_sparkle_config() {
+  if [[ -n "$sparkle_feed_url" || -n "$sparkle_public_ed_key" ]]; then
+    if [[ -z "$sparkle_feed_url" || -z "$sparkle_public_ed_key" ]]; then
+      echo "AGENTD_SPARKLE_FEED_URL and AGENTD_SPARKLE_PUBLIC_ED_KEY must be set together." >&2
+      exit 1
+    fi
+  fi
+  if [[ -n "$sparkle_download_url" ]]; then
+    if [[ -z "$sparkle_feed_url" || -z "$sparkle_public_ed_key" ]]; then
+      echo "AGENTD_SPARKLE_DOWNLOAD_URL requires Sparkle feed URL and public EdDSA key." >&2
+      exit 1
+    fi
+  fi
+}
+
+find_sparkle_framework() {
+  find "$root/.build" -path "*/Sparkle.framework" -type d -print -quit 2>/dev/null || true
+}
+
+find_sparkle_sign_update() {
+  if [[ -n "$sparkle_bin_dir" && -x "$sparkle_bin_dir/sign_update" ]]; then
+    printf '%s\n' "$sparkle_bin_dir/sign_update"
+    return
+  fi
+  find "$root/.build" -path "*/Sparkle/bin/sign_update" -type f -perm -111 -print -quit 2>/dev/null || true
+}
+
+codesign_nested_sparkle() {
+  local framework_path="$1"
+  local timestamp_args=()
+  if [[ "$identity" != "-" ]]; then
+    timestamp_args+=(--timestamp)
+  fi
+
+  codesign_sparkle_component() {
+    local target="$1"
+    shift
+    local args=(--force --sign "$identity" --options runtime "$@")
+    if [[ ${#timestamp_args[@]} -gt 0 ]]; then
+      args+=("${timestamp_args[@]}")
+    fi
+    args+=("$target")
+    codesign "${args[@]}"
+  }
+
+  local nested
+  for nested in \
+    "$framework_path"/Versions/*/XPCServices/*.xpc \
+    "$framework_path"/Versions/*/Autoupdate \
+    "$framework_path"/Versions/*/Updater.app
+  do
+    [[ -e "$nested" ]] || continue
+    if [[ "$(basename "$nested")" == "Downloader.xpc" ]]; then
+      codesign_sparkle_component "$nested" --preserve-metadata=entitlements
+    else
+      codesign_sparkle_component "$nested"
+    fi
+  done
+
+  codesign_sparkle_component "$framework_path"
+}
+
+sparkle_signature_for_zip() {
+  if [[ -n "$sparkle_ed_signature" ]]; then
+    printf '%s\n' "$sparkle_ed_signature"
+    return
+  fi
+
+  local sign_update
+  sign_update="$(find_sparkle_sign_update)"
+  if [[ -z "$sign_update" ]]; then
+    echo "Sparkle sign_update was not found. Set AGENTD_SPARKLE_BIN_DIR or AGENTD_SPARKLE_ED_SIGNATURE." >&2
+    exit 1
+  fi
+
+  local fragment
+  if [[ -n "$sparkle_ed_key_file" ]]; then
+    fragment="$("$sign_update" --ed-key-file "$sparkle_ed_key_file" "$zip_path")"
+  else
+    fragment="$("$sign_update" "$zip_path")"
+  fi
+  local signature
+  signature="$(printf '%s' "$fragment" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')"
+  if [[ -z "$signature" ]]; then
+    echo "Could not parse Sparkle EdDSA signature from sign_update output." >&2
+    printf '%s\n' "$fragment" >&2
+    exit 1
+  fi
+  printf '%s\n' "$signature"
+}
+
+write_sparkle_appcast() {
+  if [[ -z "$sparkle_download_url" ]]; then
+    rm -f "$sparkle_appcast_path"
+    return
+  fi
+  if [[ "$notarized" != "1" && "${AGENTD_SPARKLE_ALLOW_UNNOTARIZED:-0}" != "1" ]]; then
+    echo "Refusing to emit Sparkle appcast for an unnotarized archive." >&2
+    echo "Set AGENTD_SPARKLE_ALLOW_UNNOTARIZED=1 only for local fixture testing." >&2
+    exit 1
+  fi
+
+  local signature
+  signature="$(sparkle_signature_for_zip)"
+  local appcast_args=(
+    write
+    --archive "$zip_path" \
+    --info-plist "$app_path/Contents/Info.plist" \
+    --output "$sparkle_appcast_path" \
+    --download-url "$sparkle_download_url" \
+    --ed-signature "$signature"
+  )
+  if [[ -n "$sparkle_release_notes_url" ]]; then
+    appcast_args+=(--release-notes-url "$sparkle_release_notes_url")
+  fi
+  if [[ -n "$sparkle_channel" ]]; then
+    appcast_args+=(--channel "$sparkle_channel")
+  fi
+  if [[ -n "$sparkle_phased_rollout_interval" ]]; then
+    appcast_args+=(--phased-rollout-interval "$sparkle_phased_rollout_interval")
+  fi
+  if [[ -n "$sparkle_minimum_autoupdate_version" ]]; then
+    appcast_args+=(--minimum-autoupdate-version "$sparkle_minimum_autoupdate_version")
+  fi
+  if [[ "$sparkle_critical_update" == "1" ]]; then
+    appcast_args+=(--critical-update)
+  fi
+  python3 "$root/scripts/sparkle_appcast.py" "${appcast_args[@]}"
+  python3 "$root/scripts/sparkle_appcast.py" verify \
+    --appcast "$sparkle_appcast_path" \
+    --archive "$zip_path" \
+    --download-url "$sparkle_download_url" \
+    --require-https
+
+  if [[ "$sparkle_require_signed_feed" == "1" ]]; then
+    if [[ -z "$sparkle_ed_key_file" ]]; then
+      echo "AGENTD_SPARKLE_REQUIRE_SIGNED_FEED=1 requires AGENTD_SPARKLE_ED_KEY_FILE." >&2
+      exit 1
+    fi
+    local sign_update
+    sign_update="$(find_sparkle_sign_update)"
+    if [[ -z "$sign_update" ]]; then
+      echo "Sparkle sign_update was not found. Set AGENTD_SPARKLE_BIN_DIR." >&2
+      exit 1
+    fi
+    "$sign_update" --ed-key-file "$sparkle_ed_key_file" "$sparkle_appcast_path"
+    "$sign_update" --ed-key-file "$sparkle_ed_key_file" --verify "$sparkle_appcast_path"
+    python3 "$root/scripts/sparkle_appcast.py" verify \
+      --appcast "$sparkle_appcast_path" \
+      --archive "$zip_path" \
+      --download-url "$sparkle_download_url" \
+      --require-https
+  fi
+}
+
+require_matching_sparkle_config
+
 swift build -c "$configuration" --product "$product"
 build_bin_dir="$(swift build -c "$configuration" --product "$product" --show-bin-path)"
 binary="$build_bin_dir/$product"
 
 rm -rf "$app_path" "$zip_path"
-mkdir -p "$app_path/Contents/MacOS" "$app_path/Contents/Resources"
+mkdir -p "$app_path/Contents/MacOS" "$app_path/Contents/Resources" "$app_path/Contents/Frameworks"
 cp "$root/support/Info.plist" "$app_path/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleExecutable $product" "$app_path/Contents/Info.plist"
+if [[ -n "$sparkle_feed_url" ]]; then
+  plist_set_or_add "SUFeedURL" "string" "$sparkle_feed_url" "$app_path/Contents/Info.plist"
+  plist_set_or_add "SUPublicEDKey" "string" "$sparkle_public_ed_key" "$app_path/Contents/Info.plist"
+  plist_set_or_add "SUVerifyUpdateBeforeExtraction" "bool" "true" "$app_path/Contents/Info.plist"
+  if [[ "$sparkle_require_signed_feed" == "1" ]]; then
+    plist_set_or_add "SURequireSignedFeed" "bool" "true" "$app_path/Contents/Info.plist"
+  fi
+fi
 cp "$binary" "$app_path/Contents/MacOS/$product"
 chmod 0755 "$app_path/Contents/MacOS/$product"
+
+sparkle_framework="$(find_sparkle_framework)"
+if [[ -z "$sparkle_framework" ]]; then
+  echo "Sparkle.framework was not found under $root/.build after SwiftPM build." >&2
+  exit 1
+fi
+ditto "$sparkle_framework" "$app_path/Contents/Frameworks/Sparkle.framework"
+codesign_nested_sparkle "$app_path/Contents/Frameworks/Sparkle.framework"
 
 codesign_args=(
   --force
@@ -69,25 +267,60 @@ if [[ "$notarized" == "1" ]] && command -v spctl >/dev/null 2>&1; then
   create_zip
 fi
 
+write_sparkle_appcast
+
 notarized_json=false
 if [[ "$notarized" == "1" ]]; then
   notarized_json=true
 fi
+sparkle_enabled_json=false
+sparkle_public_key_configured_json=false
+sparkle_require_signed_feed_json=false
+sparkle_appcast_json=""
+if [[ -n "$sparkle_feed_url" ]]; then
+  sparkle_enabled_json=true
+  sparkle_public_key_configured_json=true
+fi
+if [[ "$sparkle_require_signed_feed" == "1" ]]; then
+  sparkle_require_signed_feed_json=true
+fi
+if [[ -f "$sparkle_appcast_path" ]]; then
+  sparkle_appcast_json="appcast.xml"
+fi
 zip_sha256="$(shasum -a 256 "$zip_path" | awk '{print $1}')"
 app_binary_sha256="$(shasum -a 256 "$app_path/Contents/MacOS/$product" | awk '{print $1}')"
-cat > "$dist_dir/update-channel.json" <<JSON
-{
-  "product": "$product",
-  "appName": "$app_name",
-  "configuration": "$configuration",
-  "archive": "$(basename "$zip_path")",
-  "archiveSha256": "$zip_sha256",
-  "appBinarySha256": "$app_binary_sha256",
-  "codesignIdentity": "$identity",
-  "notarized": $notarized_json
+python3 - "$dist_dir/update-channel.json" <<PY
+import json
+import sys
+
+payload = {
+    "product": "$product",
+    "appName": "$app_name",
+    "configuration": "$configuration",
+    "archive": "$(basename "$zip_path")",
+    "archiveSha256": "$zip_sha256",
+    "appBinarySha256": "$app_binary_sha256",
+    "codesignIdentity": "$identity",
+    "notarized": "$notarized_json" == "true",
+    "sparkleEnabled": "$sparkle_enabled_json" == "true",
+    "sparkleFeedURL": "$sparkle_feed_url",
+    "sparklePublicEDKeyConfigured": "$sparkle_public_key_configured_json" == "true",
+    "sparkleRequireSignedFeed": "$sparkle_require_signed_feed_json" == "true",
+    "sparkleDownloadURL": "$sparkle_download_url",
+    "sparkleAppcast": "$sparkle_appcast_json" or None,
+    "sparkleChannel": "$sparkle_channel",
+    "sparklePhasedRolloutInterval": "$sparkle_phased_rollout_interval",
+    "sparkleMinimumAutoupdateVersion": "$sparkle_minimum_autoupdate_version",
+    "sparkleCriticalUpdate": "$sparkle_critical_update" == "1",
 }
-JSON
+with open(sys.argv[1], "w", encoding="utf-8") as fh:
+    json.dump(payload, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+PY
 
 echo "Packaged $app_path"
 echo "Archive $zip_path"
 echo "Update metadata $dist_dir/update-channel.json"
+if [[ -f "$sparkle_appcast_path" ]]; then
+  echo "Sparkle appcast $sparkle_appcast_path"
+fi

--- a/scripts/sparkle_appcast.py
+++ b/scripts/sparkle_appcast.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BUSL-1.1
+"""Write and verify the agentd Sparkle appcast metadata."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import plistlib
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+SPARKLE_NS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+ET.register_namespace("sparkle", SPARKLE_NS)
+
+
+def _sparkle(name: str) -> str:
+    return f"{{{SPARKLE_NS}}}{name}"
+
+
+def _read_versions(plist_path: Path) -> tuple[str, str]:
+    with plist_path.open("rb") as fh:
+        plist = plistlib.load(fh)
+    version = str(plist.get("CFBundleVersion") or "")
+    short_version = str(plist.get("CFBundleShortVersionString") or version)
+    if not version:
+        raise SystemExit(f"{plist_path} does not contain CFBundleVersion")
+    return version, short_version
+
+
+def _pubdate() -> str:
+    source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if source_date_epoch:
+        when = dt.datetime.fromtimestamp(int(source_date_epoch), tz=dt.timezone.utc)
+    else:
+        when = dt.datetime.now(tz=dt.timezone.utc)
+    return when.strftime("%a, %d %b %Y %H:%M:%S %z")
+
+
+def write_appcast(args: argparse.Namespace) -> None:
+    archive = args.archive.resolve()
+    if not archive.exists():
+        raise SystemExit(f"archive does not exist: {archive}")
+    signature = args.ed_signature.strip()
+    if not signature:
+        raise SystemExit("--ed-signature is required for Sparkle appcasts")
+
+    version, short_version = _read_versions(args.info_plist)
+    length = archive.stat().st_size
+
+    rss = ET.Element("rss", {"version": "2.0"})
+    channel = ET.SubElement(rss, "channel")
+    ET.SubElement(channel, "title").text = args.title
+    ET.SubElement(channel, "description").text = "Signed EvalOps agentd updates"
+    item = ET.SubElement(channel, "item")
+    ET.SubElement(item, "title").text = f"Version {short_version}"
+    if args.channel:
+        ET.SubElement(item, _sparkle("channel")).text = args.channel
+    ET.SubElement(item, _sparkle("version")).text = version
+    ET.SubElement(item, _sparkle("shortVersionString")).text = short_version
+    if args.minimum_autoupdate_version:
+        ET.SubElement(item, _sparkle("minimumAutoupdateVersion")).text = (
+            args.minimum_autoupdate_version
+        )
+    if args.phased_rollout_interval:
+        ET.SubElement(item, _sparkle("phasedRolloutInterval")).text = str(
+            args.phased_rollout_interval
+        )
+    if args.critical_update:
+        ET.SubElement(item, _sparkle("criticalUpdate"))
+    ET.SubElement(item, "pubDate").text = _pubdate()
+    if args.release_notes_url:
+        ET.SubElement(item, _sparkle("releaseNotesLink")).text = args.release_notes_url
+    ET.SubElement(
+        item,
+        "enclosure",
+        {
+            "url": args.download_url,
+            _sparkle("edSignature"): signature,
+            "length": str(length),
+            "type": "application/octet-stream",
+        },
+    )
+    ET.SubElement(item, _sparkle("minimumSystemVersion")).text = args.minimum_system_version
+
+    ET.indent(rss)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    tree = ET.ElementTree(rss)
+    tree.write(args.output, encoding="utf-8", xml_declaration=True)
+    print(f"Wrote Sparkle appcast {args.output}")
+
+
+def _first_item(root: ET.Element) -> ET.Element:
+    item = root.find("./channel/item")
+    if item is None:
+        raise SystemExit("appcast is missing channel/item")
+    return item
+
+
+def verify_appcast(args: argparse.Namespace) -> None:
+    root = ET.parse(args.appcast).getroot()
+    item = _first_item(root)
+    enclosure = item.find("enclosure")
+    if enclosure is None:
+        raise SystemExit("appcast item is missing enclosure")
+
+    url = enclosure.attrib.get("url", "")
+    signature = enclosure.attrib.get(_sparkle("edSignature"), "")
+    length = enclosure.attrib.get("length", "")
+    version = item.findtext(_sparkle("version"), "")
+    short_version = item.findtext(_sparkle("shortVersionString"), "")
+    channel = item.findtext(_sparkle("channel"), "")
+    rollout = item.findtext(_sparkle("phasedRolloutInterval"), "")
+
+    if args.require_https and not url.startswith("https://"):
+        raise SystemExit(f"appcast enclosure URL must use https://, got {url!r}")
+    if args.download_url and url != args.download_url:
+        raise SystemExit(f"download URL mismatch: expected {args.download_url!r}, got {url!r}")
+    if args.expected_version and version != args.expected_version:
+        raise SystemExit(f"version mismatch: expected {args.expected_version!r}, got {version!r}")
+    if args.expected_short_version and short_version != args.expected_short_version:
+        raise SystemExit(
+            "short version mismatch: "
+            f"expected {args.expected_short_version!r}, got {short_version!r}"
+        )
+    if args.expected_channel and channel != args.expected_channel:
+        raise SystemExit(f"channel mismatch: expected {args.expected_channel!r}, got {channel!r}")
+    if args.expected_phased_rollout_interval:
+        expected_rollout = str(args.expected_phased_rollout_interval)
+        if rollout != expected_rollout:
+            raise SystemExit(
+                "phased rollout interval mismatch: "
+                f"expected {expected_rollout!r}, got {rollout!r}"
+            )
+    if not signature.strip():
+        raise SystemExit("appcast enclosure is missing sparkle:edSignature")
+    if not length.isdigit() or int(length) <= 0:
+        raise SystemExit(f"appcast enclosure has invalid length: {length!r}")
+    if args.archive and int(length) != args.archive.stat().st_size:
+        raise SystemExit(
+            f"archive length mismatch: expected {args.archive.stat().st_size}, got {length}"
+        )
+
+    print(f"Verified Sparkle appcast {args.appcast}")
+
+
+def self_test(_: argparse.Namespace) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        base = Path(tmp)
+        archive = base / "agentd.zip"
+        archive.write_bytes(b"agentd update archive")
+        plist = base / "Info.plist"
+        with plist.open("wb") as fh:
+            plistlib.dump(
+                {
+                    "CFBundleVersion": "42",
+                    "CFBundleShortVersionString": "1.2.3",
+                },
+                fh,
+            )
+        appcast = base / "appcast.xml"
+        write_appcast(
+            argparse.Namespace(
+                archive=archive,
+                info_plist=plist,
+                output=appcast,
+                download_url="https://updates.example.invalid/agentd.zip",
+                ed_signature="fixture-signature",
+                release_notes_url=None,
+                title="EvalOps agentd Updates",
+                minimum_system_version="14.0.0",
+                channel="beta",
+                phased_rollout_interval=86400,
+                minimum_autoupdate_version=None,
+                critical_update=False,
+            )
+        )
+        verify_appcast(
+            argparse.Namespace(
+                appcast=appcast,
+                archive=archive,
+                download_url="https://updates.example.invalid/agentd.zip",
+                expected_version="42",
+                expected_short_version="1.2.3",
+                expected_channel="beta",
+                expected_phased_rollout_interval=86400,
+                require_https=True,
+            )
+        )
+    print("Sparkle appcast self-test passed")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    write_parser = subparsers.add_parser("write")
+    write_parser.add_argument("--archive", required=True, type=Path)
+    write_parser.add_argument("--info-plist", required=True, type=Path)
+    write_parser.add_argument("--output", required=True, type=Path)
+    write_parser.add_argument("--download-url", required=True)
+    write_parser.add_argument("--ed-signature", required=True)
+    write_parser.add_argument("--release-notes-url")
+    write_parser.add_argument("--title", default="EvalOps agentd Updates")
+    write_parser.add_argument("--minimum-system-version", default="14.0.0")
+    write_parser.add_argument("--channel")
+    write_parser.add_argument("--phased-rollout-interval", type=int)
+    write_parser.add_argument("--minimum-autoupdate-version")
+    write_parser.add_argument("--critical-update", action="store_true")
+    write_parser.set_defaults(func=write_appcast)
+
+    verify_parser = subparsers.add_parser("verify")
+    verify_parser.add_argument("--appcast", required=True, type=Path)
+    verify_parser.add_argument("--archive", type=Path)
+    verify_parser.add_argument("--download-url")
+    verify_parser.add_argument("--expected-version")
+    verify_parser.add_argument("--expected-short-version")
+    verify_parser.add_argument("--expected-channel")
+    verify_parser.add_argument("--expected-phased-rollout-interval", type=int)
+    verify_parser.add_argument("--require-https", action="store_true")
+    verify_parser.set_defaults(func=verify_appcast)
+
+    self_test_parser = subparsers.add_parser("self-test")
+    self_test_parser.set_defaults(func=self_test)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/sparkle_update_probe.sh
+++ b/scripts/sparkle_update_probe.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BUSL-1.1
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+dist_dir="${DIST_DIR:-"$root/dist"}"
+app_name="${AGENTD_APP_NAME:-EvalOps agentd}"
+app_path="${AGENTD_APP_PATH:-"$dist_dir/$app_name.app"}"
+feed_url="${AGENTD_SPARKLE_PROBE_FEED_URL:-${AGENTD_SPARKLE_FEED_URL:-}}"
+appcast_path="${AGENTD_SPARKLE_APPCAST_PATH:-"$dist_dir/appcast.xml"}"
+channels="${AGENTD_SPARKLE_PROBE_CHANNELS:-}"
+user_agent="${AGENTD_SPARKLE_PROBE_USER_AGENT:-EvalOps agentd update probe}"
+
+find_sparkle_cli() {
+  if [[ -n "${AGENTD_SPARKLE_BIN_DIR:-}" ]]; then
+    if [[ -x "$AGENTD_SPARKLE_BIN_DIR/sparkle" ]]; then
+      printf '%s\n' "$AGENTD_SPARKLE_BIN_DIR/sparkle"
+      return
+    fi
+    if [[ -x "$AGENTD_SPARKLE_BIN_DIR/sparkle.app/Contents/MacOS/sparkle" ]]; then
+      printf '%s\n' "$AGENTD_SPARKLE_BIN_DIR/sparkle.app/Contents/MacOS/sparkle"
+      return
+    fi
+  fi
+  find "$root/.build" \( \
+    -path "*/Sparkle/bin/sparkle" -o \
+    -path "*/Sparkle/bin/sparkle.app/Contents/MacOS/sparkle" \
+  \) -type f -perm -111 -print -quit 2>/dev/null || true
+}
+
+if [[ ! -d "$app_path" ]]; then
+  echo "App bundle not found: $app_path" >&2
+  echo "Run scripts/package_app.sh first or set AGENTD_APP_PATH." >&2
+  exit 1
+fi
+
+sparkle_cli="$(find_sparkle_cli)"
+if [[ -z "$sparkle_cli" ]]; then
+  echo "Sparkle CLI was not found. Set AGENTD_SPARKLE_BIN_DIR or build/resolve Sparkle first." >&2
+  exit 1
+fi
+
+if [[ -z "$feed_url" && -f "$appcast_path" ]]; then
+  feed_url="$(python3 - "$appcast_path" <<'PY'
+from pathlib import Path
+import sys
+print(Path(sys.argv[1]).resolve().as_uri())
+PY
+)"
+fi
+
+args=(--probe --user-agent-name "$user_agent")
+if [[ -n "$feed_url" ]]; then
+  args+=(--feed-url "$feed_url")
+fi
+if [[ -n "$channels" ]]; then
+  args+=(--channels "$channels")
+fi
+if [[ "${AGENTD_SPARKLE_ALLOW_MAJOR_UPGRADES:-0}" == "1" ]]; then
+  args+=(--allow-major-upgrades)
+fi
+
+echo "Probing Sparkle updates for $app_path"
+if [[ -n "$feed_url" ]]; then
+  echo "Using feed $feed_url"
+fi
+exec "$sparkle_cli" "${args[@]}" "$app_path"


### PR DESCRIPTION
## Summary
- embed Sparkle 2.9.1 and add a guarded menu-bar “Check for Updates…” action
- extend packaging to copy/sign Sparkle.framework, inject release-only feed/key plist settings, and generate/verify signed appcasts
- add release workflow secrets/input handling for signed feeds, plus appcast/probe developer tooling and docs

## Research notes
- Sparkle latest release checked via GitHub API: 2.9.1 published 2026-03-29
- Sparkle docs recommend SPUStandardUpdaterController for menu-driven update checks, SUFeedURL/SUPublicEDKey in Info.plist, ditto-created archives, EdDSA-signed updates, and signed feeds for stronger metadata validation

## Verification
- swift build -Xswiftc -warnings-as-errors
- swift test
- python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
- python3 scripts/macos_availability_audit.py
- python3 scripts/sparkle_appcast.py self-test
- xcrun swift-format lint --strict --recursive Sources Tests Package.swift
- scripts/package_app.sh
- fixture appcast package: AGENTD_SPARKLE_FEED_URL=... AGENTD_SPARKLE_PUBLIC_ED_KEY=... AGENTD_SPARKLE_DOWNLOAD_URL=... AGENTD_SPARKLE_ED_SIGNATURE=... AGENTD_SPARKLE_ALLOW_UNNOTARIZED=1 scripts/package_app.sh
- signed-feed fixture package with temporary EdDSA seed: AGENTD_SPARKLE_REQUIRE_SIGNED_FEED=1 AGENTD_SPARKLE_ALLOW_UNNOTARIZED=1 scripts/package_app.sh

Refs #39