### PR TITLE
fix: address capture drop accounting feedback

### DIFF
--- a/Sources/agentd/CaptureService.swift
+++ b/Sources/agentd/CaptureService.swift
@@ -693,10 +693,14 @@ final class BufferedFrameDispatcher: @unchecked Sendable {
     case .dropped:
       Task { await onDropped() }
       return false
-    case .enqueued, .terminated:
+    case .enqueued:
       return true
+    case .terminated:
+      Task { await onDropped() }
+      return false
     @unknown default:
-      return true
+      Task { await onDropped() }
+      return false
     }
   }
 

--- a/Sources/agentd/SparseFrameStore.swift
+++ b/Sources/agentd/SparseFrameStore.swift
@@ -149,7 +149,14 @@ actor SparseFrameStore {
       options: [.skipsHiddenFiles]
     )
     for url in urls {
-      let values = try url.resourceValues(forKeys: [.contentModificationDateKey, .isDirectoryKey])
+      guard
+        let values = try? url.resourceValues(forKeys: [
+          .contentModificationDateKey,
+          .isDirectoryKey,
+        ])
+      else {
+        continue
+      }
       guard let modified = values.contentModificationDate, modified < cutoff else { continue }
       try? FileManager.default.removeItem(at: url)
     }

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -359,6 +359,24 @@ final class PipelineTests: XCTestCase {
     XCTAssertGreaterThan(dropped, 0)
   }
 
+  func testBufferedFrameDispatcherReportsTerminatedYieldsAsDropped() async throws {
+    let counts = DispatchCounts()
+    let dispatcher = BufferedFrameDispatcher(bufferingNewest: 2) { _ in
+      await counts.recordProcessed()
+    } onDropped: {
+      await counts.recordDropped()
+    }
+
+    dispatcher.finish()
+    XCTAssertFalse(dispatcher.yield(Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA)))
+
+    try await Task.sleep(nanoseconds: 50_000_000)
+    let processed = await counts.processed
+    let dropped = await counts.dropped
+    XCTAssertEqual(processed, 0)
+    XCTAssertEqual(dropped, 1)
+  }
+
   func testSparseFrameStoreWritesChronicleStyleArtifactsAfterScrub() async throws {
     let root = try Self.temporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
## Summary\n- treat terminated frame dispatcher yields as dropped instead of successful enqueue\n- report terminated yields through the dropped callback so capture diagnostics stay honest\n- keep sparse-frame retention pruning resilient when one artifact cannot return metadata\n\nAddresses missed post-merge review feedback from evalops/agentd#49 and evalops/agentd#58.\n\n## Verification\n- swift test --filter PipelineTests/testBufferedFrameDispatcherReportsTerminatedYieldsAsDropped\n- swift test --filter PipelineTests\n- swift test\n- xcrun swift-format lint --strict --recursive Sources Tests Package.swift\n- git diff --check