### PR TITLE
fix: address agentd post-merge feedback

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -53,6 +53,7 @@ jobs:
           AGENTD_SPARKLE_FEED_URL: ${{ secrets.AGENTD_SPARKLE_FEED_URL }}
           AGENTD_SPARKLE_PUBLIC_ED_KEY: ${{ secrets.AGENTD_SPARKLE_PUBLIC_ED_KEY }}
           AGENTD_SPARKLE_PRIVATE_ED_KEY: ${{ secrets.AGENTD_SPARKLE_PRIVATE_ED_KEY }}
+          AGENTD_SPARKLE_DOWNLOAD_URL: ${{ inputs.sparkle_download_url }}
         run: |
           set -euo pipefail
           missing=0
@@ -72,7 +73,7 @@ jobs:
               missing=1
             fi
           done
-          if [ -z "${{ inputs.sparkle_download_url }}" ]; then
+          if [ -z "${AGENTD_SPARKLE_DOWNLOAD_URL:-}" ]; then
             echo "::error::Missing required workflow input sparkle_download_url"
             missing=1
           fi

--- a/Sources/agentd/CaptureService.swift
+++ b/Sources/agentd/CaptureService.swift
@@ -97,6 +97,7 @@ actor CaptureService {
       captureAllDisplays: current.captureAllDisplays,
       selectedDisplayIds: current.selectedDisplayIds
     )
