### PR TITLE
feat: add Chronicle behavioral capture signals

### DIFF
--- a/Sources/agentd/ChronicleBehavior.swift
+++ b/Sources/agentd/ChronicleBehavior.swift
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import Foundation
+
+enum CaptureTier: String, Sendable, Codable, Equatable {
+  case evidence
+  case audit
+  case deny
+}
+
+struct DomainTier: Sendable, Codable, Equatable {
+  var pattern: String
+  var tier: CaptureTier
+}
+
+struct BundleCaptureProfile: Sendable, Codable, Equatable {
+  var bundleId: String
+  var captureFps: Double?
+  var idleFps: Double?
+  var eventDrivenOnly: Bool?
+}
+
+struct BehavioralClassification: Sendable, Codable, Equatable {
+  var workDomains: [String]
+  var leisureDomains: [String]
+  var workBundleIds: [String]
+  var leisureBundleIds: [String]
+
+  static let `default` = BehavioralClassification(
+    workDomains: ["github.com", "localhost", "127.0.0.1"],
+    leisureDomains: ["x.com", "twitter.com", "youtube.com", "reddit.com"],
+    workBundleIds: [
+      "com.apple.dt.Xcode",
+      "com.microsoft.VSCode",
+      "com.todesktop.230313mzl4w4u92",
+      "com.googlecode.iterm2",
+      "com.apple.Terminal",
+      "dev.warp.Warp-Stable",
+      "com.openai.codex",
+    ],
+    leisureBundleIds: []
+  )
+}
+
+struct ContextExtractor: Sendable, Codable, Equatable {
+  var name: String
+  var documentPattern: String
+  var captureKey: String
+  var lastPathSegments: Int?
+  var regex: String?
+  var captureGroup: Int?
+
+  static let defaults: [ContextExtractor] = [
+    ContextExtractor(
+      name: "github-issue",
+      documentPattern: "github.com/*/issues/*",
+      captureKey: "activeIssue",
+      lastPathSegments: 4,
+      regex: nil,
+      captureGroup: nil
+    ),
+    ContextExtractor(
+      name: "github-pr",
+      documentPattern: "github.com/*/pull/*",
+      captureKey: "activePullRequest",
+      lastPathSegments: 4,
+      regex: nil,
+      captureGroup: nil
+    ),
+  ]
+}
+
+struct ThrashRule: Sendable, Codable, Equatable {
+  var name: String
+  var domainPattern: String
+  var windowSeconds: Int
+  var distinctThreshold: Int
+
+  static let githubPR = ThrashRule(
+    name: "github-pr",
+    domainPattern: "github.com/*/pull/*",
+    windowSeconds: 600,
+    distinctThreshold: 5
+  )
+}
+
+struct BoundaryHookConfig: Sendable, Codable, Equatable {
+  var foregroundChurnWindowSeconds: Int
+  var foregroundChurnThreshold: Int
+
+  static let `default` = BoundaryHookConfig(
+    foregroundChurnWindowSeconds: 60,
+    foregroundChurnThreshold: 8
+  )
+}
+
+struct EmittedCounts: Sendable, Codable, Equatable {
+  let distinctBundles: Int
+  let distinctDomains: Int
+  let distinctDocumentPaths: Int
+  let distinctGithubPrs: Int
+  let foregroundChanges: Int
+  let documentChanges: Int
+  let workLeisureFlips: Int
+  let longestUninterruptedSeconds: Int
+  let thrashEventCount: Int
+
+  static let empty = EmittedCounts(
+    distinctBundles: 0,
+    distinctDomains: 0,
+    distinctDocumentPaths: 0,
+    distinctGithubPrs: 0,
+    foregroundChanges: 0,
+    documentChanges: 0,
+    workLeisureFlips: 0,
+    longestUninterruptedSeconds: 0,
+    thrashEventCount: 0
+  )
+}
+
+enum ChronicleBehavior {
+  static func captureTier(for documentPath: String?, domainTiers: [DomainTier]) -> CaptureTier {
+    guard let documentPath, !documentPath.isEmpty else { return .evidence }
+    let matches = domainTiers.filter { globMatches($0.pattern, documentPath) }
+    return matches.max { specificity($0.pattern) < specificity($1.pattern) }?.tier ?? .evidence
+  }
+
+  static func auditDocumentPath(_ documentPath: String?) -> String? {
+    guard let documentPath, !documentPath.isEmpty else { return nil }
+    guard let components = URLComponents(string: documentPath), let host = components.host else {
+      return nil
+    }
+    let scheme = components.scheme.map { "\($0)://" } ?? ""
+    return "\(scheme)\(host)"
+  }
+
+  static func emittedCounts(
+    for frames: [ProcessedFrame],
+    classification: BehavioralClassification,
+    thrashRules: [ThrashRule]
+  ) -> EmittedCounts {
+    guard !frames.isEmpty else { return .empty }
+    let sorted = frames.sorted { $0.capturedAt < $1.capturedAt }
+    let bundles = Set(sorted.map(\.bundleId).filter { !$0.isEmpty })
+    let documentPaths = Set(sorted.compactMap(\.documentPath).filter { !$0.isEmpty })
+    let domains = Set(documentPaths.compactMap(host))
+    let prs = Set(documentPaths.compactMap(githubPullRequestArtifact))
+    var foregroundChanges = 0
+    var documentChanges = 0
+    var workLeisureFlips = 0
+    var longest = 0.0
+    var uninterruptedStart = sorted[0].capturedAt
+    var previousBundle = sorted[0].bundleId
+    var previousDocument = sorted[0].documentPath ?? ""
+    var previousClass = activityClass(for: sorted[0], classification: classification)
+
+    for frame in sorted.dropFirst() {
+      if frame.bundleId != previousBundle {
+        foregroundChanges += 1
+        longest = max(longest, frame.capturedAt.timeIntervalSince(uninterruptedStart))
+        uninterruptedStart = frame.capturedAt
+        previousBundle = frame.bundleId
+      }
+      let document = frame.documentPath ?? ""
+      if document != previousDocument {
+        documentChanges += 1
+        previousDocument = document
+      }
+      let nextClass = activityClass(for: frame, classification: classification)
+      if previousClass != .neutral && nextClass != .neutral && previousClass != nextClass {
+        workLeisureFlips += 1
+      }
+      if nextClass != .neutral {
+        previousClass = nextClass
+      }
+    }
+    if let last = sorted.last {
+      longest = max(longest, last.capturedAt.timeIntervalSince(uninterruptedStart))
+    }
+
+    return EmittedCounts(
+      distinctBundles: bundles.count,
+      distinctDomains: domains.count,
+      distinctDocumentPaths: documentPaths.count,
+      distinctGithubPrs: prs.count,
+      foregroundChanges: foregroundChanges,
+      documentChanges: documentChanges,
+      workLeisureFlips: workLeisureFlips,
+      longestUninterruptedSeconds: max(0, Int(longest.rounded())),
+      thrashEventCount: thrashEvents(in: sorted, rules: thrashRules).count
+    )
+  }
+
+  static func contextMetadata(
+    for frames: [ProcessedFrame],
+    extractors: [ContextExtractor]
+  ) -> [String: String] {
+    var metadata: [String: String] = [:]
+    var firstSeen: [String: Date] = [:]
+    var foregroundSeconds: [String: TimeInterval] = [:]
+    let sorted = frames.sorted { $0.capturedAt < $1.capturedAt }
+    for (index, frame) in sorted.enumerated() {
+      guard frame.tier != .audit, let documentPath = frame.documentPath else { continue }
+      for extractor in extractors where globMatches(extractor.documentPattern, documentPath) {
+        guard let value = extractValue(from: documentPath, extractor: extractor) else { continue }
+        let key = extractor.captureKey
+        metadata[key] = value
+        firstSeen[key] = firstSeen[key] ?? frame.capturedAt
+        let nextAt = index + 1 < sorted.count ? sorted[index + 1].capturedAt : frame.capturedAt
+        foregroundSeconds[key, default: 0] += max(0, nextAt.timeIntervalSince(frame.capturedAt))
+      }
+    }
+    for (key, date) in firstSeen {
+      metadata["\(key).firstSeenAt"] = ISO8601DateFormatter().string(from: date)
+      metadata["\(key).foregroundSeconds"] = String(Int(foregroundSeconds[key, default: 0]))
+    }
+    return metadata
+  }
+
+  static func profile(
+    for bundleId: String,
+    profiles: [BundleCaptureProfile]
+  ) -> BundleCaptureProfile? {
+    profiles.first { globMatches($0.bundleId, bundleId) }
+  }
+
+  private enum ActivityClass {
+    case work
+    case leisure
+    case neutral
+  }
+
+  private static func activityClass(
+    for frame: ProcessedFrame,
+    classification: BehavioralClassification
+  ) -> ActivityClass {
+    if classification.workBundleIds.contains(frame.bundleId) {
+      return .work
+    }
+    if classification.leisureBundleIds.contains(frame.bundleId) {
+      return .leisure
+    }
+    guard let domain = frame.documentPath.flatMap(host) else { return .neutral }
+    if classification.workDomains.contains(where: { globMatches($0, domain) }) {
+      return .work
+    }
+    if classification.leisureDomains.contains(where: { globMatches($0, domain) }) {
+      return .leisure
+    }
+    return .neutral
+  }
+
+  private static func thrashEvents(in frames: [ProcessedFrame], rules: [ThrashRule]) -> [String] {
+    var events: [String] = []
+    for rule in rules where rule.distinctThreshold > 0 && rule.windowSeconds > 0 {
+      for frame in frames {
+        let windowEnd = frame.capturedAt.addingTimeInterval(TimeInterval(rule.windowSeconds))
+        let distinct = Set(
+          frames.compactMap { candidate -> String? in
+            guard candidate.capturedAt >= frame.capturedAt, candidate.capturedAt <= windowEnd,
+              let documentPath = candidate.documentPath,
+              globMatches(rule.domainPattern, documentPath)
+            else {
+              return nil
+            }
+            return documentPath
+          })
+        if distinct.count >= rule.distinctThreshold {
+          events.append(rule.name)
+          break
+        }
+      }
+    }
+    return events
+  }
+
+  private static func extractValue(from documentPath: String, extractor: ContextExtractor)
+    -> String?
+  {
+    if let regex = extractor.regex, !regex.isEmpty,
+      let expression = try? NSRegularExpression(pattern: regex),
+      let match = expression.firstMatch(
+        in: documentPath,
+        range: NSRange(documentPath.startIndex..., in: documentPath)
+      )
+    {
+      let group = extractor.captureGroup ?? 1
+      guard group < match.numberOfRanges,
+        let range = Range(match.range(at: group), in: documentPath)
+      else {
+        return nil
+      }
+      return String(documentPath[range])
+    }
+    let segments = pathSegments(documentPath)
+    let count = max(1, extractor.lastPathSegments ?? 1)
+    guard segments.count >= count else { return nil }
+    let selected = segments.suffix(count)
+    if selected.count >= 5, selected.first == "github.com" {
+      let values = Array(selected)
+      return "\(values[1])/\(values[2])#\(values[4])"
+    }
+    if selected.count >= 4 {
+      let values = Array(selected)
+      if values[2] == "pull" || values[2] == "issues" {
+        return "\(values[0])/\(values[1])#\(values[3])"
+      }
+    }
+    return selected.joined(separator: "/")
+  }
+
+  private static func githubPullRequestArtifact(_ documentPath: String) -> String? {
+    let segments = pathSegments(documentPath)
+    guard let hostIndex = segments.firstIndex(of: "github.com"),
+      hostIndex + 4 < segments.count,
+      segments[hostIndex + 3] == "pull"
+    else {
+      return nil
+    }
+    return "\(segments[hostIndex + 1])/\(segments[hostIndex + 2])#\(segments[hostIndex + 4])"
+  }
+
+  private static func pathSegments(_ value: String) -> [String] {
+    if let components = URLComponents(string: value), let host = components.host {
+      return ([host] + components.path.split(separator: "/").map(String.init)).filter {
+        !$0.isEmpty
+      }
+    }
+    return value.split(separator: "/").map(String.init)
+  }
+
+  private static func host(_ value: String) -> String? {
+    if let components = URLComponents(string: value), let host = components.host {
+      return host.lowercased()
+    }
+    return nil
+  }
+
+  private static func globMatches(_ pattern: String, _ value: String) -> Bool {
+    let pattern = pattern.lowercased()
+    let value = value.lowercased()
+    if pattern == value || value.contains(pattern) {
+      return true
+    }
+    let escaped = NSRegularExpression.escapedPattern(for: pattern)
+      .replacingOccurrences(of: "\\*", with: ".*")
+    return value.range(of: ".*\(escaped).*", options: .regularExpression) != nil
+  }
+
+  private static func specificity(_ pattern: String) -> Int {
+    pattern.filter { $0 != "*" }.count
+  }
+}

