### PR TITLE
fix: address additional capture review feedback

### DIFF
--- a/Sources/agentd/CaptureService.swift
+++ b/Sources/agentd/CaptureService.swift
@@ -102,6 +102,7 @@ actor CaptureService {
       try await workerClient.start(scope: next)
       runningScope = next
     } catch {
+      runningScope = current
       Log.capture.error(
         "capture worker fps update failed: \(error.localizedDescription, privacy: .public)"
       )

--- a/Sources/agentd/CaptureWorkerSupervisor.swift
+++ b/Sources/agentd/CaptureWorkerSupervisor.swift
@@ -66,6 +66,7 @@ enum CaptureWorkerSupervisorError: Error, LocalizedError, Equatable {
 final class CaptureWorkerSupervisor: @unchecked Sendable {
   private let lock = NSLock()
   private var process: Process?
+  private var terminatingProcess: Process?
   private var starts = 0
   private var terminations = 0
   private var forceKills = 0
@@ -85,7 +86,8 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
     }
 
     return try lock.withLock {
-      if let current = self.process, current.isRunning {
+      self.reapExitedProcessIfNeededLocked()
+      if let current = self.process {
         throw CaptureWorkerSupervisorError.alreadyRunning(pid: current.processIdentifier)
       }
       try process.run()
@@ -102,7 +104,7 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
   func terminate(graceSeconds: TimeInterval) -> CaptureWorkerTerminationResult {
     let target = lock.withLock { () -> Process? in
       guard let process = self.process else { return nil }
-      self.process = nil
+      self.terminatingProcess = process
       return process
     }
     guard let target else {
@@ -153,11 +155,6 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
     let pid = target.processIdentifier
     let exited = Self.wait(for: target, timeoutSeconds: max(0, timeoutSeconds))
     guard exited else { return nil }
-    lock.withLock {
-      if self.process === target {
-        self.process = nil
-      }
-    }
     return recordTermination(
       process: target,
       pid: pid,
@@ -192,8 +189,14 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
       if killSent {
         forceKills += 1
       }
-      lastPid = pid
-      lastExitStatus = status
+      if self.process === process {
+        self.process = nil
+        self.terminatingProcess = nil
+        lastPid = pid
+        lastExitStatus = status
+      } else if self.terminatingProcess === process {
+        self.terminatingProcess = nil
+      }
     }
     return CaptureWorkerTerminationResult(
       pid: pid,
@@ -202,6 +205,18 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
       exited: exited,
       terminationStatus: status
     )
+  }
+
+  private func reapExitedProcessIfNeededLocked() {
+    guard let current = process, !current.isRunning else { return }
+    current.waitUntilExit()
+    process = nil
+    if terminatingProcess === current {
+      terminatingProcess = nil
+    }
+    terminations += 1
+    lastPid = current.processIdentifier
+    lastExitStatus = current.terminationStatus
   }
 
   private static func wait(for process: Process, timeoutSeconds: TimeInterval) -> Bool {

--- a/Sources/agentd/EventCaptureScheduler.swift
+++ b/Sources/agentd/EventCaptureScheduler.swift
@@ -141,7 +141,7 @@ struct EventCaptureScheduler: Sendable {
 
   private mutating func shouldRunIdleFallback(now: Date) -> Bool {
     guard config.eventCaptureIdleFallbackSeconds > 0 else { return false }
-    let reference = lastIdleFallbackAt ?? lastAcceptedAt
+    let reference = lastAcceptedAt ?? lastIdleFallbackAt
     guard let reference else { return true }
     return now.timeIntervalSince(reference) >= config.eventCaptureIdleFallbackSeconds
   }

--- a/Sources/agentd/ForegroundPrivacyPause.swift
+++ b/Sources/agentd/ForegroundPrivacyPause.swift
@@ -26,9 +26,6 @@ enum ForegroundPrivacyPauseDetector {
   static func isProtectedApplication(_ value: String) -> Bool {
     let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     guard !normalized.isEmpty else { return false }
-    if normalized == "max" {
-      return true
-    }
     return protectedApplicationFragments.contains { normalized.contains($0) }
   }
 

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -662,8 +662,11 @@ struct PrivacyObservationSignature: Sendable, Hashable {
     let policy = PathPolicy(deniedPrefixes: deniedPrefixes)
     if policy.deny(path) {
       let matched = deniedPrefixes.first { prefix in
+        let homeRelative = FileManager.default.homeDirectoryForCurrentUser
+          .appendingPathComponent(prefix).path
         let expanded = NSString(string: prefix).expandingTildeInPath
-        return path.hasPrefix(expanded) || path.hasPrefix(prefix)
+        return path.hasPrefix(expanded) || path.hasPrefix(homeRelative)
+          || path.hasPrefix(prefix) || path.contains("/" + prefix + "/")
       }
       return "denied:\(stableClassHash(matched ?? "path"))"
     }

--- a/Sources/agentd/SparseFrameStore.swift
+++ b/Sources/agentd/SparseFrameStore.swift
@@ -33,6 +33,9 @@ actor SparseFrameStore {
   func record(image: CGImage, processed: ProcessedFrame) throws {
     try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
     var session = try sessions[processed.displayId] ?? createSession(for: processed)
+    if !FileManager.default.fileExists(atPath: session.directory.path) {
+      session = try createSession(for: processed)
+    }
     let storageImage =
       visualRedactionEnabled
       ? SparseFrameVisualRedactor.mask(image: image, regions: processed.ocrTextRegions)
@@ -158,7 +161,12 @@ actor SparseFrameStore {
         continue
       }
       guard let modified = values.contentModificationDate, modified < cutoff else { continue }
-      try? FileManager.default.removeItem(at: url)
+      if FileManager.default.fileExists(atPath: url.path) {
+        try? FileManager.default.removeItem(at: url)
+      }
+      if values.isDirectory == true {
+        sessions = sessions.filter { $0.value.directory != url }
+      }
     }
   }
 
@@ -240,7 +248,7 @@ enum SparseFrameVisualRedactor {
     let imageWidth = CGFloat(width)
     let imageHeight = CGFloat(height)
     let x = normalized.minX * imageWidth
-    let y = (1 - normalized.maxY) * imageHeight
+    let y = normalized.minY * imageHeight
     return CGRect(
       x: x,
       y: y,

--- a/Tests/agentdTests/CaptureWorkerSupervisorTests.swift
+++ b/Tests/agentdTests/CaptureWorkerSupervisorTests.swift
@@ -80,6 +80,68 @@ final class CaptureWorkerSupervisorTests: XCTestCase {
     }
   }
 
+  func testWaitForExitRecordsStatsAndAllowsRestart() throws {
+    let supervisor = CaptureWorkerSupervisor()
+    let firstPID = try supervisor.start(
+      CaptureWorkerProcessSpec(
+        executableURL: URL(fileURLWithPath: "/bin/sh"),
+        arguments: ["-c", "exit 0"]
+      )
+    )
+
+    let result = try XCTUnwrap(supervisor.waitForExit(timeoutSeconds: 2))
+    XCTAssertEqual(result.pid, firstPID)
+    XCTAssertEqual(supervisor.stats().terminations, 1)
+    XCTAssertEqual(supervisor.stats().lastPid, firstPID)
+
+    let secondPID = try supervisor.start(
+      CaptureWorkerProcessSpec(
+        executableURL: URL(fileURLWithPath: "/bin/sleep"),
+        arguments: ["1"]
+      )
+    )
+    defer { _ = supervisor.terminate(graceSeconds: 1) }
+    XCTAssertNotEqual(secondPID, firstPID)
+  }
+
+  func testRejectsStartWhileWorkerIsTerminating() throws {
+    let supervisor = CaptureWorkerSupervisor()
+    let output = Pipe()
+    let pid = try supervisor.start(
+      CaptureWorkerProcessSpec(
+        executableURL: URL(fileURLWithPath: "/usr/bin/perl"),
+        arguments: [
+          "-e",
+          "$|=1; $SIG{TERM}=sub{}; print \"ready\\n\"; while (1) { select undef, undef, undef, 0.1 }",
+        ],
+        standardOutput: output
+      )
+    )
+    XCTAssertTrue(waitForReadyLine(from: output))
+
+    let terminated = DispatchSemaphore(value: 0)
+    let result = LockedTerminationResult()
+    DispatchQueue.global(qos: .userInitiated).async {
+      result.store(supervisor.terminate(graceSeconds: 0.3))
+      terminated.signal()
+    }
+    Thread.sleep(forTimeInterval: 0.05)
+
+    XCTAssertThrowsError(
+      try supervisor.start(
+        CaptureWorkerProcessSpec(
+          executableURL: URL(fileURLWithPath: "/bin/sleep"),
+          arguments: ["1"]
+        )
+      )
+    ) { error in
+      XCTAssertEqual(error as? CaptureWorkerSupervisorError, .alreadyRunning(pid: pid))
+    }
+    XCTAssertEqual(terminated.wait(timeout: .now() + 2), .success)
+    XCTAssertEqual(result.value?.pid, pid)
+    XCTAssertTrue(result.value?.killSent == true)
+  }
+
   private func waitForReadyLine(from pipe: Pipe, timeoutSeconds: TimeInterval = 2) -> Bool {
     let semaphore = DispatchSemaphore(value: 0)
     let buffer = ReadyLineBuffer()
@@ -93,6 +155,21 @@ final class CaptureWorkerSupervisorTests: XCTestCase {
     let ready = semaphore.wait(timeout: .now() + timeoutSeconds) == .success
     pipe.fileHandleForReading.readabilityHandler = nil
     return ready
+  }
+}
+
+private final class LockedTerminationResult: @unchecked Sendable {
+  private let lock = NSLock()
+  private var stored: CaptureWorkerTerminationResult?
+
+  var value: CaptureWorkerTerminationResult? {
+    lock.withLock { stored }
+  }
+
+  func store(_ result: CaptureWorkerTerminationResult) {
+    lock.withLock {
+      stored = result
+    }
   }
 }
 

--- a/Tests/agentdTests/EventCaptureSchedulerTests.swift
+++ b/Tests/agentdTests/EventCaptureSchedulerTests.swift
@@ -89,6 +89,44 @@ final class EventCaptureSchedulerTests: XCTestCase {
     )
   }
 
+  func testIdleFallbackUsesMostRecentAcceptedTriggerAsReference() {
+    var cfg = Self.config()
+    cfg.eventCaptureIdleFallbackSeconds = 30
+    cfg.eventCaptureMinGapSeconds = 0
+    cfg.eventCaptureDebounceSeconds = 0
+    var scheduler = EventCaptureScheduler(config: cfg)
+    let start = Date(timeIntervalSince1970: 100)
+
+    XCTAssertEqual(
+      scheduler.observe(context: nil, clipboardChangeCount: 1, now: start),
+      [.idleFallback]
+    )
+    XCTAssertEqual(
+      scheduler.observe(
+        context: Self.context(windowTitle: "A"),
+        clipboardChangeCount: 1,
+        now: start.addingTimeInterval(15)
+      ),
+      []
+    )
+    XCTAssertEqual(
+      scheduler.observe(
+        context: Self.context(windowTitle: "A"),
+        clipboardChangeCount: 1,
+        now: start.addingTimeInterval(15.1)
+      ),
+      [.focusedWindow]
+    )
+    XCTAssertEqual(
+      scheduler.observe(context: nil, clipboardChangeCount: 1, now: start.addingTimeInterval(30)),
+      []
+    )
+    XCTAssertEqual(
+      scheduler.observe(context: nil, clipboardChangeCount: 1, now: start.addingTimeInterval(45.2)),
+      [.idleFallback]
+    )
+  }
+
   func testDisabledSchedulerIgnoresSignals() {
     var cfg = Self.config()
     cfg.eventCaptureEnabled = false

--- a/Tests/agentdTests/ForegroundPrivacyPauseTests.swift
+++ b/Tests/agentdTests/ForegroundPrivacyPauseTests.swift
@@ -33,6 +33,14 @@ final class ForegroundPrivacyPauseTests: XCTestCase {
     XCTAssertEqual(reason, "protected_application")
   }
 
+  func testUnrelatedMaxApplicationDoesNotPause() {
+    XCTAssertNil(
+      ForegroundPrivacyPauseDetector.reason(
+        context: Self.context(appName: "Max"),
+        config: Self.config()
+      ))
+  }
+
   func testUnrelatedWindowDoesNotPause() {
     XCTAssertNil(
       ForegroundPrivacyPauseDetector.reason(

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -450,6 +450,48 @@ final class PipelineTests: XCTestCase {
     XCTAssertGreaterThan(corner.blue, 240)
   }
 
+  func testSparseFrameVisualRedactorUsesBottomLeftVisionCoordinates() {
+    let rect = SparseFrameVisualRedactor.pixelRect(
+      normalized: CGRect(x: 0.10, y: 0.20, width: 0.30, height: 0.10),
+      width: 100,
+      height: 200
+    )
+
+    XCTAssertEqual(rect.origin.x, 10, accuracy: 0.001)
+    XCTAssertEqual(rect.origin.y, 40, accuracy: 0.001)
+    XCTAssertEqual(rect.width, 30, accuracy: 0.001)
+    XCTAssertEqual(rect.height, 20, accuracy: 0.001)
+  }
+
+  func testSparseFrameStoreRecreatesMissingCachedSessionDirectory() async throws {
+    let root = try Self.temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = SparseFrameStore(root: root, retentionHours: 6)
+    let first = Date(timeIntervalSince1970: 100)
+    let second = Date(timeIntervalSince1970: 200)
+
+    try await store.record(
+      image: Self.image(bits: 0xAAAA_AAAA_AAAA_AAAA),
+      processed: Self.processedFrame(capturedAt: first, ocrText: "first")
+    )
+    let firstDirectory = try XCTUnwrap(
+      try FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil)
+        .first { url in
+          var isDirectory: ObjCBool = false
+          return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
+        })
+    try FileManager.default.removeItem(at: firstDirectory)
+
+    try await store.record(
+      image: Self.image(bits: 0x5555_5555_5555_5555),
+      processed: Self.processedFrame(capturedAt: second, ocrText: "second")
+    )
+
+    let files = try FileManager.default.contentsOfDirectory(atPath: root.path)
+    XCTAssertTrue(files.contains { $0.contains("1970-01-01T00-03-20-display-1") })
+  }
+
   func testSparseFrameStoreCanOptIntoVisualRedactionMetadata() async throws {
     let root = try Self.temporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }
@@ -679,6 +721,22 @@ final class PipelineTests: XCTestCase {
     XCTAssertEqual(decision.dropKind, .deniedPath)
   }
 
+  func testDeniedPathClassSeparatesDefaultDeniedPrefixes() {
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+    let ssh = PrivacyObservationSignature.pathClass(
+      "\(home)/.ssh/id_ed25519",
+      deniedPrefixes: [".ssh", ".aws"]
+    )
+    let aws = PrivacyObservationSignature.pathClass(
+      "\(home)/.aws/credentials",
+      deniedPrefixes: [".ssh", ".aws"]
+    )
+
+    XCTAssertTrue(ssh.hasPrefix("denied:"))
+    XCTAssertTrue(aws.hasPrefix("denied:"))
+    XCTAssertNotEqual(ssh, aws)
+  }
+
   func testOcrCacheAvoidsRecognizingSameDuplicateWhenSamplerEnabled() async throws {
     var cfg = Self.config()
     cfg.ocrDiffSamplerEnabled = true
@@ -827,6 +885,30 @@ final class PipelineTests: XCTestCase {
       timestamp: Date(),
       cgImage: image(bits: bits),
       displayId: 1,
+      displayScale: 2.0,
+      mainDisplay: true
+    )
+  }
+
+  static func processedFrame(
+    capturedAt: Date,
+    ocrText: String,
+    displayId: UInt32 = 1
+  ) -> ProcessedFrame {
+    ProcessedFrame(
+      frameHash: UUID().uuidString,
+      perceptualHash: 1,
+      capturedAt: capturedAt,
+      bundleId: "com.test.App",
+      appName: "TestApp",
+      windowTitle: "clean",
+      documentPath: nil,
+      ocrText: ocrText,
+      ocrConfidence: 0.9,
+      widthPx: 8,
+      heightPx: 8,
+      bytesPng: 8 * 8 * 4,
+      displayId: displayId,
       displayScale: 2.0,
       mainDisplay: true
     )


### PR DESCRIPTION
## Summary\n- fix sparse-frame redaction y-coordinate handling and recreate cached sessions whose directories disappeared\n- keep denied-path observation buckets specific to the matched default prefix\n- prevent idle fallback from ignoring more recent accepted activity\n- remove the exact "Max" protected-app false positive\n- keep capture FPS retries recoverable after a failed worker restart\n- keep the worker supervisor from allowing a second start while a process is terminating\n\nAddresses missed post-merge review feedback from evalops/agentd#58, #63, #64, #69, #70, #75, and #89.\n\n## Verification\n- swift test --filter CaptureWorkerSupervisorTests\n- swift test --filter EventCaptureSchedulerTests\n- swift test --filter ForegroundPrivacyPauseTests\n- swift test --filter PipelineTests/testSparseFrameVisualRedactorUsesBottomLeftVisionCoordinates --filter PipelineTests/testSparseFrameStoreRecreatesMissingCachedSessionDirectory --filter PipelineTests/testDeniedPathClassSeparatesDefaultDeniedPrefixes\n- xcrun swift-format lint --strict --recursive Sources Tests Package.swift\n- swift test\n- git diff --check