+    runningScope = nil
     do {
       try await workerClient.start(scope: next)
       runningScope = next
@@ -421,12 +422,19 @@ final class CaptureWorkerStream: @unchecked Sendable {
   func start(executable: URL, fps: Double) throws {
     stdout.fileHandleForReading.readabilityHandler = { @Sendable [reader] handle in
       let data = handle.availableData
-      guard !data.isEmpty else { return }
+      guard !data.isEmpty else {
+        handle.readabilityHandler = nil
+        return
+      }
       reader.append(data)
     }
     stderr.fileHandleForReading.readabilityHandler = { @Sendable [display] handle in
       let data = handle.availableData
-      guard !data.isEmpty, let message = String(data: data, encoding: .utf8) else { return }
+      guard !data.isEmpty else {
+        handle.readabilityHandler = nil
+        return
+      }
+      guard let message = String(data: data, encoding: .utf8) else { return }
       Log.capture.warning(
         "capture worker stderr display=\(display.displayId, privacy: .public) \(message, privacy: .public)"
       )

--- a/Sources/agentd/MenuBarController.swift
+++ b/Sources/agentd/MenuBarController.swift
@@ -72,6 +72,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
 
   private func configure() {
     menu.minimumWidth = 340
+    menu.autoenablesItems = false
     menu.delegate = self
 
     if let button = statusItem.button {

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -598,7 +598,7 @@ enum BrowserPrivacyObservation {
     browserBundleIds.contains(bundleId)
   }
 
-  private static func isMeetingURL(_ value: String?) -> Bool {
+  static func isMeetingURL(_ value: String?) -> Bool {
     guard let value, !value.isEmpty else { return false }
     let lower = value.lowercased()
     guard lower.contains("meet.google.com") else { return false }
@@ -666,6 +666,9 @@ struct PrivacyObservationSignature: Sendable, Hashable {
         return path.hasPrefix(expanded) || path.hasPrefix(prefix)
       }
       return "denied:\(stableClassHash(matched ?? "path"))"
+    }
+    if BrowserPrivacyObservation.isMeetingURL(path) {
+      return "browser_meeting_url"
     }
     return "present"
   }

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -606,6 +606,35 @@ final class PipelineTests: XCTestCase {
     XCTAssertEqual(meetDecision.reasonCode, "browser_meeting_window")
   }
 
+  func testPrivacyDecisionCacheSeparatesBrowserMeetingURLs() {
+    var cache = PrivacyDecisionCache()
+    var cfg = Self.config()
+    cfg.allowedBundleIds += ["com.google.Chrome"]
+
+    let normalDecision = cache.decision(
+      for: Self.context(
+        bundleId: "com.google.Chrome",
+        windowTitle: "Docs",
+        documentPath: "https://docs.google.com/document/d/abc"
+      ),
+      config: cfg
+    )
+    let meetDecision = cache.decision(
+      for: Self.context(
+        bundleId: "com.google.Chrome",
+        windowTitle: "Sprint Review",
+        documentPath: "https://meet.google.com/abc-defg-hij"
+      ),
+      config: cfg
+    )
+
+    XCTAssertTrue(normalDecision.allowed)
+    XCTAssertFalse(meetDecision.allowed)
+    XCTAssertFalse(meetDecision.cached)
+    XCTAssertEqual(meetDecision.reasonCode, "browser_meeting_window")
+    XCTAssertNotEqual(normalDecision.observationId, meetDecision.observationId)
+  }
+
   func testPrivacyDecisionCachePolicyInvalidationChangesObservationId() {
     var cache = PrivacyDecisionCache()
     let cfg = Self.config()

--- a/scripts/multi_display_smoke.sh
+++ b/scripts/multi_display_smoke.sh
@@ -13,7 +13,7 @@ Examples:
   scripts/multi_display_smoke.sh --phase after-detach
 
 Environment:
-  AGENTD_AGENTD_BIN               Existing agentd binary to use.
+  AGENTD_BIN                      Existing agentd binary to use.
   AGENTD_MULTI_DISPLAY_REPORT     Markdown report path.
 USAGE
 }
@@ -54,18 +54,18 @@ done
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 report_path="${AGENTD_MULTI_DISPLAY_REPORT:-"$root/dist/multi-display-smoke-report.md"}"
 snapshot_dir="$(dirname "$report_path")/multi-display-smoke"
-bin="${AGENTD_AGENTD_BIN:-"$root/.build/debug/agentd"}"
+bin="${AGENTD_BIN:-${AGENTD_AGENTD_BIN:-"$root/.build/debug/agentd"}}"
 timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 safe_phase="$(printf '%s' "$phase" | tr -c 'A-Za-z0-9._-' '-')"
 json_path="$snapshot_dir/${timestamp}-${safe_phase}.json"
 
-if [[ "$build" == "1" && -z "${AGENTD_AGENTD_BIN:-}" ]]; then
+if [[ "$build" == "1" && -z "${AGENTD_BIN:-}${AGENTD_AGENTD_BIN:-}" ]]; then
   (cd "$root" && swift build)
 fi
 
 if [[ ! -x "$bin" ]]; then
   echo "Missing agentd binary: $bin" >&2
-  echo "Run swift build, or set AGENTD_AGENTD_BIN." >&2
+  echo "Run swift build, or set AGENTD_BIN." >&2
   exit 66
 fi
 

--- a/scripts/permission_smoke.sh
+++ b/scripts/permission_smoke.sh
@@ -56,7 +56,11 @@ elif [[ ! -d "$source_app_path" ]]; then
 fi
 
 if [[ "$install_applications" != "0" ]]; then
-  if [[ "$installed_app_path" != "$applications_dir/"*"EvalOps agentd.app" ]]; then
+  if [[ -z "$applications_dir" || "$applications_dir" == "/" ]]; then
+    echo "Refusing unsafe Applications directory: $applications_dir" >&2
+    exit 64
+  fi
+  if [[ "$(basename "$installed_app_path")" != "EvalOps agentd.app" ]]; then
     echo "Refusing unsafe Applications install path: $installed_app_path" >&2
     exit 64
   fi


### PR DESCRIPTION
## Summary
- avoid shell interpolation of the Sparkle download URL workflow input
- preserve manual disabled menu items by disabling NSMenu auto-enable behavior
- harden permission and multi-display smoke scripts
- separate browser meeting URLs in privacy-decision cache signatures
- clear capture worker readability handlers on EOF and reset stale FPS scope before restart attempts

## Review threads addressed
- #86: release workflow input shell interpolation
- #83: menu item enabled-state preservation
- #82/#81: smoke-script safety and naming issues
- #78: browser meeting URL cache signature
- #77: FPS scope and worker EOF handling

## Verification
- `bash -n scripts/permission_smoke.sh scripts/multi_display_smoke.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/package-release.yml")'`
- `swift test --filter 'PipelineTests|CaptureWorkerProtocolTests|MenuBarControllerTests'`
- `git diff --check`