--- a/Sources/agentd/ChronicleControl.swift
+++ b/Sources/agentd/ChronicleControl.swift
@@ -30,6 +30,12 @@ struct CapturePolicy: Sendable, Codable, Equatable {
   var pauseWindowTitlePatterns: [String]
   var secretPatterns: [String]
   var cloudConsolidationTier: String
+  var domainTiers: [DomainTier]
+  var perBundleProfiles: [BundleCaptureProfile]
+  var behavioralClassification: BehavioralClassification?
+  var contextExtractors: [ContextExtractor]
+  var thrashAlerts: [ThrashRule]
+  var sessionBoundaryHooks: BoundaryHookConfig?
   var captureAllDisplays: Bool?
   var selectedDisplayIds: [UInt32]?
   var minBatchIntervalSeconds: Int
@@ -46,6 +52,12 @@ struct CapturePolicy: Sendable, Codable, Equatable {
     pauseWindowTitlePatterns: [String] = [],
     secretPatterns: [String] = [],
     cloudConsolidationTier: String = "",
+    domainTiers: [DomainTier] = [],
+    perBundleProfiles: [BundleCaptureProfile] = [],
+    behavioralClassification: BehavioralClassification? = nil,
+    contextExtractors: [ContextExtractor] = [],
+    thrashAlerts: [ThrashRule] = [],
+    sessionBoundaryHooks: BoundaryHookConfig? = nil,
     captureAllDisplays: Bool? = nil,
     selectedDisplayIds: [UInt32]? = nil,
     minBatchIntervalSeconds: Int = 0,
@@ -61,6 +73,12 @@ struct CapturePolicy: Sendable, Codable, Equatable {
     self.pauseWindowTitlePatterns = pauseWindowTitlePatterns
     self.secretPatterns = secretPatterns
     self.cloudConsolidationTier = cloudConsolidationTier
+    self.domainTiers = domainTiers
+    self.perBundleProfiles = perBundleProfiles
+    self.behavioralClassification = behavioralClassification
+    self.contextExtractors = contextExtractors
+    self.thrashAlerts = thrashAlerts
+    self.sessionBoundaryHooks = sessionBoundaryHooks
     self.captureAllDisplays = captureAllDisplays
     self.selectedDisplayIds = selectedDisplayIds
     self.minBatchIntervalSeconds = minBatchIntervalSeconds
@@ -78,6 +96,12 @@ struct CapturePolicy: Sendable, Codable, Equatable {
     case pauseWindowTitlePatterns
     case secretPatterns
     case cloudConsolidationTier
+    case domainTiers
+    case perBundleProfiles
+    case behavioralClassification
+    case contextExtractors
+    case thrashAlerts
+    case sessionBoundaryHooks
     case captureAllDisplays
     case selectedDisplayIds
     case minBatchIntervalSeconds
@@ -107,6 +131,24 @@ struct CapturePolicy: Sendable, Codable, Equatable {
         String.self,
         forKey: .cloudConsolidationTier
       ) ?? "",
+      domainTiers: try container.decodeIfPresent([DomainTier].self, forKey: .domainTiers) ?? [],
+      perBundleProfiles: try container.decodeIfPresent(
+        [BundleCaptureProfile].self,
+        forKey: .perBundleProfiles
+      ) ?? [],
+      behavioralClassification: try container.decodeIfPresent(
+        BehavioralClassification.self,
+        forKey: .behavioralClassification
+      ),
+      contextExtractors: try container.decodeIfPresent(
+        [ContextExtractor].self,
+        forKey: .contextExtractors
+      ) ?? [],
+      thrashAlerts: try container.decodeIfPresent([ThrashRule].self, forKey: .thrashAlerts) ?? [],
+      sessionBoundaryHooks: try container.decodeIfPresent(
+        BoundaryHookConfig.self,
+        forKey: .sessionBoundaryHooks
+      ),
       captureAllDisplays: try container.decodeIfPresent(Bool.self, forKey: .captureAllDisplays),
       selectedDisplayIds: try container.decodeIfPresent([UInt32].self, forKey: .selectedDisplayIds),
       minBatchIntervalSeconds: try container.decodeIfPresent(

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -65,6 +65,12 @@ struct AgentConfig: Codable, Sendable {
   var deniedBundleIds: [String]
   var deniedPathPrefixes: [String]
   var pauseWindowTitlePatterns: [String]
+  var domainTiers: [DomainTier]
+  var perBundleProfiles: [BundleCaptureProfile]
+  var behavioralClassification: BehavioralClassification
+  var contextExtractors: [ContextExtractor]
+  var thrashAlerts: [ThrashRule]
+  var sessionBoundaryHooks: BoundaryHookConfig
   var captureAllDisplays: Bool
   var selectedDisplayIds: [UInt32]
   var captureFps: Double
@@ -75,6 +81,7 @@ struct AgentConfig: Codable, Sendable {
   var maxBatchBytes: Int64
   var maxBatchAgeDays: Double
   var idleThresholdSeconds: Double
+  var urlChangeIdleThresholdSeconds: Double
   var idlePollSeconds: Double
   var adaptiveOcrMinChars: Int
   var adaptiveOcrBackpressureThreshold: Int
@@ -110,6 +117,12 @@ struct AgentConfig: Codable, Sendable {
     case deniedBundleIds
     case deniedPathPrefixes
     case pauseWindowTitlePatterns
+    case domainTiers
+    case perBundleProfiles
+    case behavioralClassification
+    case contextExtractors
+    case thrashAlerts
+    case sessionBoundaryHooks
     case captureAllDisplays
     case selectedDisplayIds
     case captureFps
@@ -120,6 +133,7 @@ struct AgentConfig: Codable, Sendable {
     case maxBatchBytes
     case maxBatchAgeDays
     case idleThresholdSeconds
+    case urlChangeIdleThresholdSeconds
     case idlePollSeconds
     case adaptiveOcrMinChars
     case adaptiveOcrBackpressureThreshold
@@ -155,6 +169,12 @@ struct AgentConfig: Codable, Sendable {
     deniedBundleIds: [String],
     deniedPathPrefixes: [String],
     pauseWindowTitlePatterns: [String],
+    domainTiers: [DomainTier] = Self.defaultDomainTiers,
+    perBundleProfiles: [BundleCaptureProfile] = [],
+    behavioralClassification: BehavioralClassification = .default,
+    contextExtractors: [ContextExtractor] = ContextExtractor.defaults,
+    thrashAlerts: [ThrashRule] = [.githubPR],
+    sessionBoundaryHooks: BoundaryHookConfig = .default,
     captureAllDisplays: Bool = false,
     selectedDisplayIds: [UInt32] = [],
     captureFps: Double,
@@ -165,6 +185,7 @@ struct AgentConfig: Codable, Sendable {
     maxBatchBytes: Int64 = 512 * 1024 * 1024,
     maxBatchAgeDays: Double = 7,
     idleThresholdSeconds: Double = 60,
+    urlChangeIdleThresholdSeconds: Double = 30,
     idlePollSeconds: Double = 5,
     adaptiveOcrMinChars: Int = 1024,
     adaptiveOcrBackpressureThreshold: Int = 8,
@@ -198,6 +219,12 @@ struct AgentConfig: Codable, Sendable {
     self.deniedBundleIds = deniedBundleIds
     self.deniedPathPrefixes = deniedPathPrefixes
     self.pauseWindowTitlePatterns = pauseWindowTitlePatterns
+    self.domainTiers = domainTiers
+    self.perBundleProfiles = perBundleProfiles
+    self.behavioralClassification = behavioralClassification
+    self.contextExtractors = contextExtractors
+    self.thrashAlerts = thrashAlerts
+    self.sessionBoundaryHooks = sessionBoundaryHooks
     self.captureAllDisplays = captureAllDisplays
     self.selectedDisplayIds = selectedDisplayIds
     self.captureFps = captureFps
@@ -208,6 +235,7 @@ struct AgentConfig: Codable, Sendable {
     self.maxBatchBytes = maxBatchBytes
     self.maxBatchAgeDays = maxBatchAgeDays
     self.idleThresholdSeconds = idleThresholdSeconds
+    self.urlChangeIdleThresholdSeconds = urlChangeIdleThresholdSeconds
     self.idlePollSeconds = idlePollSeconds
     self.adaptiveOcrMinChars = adaptiveOcrMinChars
     self.adaptiveOcrBackpressureThreshold = adaptiveOcrBackpressureThreshold
@@ -252,6 +280,24 @@ struct AgentConfig: Codable, Sendable {
       currentValues: pauseWindowTitlePatterns,
       policyValues: policy.pauseWindowTitlePatterns
     )
+    if !policy.domainTiers.isEmpty {
+      next.domainTiers = policy.domainTiers
+    }
+    if !policy.perBundleProfiles.isEmpty {
+      next.perBundleProfiles = policy.perBundleProfiles
+    }
+    if let behavioralClassification = policy.behavioralClassification {
+      next.behavioralClassification = behavioralClassification
+    }
+    if !policy.contextExtractors.isEmpty {
+      next.contextExtractors = policy.contextExtractors
+    }
+    if !policy.thrashAlerts.isEmpty {
+      next.thrashAlerts = policy.thrashAlerts
+    }
+    if let hooks = policy.sessionBoundaryHooks {
+      next.sessionBoundaryHooks = hooks
+    }
 
     if policy.captureAllDisplays != nil {
       next.captureAllDisplays = policy.captureAllDisplays == true
@@ -312,6 +358,24 @@ struct AgentConfig: Codable, Sendable {
     pauseWindowTitlePatterns =
       try container.decodeIfPresent([String].self, forKey: .pauseWindowTitlePatterns)
       ?? Self.defaultPauseWindowPatterns
+    domainTiers =
+      try container.decodeIfPresent([DomainTier].self, forKey: .domainTiers)
+      ?? Self.defaultDomainTiers
+    perBundleProfiles =
+      try container.decodeIfPresent([BundleCaptureProfile].self, forKey: .perBundleProfiles) ?? []
+    behavioralClassification =
+      try container.decodeIfPresent(
+        BehavioralClassification.self,
+        forKey: .behavioralClassification
+      ) ?? .default
+    contextExtractors =
+      try container.decodeIfPresent([ContextExtractor].self, forKey: .contextExtractors)
+      ?? ContextExtractor.defaults
+    thrashAlerts =
+      try container.decodeIfPresent([ThrashRule].self, forKey: .thrashAlerts) ?? [.githubPR]
+    sessionBoundaryHooks =
+      try container.decodeIfPresent(BoundaryHookConfig.self, forKey: .sessionBoundaryHooks)
+      ?? .default
     captureAllDisplays =
       try container.decodeIfPresent(Bool.self, forKey: .captureAllDisplays) ?? false
     selectedDisplayIds =
@@ -327,6 +391,8 @@ struct AgentConfig: Codable, Sendable {
     maxBatchAgeDays = try container.decodeIfPresent(Double.self, forKey: .maxBatchAgeDays) ?? 7
     idleThresholdSeconds =
       try container.decodeIfPresent(Double.self, forKey: .idleThresholdSeconds) ?? 60
+    urlChangeIdleThresholdSeconds =
+      try container.decodeIfPresent(Double.self, forKey: .urlChangeIdleThresholdSeconds) ?? 30
     idlePollSeconds = try container.decodeIfPresent(Double.self, forKey: .idlePollSeconds) ?? 5
     adaptiveOcrMinChars =
       try container.decodeIfPresent(Int.self, forKey: .adaptiveOcrMinChars) ?? 1024
@@ -383,6 +449,14 @@ struct AgentConfig: Codable, Sendable {
     try container.encode(deniedBundleIds, forKey: .deniedBundleIds)
     try container.encode(deniedPathPrefixes, forKey: .deniedPathPrefixes)
     try container.encode(pauseWindowTitlePatterns, forKey: .pauseWindowTitlePatterns)
+    try container.encode(domainTiers, forKey: .domainTiers)
+    if !perBundleProfiles.isEmpty {
+      try container.encode(perBundleProfiles, forKey: .perBundleProfiles)
+    }
+    try container.encode(behavioralClassification, forKey: .behavioralClassification)
+    try container.encode(contextExtractors, forKey: .contextExtractors)
+    try container.encode(thrashAlerts, forKey: .thrashAlerts)
+    try container.encode(sessionBoundaryHooks, forKey: .sessionBoundaryHooks)
     try container.encode(captureAllDisplays, forKey: .captureAllDisplays)
     if !selectedDisplayIds.isEmpty {
       try container.encode(selectedDisplayIds, forKey: .selectedDisplayIds)
@@ -395,6 +469,7 @@ struct AgentConfig: Codable, Sendable {
     try container.encode(maxBatchBytes, forKey: .maxBatchBytes)
     try container.encode(maxBatchAgeDays, forKey: .maxBatchAgeDays)
     try container.encode(idleThresholdSeconds, forKey: .idleThresholdSeconds)
+    try container.encode(urlChangeIdleThresholdSeconds, forKey: .urlChangeIdleThresholdSeconds)
     try container.encode(idlePollSeconds, forKey: .idlePollSeconds)
     try container.encode(adaptiveOcrMinChars, forKey: .adaptiveOcrMinChars)
     try container.encode(
@@ -464,6 +539,14 @@ struct AgentConfig: Codable, Sendable {
     "Private Browsing", "Private", "Incognito",
   ]
 
+  static let defaultDomainTiers: [DomainTier] = [
+    DomainTier(pattern: "github.com/*/pull/*", tier: .evidence),
+    DomainTier(pattern: "github.com/*/issues/*", tier: .evidence),
+    DomainTier(pattern: "x.com", tier: .audit),
+    DomainTier(pattern: "twitter.com", tier: .audit),
+    DomainTier(pattern: "youtube.com", tier: .audit),
+  ]
+
   static func fallback() -> AgentConfig {
     AgentConfig(
       deviceId: ProcessInfo.processInfo.globallyUniqueString,
@@ -473,6 +556,12 @@ struct AgentConfig: Codable, Sendable {
       deniedBundleIds: defaultDeniedBundleIds,
       deniedPathPrefixes: defaultDeniedPathPrefixes,
       pauseWindowTitlePatterns: defaultPauseWindowPatterns,
+      domainTiers: defaultDomainTiers,
+      perBundleProfiles: [],
+      behavioralClassification: .default,
+      contextExtractors: ContextExtractor.defaults,
+      thrashAlerts: [.githubPR],
+      sessionBoundaryHooks: .default,
       captureAllDisplays: false,
       selectedDisplayIds: [],
       captureFps: 1.0,
@@ -483,6 +572,7 @@ struct AgentConfig: Codable, Sendable {
       maxBatchBytes: 512 * 1024 * 1024,
       maxBatchAgeDays: 7,
       idleThresholdSeconds: 60,
+      urlChangeIdleThresholdSeconds: 30,
       idlePollSeconds: 5,
       adaptiveOcrMinChars: 1024,
       adaptiveOcrBackpressureThreshold: 8,

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -28,6 +28,7 @@ struct ProcessedFrame: Sendable, Codable {
   let appName: String
   let windowTitle: String
   let documentPath: String?
+  let tier: CaptureTier
   let ocrText: String
   let ocrTextTruncated: Bool
   let ocrConfidence: Float
@@ -47,6 +48,7 @@ struct ProcessedFrame: Sendable, Codable {
     case appName
     case windowTitle
     case documentPath
+    case tier
     case ocrText
     case ocrTextTruncated
     case ocrConfidence
@@ -66,6 +68,7 @@ struct ProcessedFrame: Sendable, Codable {
     appName: String,
     windowTitle: String,
     documentPath: String?,
+    tier: CaptureTier = .evidence,
     ocrText: String,
     ocrTextTruncated: Bool = false,
     ocrConfidence: Float,
@@ -84,6 +87,7 @@ struct ProcessedFrame: Sendable, Codable {
     self.appName = appName
     self.windowTitle = windowTitle
     self.documentPath = documentPath
+    self.tier = tier
     self.ocrText = ocrText
     self.ocrTextTruncated = ocrTextTruncated
     self.ocrConfidence = ocrConfidence
@@ -110,6 +114,7 @@ struct ProcessedFrame: Sendable, Codable {
     appName = try container.decode(String.self, forKey: .appName)
     windowTitle = try container.decode(String.self, forKey: .windowTitle)
     documentPath = try container.decodeIfPresent(String.self, forKey: .documentPath)
+    tier = try container.decodeIfPresent(CaptureTier.self, forKey: .tier) ?? .evidence
     ocrText = try container.decode(String.self, forKey: .ocrText)
     ocrTextTruncated = try container.decodeIfPresent(Bool.self, forKey: .ocrTextTruncated) ?? false
     ocrConfidence = try container.decode(Float.self, forKey: .ocrConfidence)
@@ -143,6 +148,7 @@ struct ProcessedFrame: Sendable, Codable {
     try container.encode(appName, forKey: .appName)
     try container.encode(windowTitle, forKey: .windowTitle)
     try container.encodeIfPresent(documentPath, forKey: .documentPath)
+    try container.encode(tier, forKey: .tier)
     try container.encode(ocrText, forKey: .ocrText)
     try container.encode(ocrTextTruncated, forKey: .ocrTextTruncated)
     try container.encode(ocrConfidence, forKey: .ocrConfidence)
@@ -170,6 +176,7 @@ struct Batch: Sendable, Codable {
   let captureWindow: CaptureWindow
   let frames: [ProcessedFrame]
   let droppedCounts: DropCounts
+  let emittedCounts: EmittedCounts
 
   init(
     batchId: String,
@@ -184,7 +191,8 @@ struct Batch: Sendable, Codable {
     endedAt: Date,
     captureWindow: CaptureWindow? = nil,
     frames: [ProcessedFrame],
-    droppedCounts: DropCounts
+    droppedCounts: DropCounts,
+    emittedCounts: EmittedCounts = .empty
   ) {
     self.batchId = batchId
     self.deviceId = deviceId
@@ -199,6 +207,7 @@ struct Batch: Sendable, Codable {
     self.captureWindow = captureWindow ?? CaptureWindow(startedAt: startedAt, endedAt: endedAt)
     self.frames = frames
     self.droppedCounts = droppedCounts
+    self.emittedCounts = emittedCounts
   }
 
   enum CodingKeys: String, CodingKey {
@@ -215,6 +224,7 @@ struct Batch: Sendable, Codable {
     case captureWindow
     case frames
     case droppedCounts
+    case emittedCounts
   }
 
   init(from decoder: Decoder) throws {
@@ -234,7 +244,9 @@ struct Batch: Sendable, Codable {
       endedAt: endedAt,
       captureWindow: try container.decodeIfPresent(CaptureWindow.self, forKey: .captureWindow),
       frames: try container.decode([ProcessedFrame].self, forKey: .frames),
-      droppedCounts: try container.decode(DropCounts.self, forKey: .droppedCounts)
+      droppedCounts: try container.decode(DropCounts.self, forKey: .droppedCounts),
+      emittedCounts: try container.decodeIfPresent(EmittedCounts.self, forKey: .emittedCounts)
+        ?? .empty
     )
   }
 }
@@ -772,6 +784,15 @@ actor FramePipeline {
       return
     }
 
+    let captureTier = ChronicleBehavior.captureTier(
+      for: ctx.documentPath,
+      domainTiers: config.domainTiers
+    )
+    if captureTier == .deny {
+      droppedDeniedPath += 1
+      return
+    }
+
     guard let phash = PerceptualHash(cgImage: frame.cgImage) else { return }
     let duplicateByHash = dedupWindow.containsDuplicate(of: phash)
     if duplicateByHash, !config.ocrDiffSamplerEnabled {
@@ -780,32 +801,36 @@ actor FramePipeline {
     }
 
     let ocrResult: OCRResult
-    let textSource: FrameTextSource
-    let axText = accessibilityText.map { AccessibilityTextExtractor.normalize($0.text) } ?? ""
-    if !axText.isEmpty {
-      ocrResult = OCRResult(text: axText, confidence: 1, language: nil)
-      textSource = .accessibility
+    if captureTier == .audit {
+      ocrResult = OCRResult(text: "", confidence: 0, language: nil)
     } else {
-      let ocrCacheKey = ImageContentHash.calculate(cgImage: frame.cgImage).map {
-        OCRCacheKey(context: ctx, imageHash: $0)
-      }
-      if let ocrCacheKey, let cached = ocrCache.result(for: ocrCacheKey) {
-        ocrResult = cached
-        textSource = .cachedOCR
+      let textSource: FrameTextSource
+      let axText = accessibilityText.map { AccessibilityTextExtractor.normalize($0.text) } ?? ""
+      if !axText.isEmpty {
+        ocrResult = OCRResult(text: axText, confidence: 1, language: nil)
+        textSource = .accessibility
       } else {
-        do {
-          ocrResult = try await ocr.recognize(cgImage: frame.cgImage)
-          textSource = .visionOCR
-          if let ocrCacheKey {
-            ocrCache.insert(ocrResult, for: ocrCacheKey)
+        let ocrCacheKey = ImageContentHash.calculate(cgImage: frame.cgImage).map {
+          OCRCacheKey(context: ctx, imageHash: $0)
+        }
+        if let ocrCacheKey, let cached = ocrCache.result(for: ocrCacheKey) {
+          ocrResult = cached
+          textSource = .cachedOCR
+        } else {
+          do {
+            ocrResult = try await ocr.recognize(cgImage: frame.cgImage)
+            textSource = .visionOCR
+            if let ocrCacheKey {
+              ocrCache.insert(ocrResult, for: ocrCacheKey)
+            }
+          } catch {
+            Log.ocr.error("ocr failed: \(error.localizedDescription, privacy: .public)")
+            return
           }
-        } catch {
-          Log.ocr.error("ocr failed: \(error.localizedDescription, privacy: .public)")
-          return
         }
       }
+      textSourceCounts[textSource, default: 0] += 1
     }
-    textSourceCounts[textSource, default: 0] += 1
 
     switch evaluateSecretSurfaces(context: ctx, ocrText: ocrResult.text) {
     case .dropped(let reason):
@@ -851,7 +876,10 @@ actor FramePipeline {
       bundleId: ctx.bundleId,
       appName: ctx.appName,
       windowTitle: ctx.windowTitle,
-      documentPath: ctx.documentPath,
+      documentPath: captureTier == .audit
+        ? ChronicleBehavior.auditDocumentPath(ctx.documentPath)
+        : ctx.documentPath,
+      tier: captureTier,
       ocrText: ocrText.value,
       ocrTextTruncated: ocrText.truncated,
       ocrConfidence: ocrResult.confidence,
@@ -867,7 +895,7 @@ actor FramePipeline {
     pending.append(processed)
     dedupWindow.remember(phash)
     lastEmittedOcrText = ocrResult.text
-    if let sparseFrameStore {
+    if captureTier != .audit, let sparseFrameStore {
       do {
         try await sparseFrameStore.record(image: frame.cgImage, processed: processed)
       } catch {
@@ -884,6 +912,10 @@ actor FramePipeline {
 
   func flush() async {
     guard !pending.isEmpty || hasDrops() else { return }
+    let batchFrames = pending
+    let metadata = config.metadata.merging(
+      ChronicleBehavior.contextMetadata(for: batchFrames, extractors: config.contextExtractors)
+    ) { _, next in next }
     let batch = Batch(
       batchId: UUID().uuidString,
       deviceId: config.deviceId,
@@ -892,16 +924,21 @@ actor FramePipeline {
       userId: config.userId,
       projectId: config.projectId,
       repository: config.repository,
-      metadata: config.metadata,
+      metadata: metadata,
       startedAt: startedAt,
       endedAt: Date(),
-      frames: pending,
+      frames: batchFrames,
       droppedCounts: DropCounts(
         secret: droppedSecret,
         duplicate: droppedDup,
         deniedApp: droppedDeniedApp,
         deniedPath: droppedDeniedPath,
         droppedBackpressure: droppedBackpressure
+      ),
+      emittedCounts: ChronicleBehavior.emittedCounts(
+        for: batchFrames,
+        classification: config.behavioralClassification,
+        thrashRules: config.thrashAlerts
       )
     )
     pending.removeAll(keepingCapacity: true)

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -36,6 +36,8 @@ final class AppController {
   private var captureHealthWatchdog = CaptureHealthWatchdog()
   private var eventCaptureInFlight = false
   private var idleMode = false
+  private var lastForegroundIdentity: String?
+  private var lastForegroundIdentityChangedAt = Date()
 
   init() {
     let cfg = ConfigStore.load()
@@ -242,14 +244,36 @@ final class AppController {
       .combinedSessionState,
       eventType: CGEventType(rawValue: ~0)!
     )
-    let shouldIdle = idleSeconds >= config.idleThresholdSeconds
+    let context = WindowContextProbe.current()
+    let foregroundIdentity = [
+      context?.bundleId ?? "",
+      context?.windowTitle ?? "",
+      context?.documentPath ?? "",
+    ].joined(separator: "|")
+    if foregroundIdentity != lastForegroundIdentity {
+      lastForegroundIdentity = foregroundIdentity
+      lastForegroundIdentityChangedAt = Date()
+    }
+    let urlIdle =
+      config.urlChangeIdleThresholdSeconds > 0
+      && Date().timeIntervalSince(lastForegroundIdentityChangedAt)
+        >= config.urlChangeIdleThresholdSeconds
+    let inputIdle = idleSeconds >= config.idleThresholdSeconds
+    let shouldIdle = inputIdle || urlIdle
     guard shouldIdle != idleMode else { return }
 
     idleMode = shouldIdle
-    let fps = shouldIdle ? config.idleFps : config.captureFps
+    let bundleProfile = context.flatMap {
+      ChronicleBehavior.profile(for: $0.bundleId, profiles: config.perBundleProfiles)
+    }
+    let fps =
+      shouldIdle
+      ? (bundleProfile?.idleFps ?? config.idleFps)
+      : (bundleProfile?.eventDrivenOnly == true
+        ? 0 : (bundleProfile?.captureFps ?? config.captureFps))
     await capture.updateFps(fps)
     Log.capture.info(
-      "adaptive fps mode=\(shouldIdle ? "idle" : "active", privacy: .public) fps=\(fps, privacy: .public)"
+      "adaptive fps mode=\(shouldIdle ? "idle" : "active", privacy: .public) inputIdle=\(inputIdle, privacy: .public) urlIdle=\(urlIdle, privacy: .public) fps=\(fps, privacy: .public)"
     )
   }
 

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -156,6 +156,61 @@ final class PipelineTests: XCTestCase {
     XCTAssertEqual(batch.frames.count, 1)
   }
 
+  func testAuditDomainTierRedactsFrameContentButKeepsHostEvidence() async throws {
+    let recorder = BatchRecorder()
+    let pipeline = FramePipeline(config: Self.config(), ocr: StubOCR(text: "should not persist")) {
+      batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(
+      Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA),
+      context: Self.context(
+        windowTitle: "x timeline",
+        documentPath: "https://x.com/home?secret_path=redacted"
+      )
+    )
+    await pipeline.flush()
+
+    let batches = await recorder.snapshot()
+    let batch = try XCTUnwrap(batches.first)
+    let frame = try XCTUnwrap(batch.frames.first)
+    XCTAssertEqual(frame.tier, .audit)
+    XCTAssertEqual(frame.documentPath, "https://x.com")
+    XCTAssertEqual(frame.ocrText, "")
+    XCTAssertEqual(frame.ocrConfidence, 0)
+    XCTAssertEqual(batch.droppedCounts.deniedPath, 0)
+  }
+
+  func testBatchEmitsBehavioralCountsAndActiveArtifactMetadata() async throws {
+    let recorder = BatchRecorder()
+    let pipeline = FramePipeline(
+      config: Self.config(maxFramesPerBatch: 2), ocr: StubOCR(text: "pr")
+    ) {
+      batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(
+      Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA),
+      context: Self.context(documentPath: "https://github.com/evalops/platform/pull/1321")
+    )
+    await pipeline.consume(
+      Self.frame(bits: 0xBBBB_BBBB_BBBB_BBBB),
+      context: Self.context(documentPath: "https://github.com/evalops/agentd/issues/99")
+    )
+    await pipeline.flush()
+
+    let batches = await recorder.snapshot()
+    let batch = try XCTUnwrap(batches.first)
+    XCTAssertEqual(batch.emittedCounts.distinctDomains, 1)
+    XCTAssertEqual(batch.emittedCounts.distinctDocumentPaths, 2)
+    XCTAssertEqual(batch.emittedCounts.distinctGithubPrs, 1)
+    XCTAssertEqual(batch.emittedCounts.documentChanges, 1)
+    XCTAssertEqual(batch.metadata["activePullRequest"], "evalops/platform#1321")
+    XCTAssertEqual(batch.metadata["activeIssue"], "evalops/agentd#99")
+  }
+
   func testFailedSubmitKeepsBatchPendingForRetry() async throws {
     let recorder = BatchRecorder(result: .failed)
     let pipeline = FramePipeline(config: Self.config(), ocr: StubOCR(text: "clean")) { batch in

--- a/docs/chronicle-parity-audit.md
+++ b/docs/chronicle-parity-audit.md
@@ -24,3 +24,24 @@ display diagnostics, sparse local artifacts, material-text-change sampling,
 browser-window privacy handling, meeting exclusion, safe-to-persist semantics,
 summarizer prompt-injection posture, macOS API availability, and the deliberate
 choice to keep audio capture out of scope.
+
+## Flagship Product Loop Signals
+
+Agentd now emits the source-side structure that lets Platform answer "what was
+I doing, what changed, and what should an agent know about it?" without
+re-parsing raw OCR:
+
+- `domainTiers` grades matching domains as `evidence`, `audit`, or `deny`.
+  Audit-tier frames preserve host-level evidence, set `tier=audit`, blank OCR,
+  truncate `documentPath` to scheme plus host, and skip sparse-frame artifacts.
+- `emittedCounts` is attached to every batch with deterministic counters for
+  distinct bundles/domains/document paths, GitHub PRs, foreground/document
+  changes, work-leisure flips, longest uninterrupted seconds, and thrash events.
+- `contextExtractors` add dynamic batch metadata such as `activeIssue` and
+  `activePullRequest`, including first-seen timestamps and foreground seconds.
+- `perBundleProfiles` and `urlChangeIdleThresholdSeconds` let managed policy
+  reduce noisy polling for browser/feed surfaces while keeping IDE and terminal
+  work at higher fidelity.
+
+These fields are additive on the wire. Older Platform versions ignore them;
+newer Platform Chronicle policy can send them back through `CapturePolicy`.


### PR DESCRIPTION
## Summary

- add source-side Chronicle behavior contracts for domain tiers, per-bundle profiles, emitted counts, context extractors, thrash rules, and boundary hook config
- apply audit/deny/evidence tiers in the frame pipeline, including host-only audit frames, no OCR persistence, and no sparse-frame artifact for audit domains
- attach emittedCounts and active issue/PR metadata to batches, and apply URL-stability idle plus per-bundle FPS policy in the runtime loop

## Issues

Refs evalops/agentd#90, evalops/agentd#91, evalops/agentd#92, evalops/agentd#94, evalops/agentd#96, evalops/agentd#97, evalops/agentd#99.

## Validation

- swift build -Xswiftc -warnings-as-errors
- swift test
- git diff --check