### PR TITLE
Polish agentd menu bar UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,10 @@ allowed app to probe a different foreground surface.
 `scripts/package_app.sh` creates `dist/EvalOps agentd.app` and
 `dist/agentd.zip`. By default CI uses ad-hoc signing with hardened runtime so
 the bundle shape, embedded Sparkle framework, and entitlements are continuously
-checked. Release builds inject `AGENTD_SPARKLE_FEED_URL` and
+checked. Ad-hoc packages add `disable-library-validation` only for the local
+signature so the embedded Sparkle framework can load; set
+`AGENTD_ADHOC_DISABLE_LIBRARY_VALIDATION=0` to test without that local escape
+hatch. Release builds inject `AGENTD_SPARKLE_FEED_URL` and
 `AGENTD_SPARKLE_PUBLIC_ED_KEY` so the menu bar's "Check for Updates..." action
 can use Sparkle. When `AGENTD_SPARKLE_DOWNLOAD_URL` is set, the package script
 signs the final zip with Sparkle EdDSA, writes `dist/appcast.xml`, and verifies

--- a/Sources/agentd/MenuBarController.swift
+++ b/Sources/agentd/MenuBarController.swift
@@ -4,12 +4,15 @@ import AppKit
 import Foundation
 
 @MainActor
-final class MenuBarController: NSObject {
+final class MenuBarController: NSObject, NSMenuDelegate {
   private let statusItem: NSStatusItem
   private let menu = NSMenu()
+  private let headerView = MenuHeaderView()
   private var captureStateItem: NSMenuItem?
   private var pauseItem: NSMenuItem?
   private var permissionItem: NSMenuItem?
+  private var refreshPermissionsItem: NSMenuItem?
+  private var permissionSetupItem: NSMenuItem?
   private var screenRecordingItem: NSMenuItem?
   private var accessibilityItem: NSMenuItem?
   private var checkForUpdatesItem: NSMenuItem?
@@ -65,6 +68,9 @@ final class MenuBarController: NSObject {
   }
 
   private func configure() {
+    menu.minimumWidth = 340
+    menu.delegate = self
+
     if let button = statusItem.button {
       button.image = NSImage(
         systemSymbolName: "circle.fill", accessibilityDescription: "agentd recording")
@@ -72,45 +78,65 @@ final class MenuBarController: NSObject {
       button.toolTip = "agentd — capturing"
     }
 
+    let headerItem = NSMenuItem()
+    headerItem.view = headerView
+    menu.addItem(headerItem)
+
     let captureStateItem = NSMenuItem(title: "Status: Starting…", action: nil, keyEquivalent: "")
     captureStateItem.isEnabled = false
     self.captureStateItem = captureStateItem
     menu.addItem(captureStateItem)
 
     menu.addItem(.separator())
+    addSectionTitle("Capture")
 
-    let pauseItem = NSMenuItem(
-      title: "Pause Capture", action: #selector(togglePause), keyEquivalent: "p")
+    let pauseItem = makeItem(
+      title: "Pause Capture",
+      symbolName: "pause.circle",
+      action: #selector(togglePause),
+      keyEquivalent: "p"
+    )
     pauseItem.keyEquivalentModifierMask = [.command, .option, .control]
-    pauseItem.target = self
     self.pauseItem = pauseItem
     menu.addItem(pauseItem)
 
-    let flushItem = NSMenuItem(
-      title: "Flush Batch Now", action: #selector(flush), keyEquivalent: "f")
+    let flushItem = makeItem(
+      title: "Flush Batch Now",
+      symbolName: "paperplane",
+      action: #selector(flush),
+      keyEquivalent: "f"
+    )
     flushItem.keyEquivalentModifierMask = [.command, .option, .control]
-    flushItem.target = self
     menu.addItem(flushItem)
 
     menu.addItem(.separator())
+    addSectionTitle("Data")
 
-    let revealItem = NSMenuItem(
-      title: "Reveal Batches in Finder", action: #selector(reveal), keyEquivalent: "")
-    revealItem.target = self
+    let revealItem = makeItem(
+      title: "Reveal Batches in Finder",
+      symbolName: "folder",
+      action: #selector(reveal)
+    )
     menu.addItem(revealItem)
 
-    let diagnosticsItem = NSMenuItem(
-      title: "Open Diagnostics Report", action: #selector(openDiagnostics), keyEquivalent: "d")
+    let diagnosticsItem = makeItem(
+      title: "Open Diagnostics Report",
+      symbolName: "stethoscope",
+      action: #selector(openDiagnostics),
+      keyEquivalent: "d"
+    )
     diagnosticsItem.keyEquivalentModifierMask = [.command, .option, .control]
-    diagnosticsItem.target = self
     menu.addItem(diagnosticsItem)
 
-    let deleteItem = NSMenuItem(
-      title: "Delete Queued Batches", action: #selector(deleteQueuedBatches), keyEquivalent: "")
-    deleteItem.target = self
+    let deleteItem = makeItem(
+      title: "Delete Queued Batches",
+      symbolName: "trash",
+      action: #selector(deleteQueuedBatches)
+    )
     menu.addItem(deleteItem)
 
     menu.addItem(.separator())
+    addSectionTitle("Permissions")
 
     let permissionItem = NSMenuItem(
       title: "Permissions: Checking…", action: nil, keyEquivalent: "")
@@ -118,52 +144,64 @@ final class MenuBarController: NSObject {
     self.permissionItem = permissionItem
     menu.addItem(permissionItem)
 
-    let refreshPermissionsItem = NSMenuItem(
-      title: "Check Permission Status", action: #selector(refreshPermissions), keyEquivalent: "")
-    refreshPermissionsItem.target = self
+    let refreshPermissionsItem = makeItem(
+      title: "Check Permission Status",
+      symbolName: "arrow.clockwise",
+      action: #selector(refreshPermissions)
+    )
+    self.refreshPermissionsItem = refreshPermissionsItem
     menu.addItem(refreshPermissionsItem)
 
-    let permissionSetupItem = NSMenuItem(
-      title: "Open Permission Setup", action: #selector(openPermissionSetup), keyEquivalent: "")
-    permissionSetupItem.target = self
+    let permissionSetupItem = makeItem(
+      title: "Open Permission Setup",
+      symbolName: "lock.shield",
+      action: #selector(openPermissionSetup)
+    )
+    self.permissionSetupItem = permissionSetupItem
     menu.addItem(permissionSetupItem)
 
-    let screenRecordingItem = NSMenuItem(
+    let screenRecordingItem = makeItem(
       title: "Open Screen & System Audio Recording Settings",
-      action: #selector(openScreenRecordingSettings),
-      keyEquivalent: ""
+      symbolName: "record.circle",
+      action: #selector(openScreenRecordingSettings)
     )
-    screenRecordingItem.target = self
     self.screenRecordingItem = screenRecordingItem
     menu.addItem(screenRecordingItem)
 
-    let accessibilityItem = NSMenuItem(
+    let accessibilityItem = makeItem(
       title: "Open Accessibility Settings",
-      action: #selector(openAccessibilitySettings),
-      keyEquivalent: ""
+      symbolName: "figure.wave",
+      action: #selector(openAccessibilitySettings)
     )
-    accessibilityItem.target = self
     self.accessibilityItem = accessibilityItem
     menu.addItem(accessibilityItem)
 
-    let relaunchItem = NSMenuItem(
-      title: "Relaunch agentd", action: #selector(relaunch), keyEquivalent: "")
-    relaunchItem.target = self
-    menu.addItem(relaunchItem)
-
     menu.addItem(.separator())
+    addSectionTitle("App")
 
-    let launchItem = NSMenuItem(
-      title: "Launch at Login", action: #selector(toggleLaunchAtLogin), keyEquivalent: "")
-    launchItem.target = self
+    let launchItem = makeItem(
+      title: "Launch at Login",
+      symbolName: "power",
+      action: #selector(toggleLaunchAtLogin)
+    )
     launchAtLoginItem = launchItem
     menu.addItem(launchItem)
 
-    let checkForUpdatesItem = NSMenuItem(
-      title: "Check for Updates…", action: nil, keyEquivalent: "")
+    let checkForUpdatesItem = makeItem(
+      title: "Check for Updates…",
+      symbolName: "arrow.down.circle",
+      action: nil
+    )
     configureUpdatesMenuItem(checkForUpdatesItem)
     self.checkForUpdatesItem = checkForUpdatesItem
     menu.addItem(checkForUpdatesItem)
+
+    let relaunchItem = makeItem(
+      title: "Relaunch agentd",
+      symbolName: "arrow.trianglehead.clockwise",
+      action: #selector(relaunch)
+    )
+    menu.addItem(relaunchItem)
 
     menu.addItem(.separator())
 
@@ -175,8 +213,12 @@ final class MenuBarController: NSObject {
 
     menu.addItem(.separator())
 
-    let quit = NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q")
-    quit.target = self
+    let quit = makeItem(
+      title: "Quit",
+      symbolName: "xmark.circle",
+      action: #selector(quit),
+      keyEquivalent: "q"
+    )
     menu.addItem(quit)
 
     statusItem.menu = menu
@@ -205,6 +247,10 @@ final class MenuBarController: NSObject {
   }
   @objc private func quit() { onQuit() }
 
+  func menuWillOpen(_ menu: NSMenu) {
+    onRefreshPermissions()
+  }
+
   func setStatus(
     paused: Bool,
     detail: String,
@@ -212,17 +258,43 @@ final class MenuBarController: NSObject {
     localOnly: Bool,
     policyVersion: String?
   ) {
+    let presentation = MenuStatusPresentation(
+      paused: paused,
+      detail: detail,
+      permissions: permissions,
+      localOnly: localOnly,
+      policyVersion: policyVersion,
+      appVersion: Bundle.main.appVersion
+    )
     self.paused = paused
     needsPermission = !permissions.allTrusted
     updateStatusButton(detail: detail)
     pauseItem?.title = paused ? "Resume Capture" : "Pause Capture"
-    captureStateItem?.title = "Status: \(detail)"
-    permissionItem?.title = "Permissions: \(permissions.menuSummary)"
+    pauseItem?.image = menuSymbol(paused ? "play.circle" : "pause.circle")
+    captureStateItem?.title = presentation.statusLine
+    permissionItem?.title = presentation.permissionsLine
+    permissionItem?.image = menuSymbol(
+      permissions.allTrusted ? "checkmark.shield" : "exclamationmark.triangle")
+    refreshPermissionsItem?.image = menuSymbol(
+      permissions.allTrusted ? "checkmark.circle" : "arrow.clockwise")
+    permissionSetupItem?.image = menuSymbol(
+      permissions.allTrusted ? "checkmark.shield" : "lock.shield")
+    screenRecordingItem?.title =
+      permissions.screenCaptureTrusted
+      ? "Screen & System Audio Recording Granted"
+      : "Open Screen & System Audio Recording Settings"
+    screenRecordingItem?.image = menuSymbol(
+      permissions.screenCaptureTrusted ? "checkmark.circle" : "record.circle")
     screenRecordingItem?.isEnabled = !permissions.screenCaptureTrusted
+    accessibilityItem?.title =
+      permissions.accessibilityTrusted
+      ? "Accessibility Granted"
+      : "Open Accessibility Settings"
+    accessibilityItem?.image = menuSymbol(
+      permissions.accessibilityTrusted ? "checkmark.circle" : "figure.wave")
     accessibilityItem?.isEnabled = !permissions.accessibilityTrusted
-    let mode = localOnly ? "local-only" : "managed"
-    let policy = policyVersion.map { " policy \($0)" } ?? ""
-    aboutItem?.title = "agentd \(Bundle.main.appVersion) — \(mode)\(policy)"
+    aboutItem?.title = presentation.aboutLine
+    headerView.update(presentation)
     launchAtLoginItem?.state = LaunchAtLoginController.isEnabled ? .on : .off
     if let checkForUpdatesItem {
       configureUpdatesMenuItem(checkForUpdatesItem)
@@ -249,6 +321,166 @@ final class MenuBarController: NSObject {
       button.image?.isTemplate = true
       button.toolTip = needsPermission ? "agentd — permissions needed" : "agentd — \(detail)"
     }
+  }
+
+  @discardableResult
+  private func addSectionTitle(_ title: String) -> NSMenuItem {
+    let item = NSMenuItem(title: title.uppercased(), action: nil, keyEquivalent: "")
+    item.isEnabled = false
+    item.attributedTitle = NSAttributedString(
+      string: title.uppercased(),
+      attributes: [
+        .font: NSFont.systemFont(ofSize: 10, weight: .semibold),
+        .foregroundColor: NSColor.secondaryLabelColor,
+      ]
+    )
+    menu.addItem(item)
+    return item
+  }
+
+  private func makeItem(
+    title: String,
+    symbolName: String,
+    action: Selector?,
+    keyEquivalent: String = ""
+  ) -> NSMenuItem {
+    let item = NSMenuItem(title: title, action: action, keyEquivalent: keyEquivalent)
+    item.target = self
+    item.image = menuSymbol(symbolName)
+    return item
+  }
+
+  private func menuSymbol(_ symbolName: String) -> NSImage? {
+    let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
+    image?.isTemplate = true
+    return image
+  }
+}
+
+struct MenuStatusPresentation: Equatable {
+  let title: String
+  let subtitle: String
+  let detail: String
+  let statusLine: String
+  let permissionsLine: String
+  let aboutLine: String
+  let symbolName: String
+
+  init(
+    paused: Bool,
+    detail: String,
+    permissions: PermissionSnapshot,
+    localOnly: Bool,
+    policyVersion: String?,
+    appVersion: String
+  ) {
+    self.detail = detail
+    let mode = localOnly ? "local-only" : "managed"
+    let policy = policyVersion.map { " policy \($0)" } ?? ""
+    self.subtitle = "\(mode)\(policy)"
+    self.title = permissions.allTrusted ? "EvalOps agentd" : "EvalOps agentd needs permissions"
+    self.statusLine = "Status: \(detail)"
+    self.permissionsLine = "Permissions: \(permissions.menuSummary)"
+    self.aboutLine = "agentd \(appVersion) — \(mode)\(policy)"
+    if !permissions.allTrusted {
+      self.symbolName = "exclamationmark.triangle.fill"
+    } else if paused {
+      self.symbolName = "pause.circle"
+    } else {
+      self.symbolName = "circle.fill"
+    }
+  }
+}
+
+@MainActor
+private final class MenuHeaderView: NSView {
+  private let iconView = NSImageView()
+  private let titleLabel = NSTextField(labelWithString: "EvalOps agentd")
+  private let subtitleLabel = NSTextField(labelWithString: "local-only")
+  private let detailLabel = NSTextField(labelWithString: "Starting…")
+  private let permissionLabel = NSTextField(labelWithString: "Permissions: Checking…")
+
+  init() {
+    super.init(frame: NSRect(x: 0, y: 0, width: 340, height: 92))
+    translatesAutoresizingMaskIntoConstraints = false
+    build()
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override var intrinsicContentSize: NSSize {
+    NSSize(width: 340, height: 92)
+  }
+
+  func update(_ presentation: MenuStatusPresentation) {
+    titleLabel.stringValue = presentation.title
+    subtitleLabel.stringValue = presentation.subtitle
+    detailLabel.stringValue = presentation.detail
+    permissionLabel.stringValue = presentation.permissionsLine
+    iconView.image = NSImage(
+      systemSymbolName: presentation.symbolName,
+      accessibilityDescription: presentation.title
+    )
+    iconView.contentTintColor =
+      presentation.symbolName == "exclamationmark.triangle.fill"
+      ? .systemYellow
+      : .controlAccentColor
+  }
+
+  private func build() {
+    iconView.image = NSImage(systemSymbolName: "circle.fill", accessibilityDescription: nil)
+    iconView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 22, weight: .semibold)
+    iconView.contentTintColor = .controlAccentColor
+    iconView.translatesAutoresizingMaskIntoConstraints = false
+
+    titleLabel.font = .systemFont(ofSize: 14, weight: .semibold)
+    titleLabel.lineBreakMode = .byTruncatingTail
+
+    subtitleLabel.font = .systemFont(ofSize: 11, weight: .medium)
+    subtitleLabel.textColor = .secondaryLabelColor
+    subtitleLabel.lineBreakMode = .byTruncatingTail
+
+    detailLabel.font = .systemFont(ofSize: 12, weight: .regular)
+    detailLabel.textColor = .labelColor
+    detailLabel.lineBreakMode = .byTruncatingTail
+
+    permissionLabel.font = .systemFont(ofSize: 11, weight: .regular)
+    permissionLabel.textColor = .secondaryLabelColor
+    permissionLabel.lineBreakMode = .byTruncatingTail
+
+    let titleStack = NSStackView(views: [titleLabel, subtitleLabel])
+    titleStack.orientation = .vertical
+    titleStack.alignment = .leading
+    titleStack.spacing = 1
+    titleStack.translatesAutoresizingMaskIntoConstraints = false
+
+    let row = NSStackView(views: [iconView, titleStack])
+    row.orientation = .horizontal
+    row.alignment = .centerY
+    row.spacing = 9
+    row.translatesAutoresizingMaskIntoConstraints = false
+
+    let stack = NSStackView(views: [row, detailLabel, permissionLabel])
+    stack.orientation = .vertical
+    stack.alignment = .leading
+    stack.spacing = 6
+    stack.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(stack)
+
+    NSLayoutConstraint.activate([
+      iconView.widthAnchor.constraint(equalToConstant: 24),
+      iconView.heightAnchor.constraint(equalToConstant: 24),
+      stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
+      stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
+      stack.topAnchor.constraint(equalTo: topAnchor, constant: 12),
+      stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
+      titleStack.trailingAnchor.constraint(lessThanOrEqualTo: stack.trailingAnchor),
+      detailLabel.trailingAnchor.constraint(lessThanOrEqualTo: stack.trailingAnchor),
+      permissionLabel.trailingAnchor.constraint(lessThanOrEqualTo: stack.trailingAnchor),
+    ])
   }
 }
 

--- a/Tests/agentdTests/MenuBarControllerTests.swift
+++ b/Tests/agentdTests/MenuBarControllerTests.swift
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import XCTest
+
+@testable import agentd
+
+final class MenuBarControllerTests: XCTestCase {
+  func testMenuPresentationShowsPermissionAttention() {
+    let presentation = MenuStatusPresentation(
+      paused: false,
+      detail: "capturing",
+      permissions: PermissionSnapshot(accessibilityTrusted: true, screenCaptureTrusted: false),
+      localOnly: true,
+      policyVersion: nil,
+      appVersion: "1.2.3"
+    )
+
+    XCTAssertEqual(presentation.title, "EvalOps agentd needs permissions")
+    XCTAssertEqual(presentation.statusLine, "Status: capturing")
+    XCTAssertEqual(presentation.aboutLine, "agentd 1.2.3 — local-only")
+    XCTAssertEqual(presentation.symbolName, "exclamationmark.triangle.fill")
+  }
+
+  func testMenuPresentationShowsManagedPolicyState() {
+    let presentation = MenuStatusPresentation(
+      paused: true,
+      detail: "scheduled pause",
+      permissions: PermissionSnapshot(accessibilityTrusted: true, screenCaptureTrusted: true),
+      localOnly: false,
+      policyVersion: "42",
+      appVersion: "1.2.3"
+    )
+
+    XCTAssertEqual(presentation.title, "EvalOps agentd")
+    XCTAssertEqual(presentation.subtitle, "managed policy 42")
+    XCTAssertEqual(presentation.statusLine, "Status: scheduled pause")
+    XCTAssertEqual(presentation.permissionsLine, "Permissions: Ready")
+    XCTAssertEqual(presentation.aboutLine, "agentd 1.2.3 — managed policy 42")
+    XCTAssertEqual(presentation.symbolName, "pause.circle")
+  }
+}

--- a/docs/release-update-channel.md
+++ b/docs/release-update-channel.md
@@ -21,8 +21,12 @@ The signed update-channel path is intentionally evidence-first:
 Sparkle is now the release update framework. Local and ad-hoc packages keep the
 menu item disabled unless the package step injects both `SUFeedURL` and
 `SUPublicEDKey`; this prevents a developer build from pointing at production
-updates by accident. A release package that sets `AGENTD_SPARKLE_DOWNLOAD_URL`
-must also be notarized and must produce a signed appcast.
+updates by accident. Ad-hoc packages also add `disable-library-validation` to
+the local app signature so macOS can load the embedded Sparkle framework without
+a Developer ID team identifier. Developer ID release packages use the normal
+app entitlements and keep library validation enabled. A release package that
+sets `AGENTD_SPARKLE_DOWNLOAD_URL` must also be notarized and must produce a
+signed appcast.
 
 Sparkle release configuration is injected at package time:
 

--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -10,6 +10,7 @@ app_path="$dist_dir/$app_name.app"
 zip_path="$dist_dir/$product.zip"
 identity="${AGENTD_CODESIGN_IDENTITY:--}"
 entitlements="${AGENTD_ENTITLEMENTS:-"$root/support/agentd.entitlements"}"
+adhoc_disable_library_validation="${AGENTD_ADHOC_DISABLE_LIBRARY_VALIDATION:-1}"
 sparkle_feed_url="${AGENTD_SPARKLE_FEED_URL:-}"
 sparkle_public_ed_key="${AGENTD_SPARKLE_PUBLIC_ED_KEY:-}"
 sparkle_download_url="${AGENTD_SPARKLE_DOWNLOAD_URL:-}"
@@ -227,11 +228,22 @@ fi
 ditto "$sparkle_framework" "$app_path/Contents/Frameworks/Sparkle.framework"
 codesign_nested_sparkle "$app_path/Contents/Frameworks/Sparkle.framework"
 
+app_entitlements="$entitlements"
+if [[ "$identity" == "-" && "$adhoc_disable_library_validation" == "1" ]]; then
+  app_entitlements="$dist_dir/agentd-adhoc.entitlements.plist"
+  cp "$entitlements" "$app_entitlements"
+  if /usr/libexec/PlistBuddy -c "Print :com.apple.security.cs.disable-library-validation" "$app_entitlements" >/dev/null 2>&1; then
+    /usr/libexec/PlistBuddy -c "Set :com.apple.security.cs.disable-library-validation true" "$app_entitlements"
+  else
+    /usr/libexec/PlistBuddy -c "Add :com.apple.security.cs.disable-library-validation bool true" "$app_entitlements"
+  fi
+fi
+
 codesign_args=(
   --force
   --sign "$identity"
   --options runtime
-  --entitlements "$entitlements"
+  --entitlements "$app_entitlements"
 )
 if [[ "$identity" != "-" ]]; then
   codesign_args+=(--timestamp)
@@ -241,6 +253,9 @@ codesign --verify --strict --deep --verbose=2 "$app_path"
 if [[ "$identity" == "-" ]]; then
   echo "Ad-hoc signed app: macOS TCC approvals can bind to this build's cdhash."
   echo "For permission smoke, approve this exact packaged app and relaunch without rebuilding."
+  if [[ "$adhoc_disable_library_validation" == "1" ]]; then
+    echo "Ad-hoc local package allows embedded frameworks with disable-library-validation."
+  fi
 fi
 
 create_zip


### PR DESCRIPTION
## Summary
- add a richer menu bar panel with a status header, grouped actions, SF Symbol icons, and dynamic permission/capture state
- refresh permission state when the menu opens and make granted/missing permission rows self-describing
- let ad-hoc local packages load embedded Sparkle under hardened runtime while keeping Developer ID release packages on normal entitlements

## Local verification
- swift test
- swift build -Xswiftc -warnings-as-errors
- xcrun swift-format lint --strict --recursive Sources Tests Package.swift
- python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
- python3 scripts/macos_availability_audit.py
- python3 scripts/sparkle_appcast.py self-test
- scripts/package_app.sh
- scripts/permission_smoke.sh; verified /Applications/EvalOps agentd.app is running as a process after launch
