### PR TITLE
fix: address remaining capture review feedback

### DIFF
--- a/Sources/agentd/AccessibilityTextExtractor.swift
+++ b/Sources/agentd/AccessibilityTextExtractor.swift
@@ -50,11 +50,13 @@ enum AccessibilityTextExtractor {
     var stack: [(AXUIElement, Int)] = [(root, 0)]
     var textParts: [String] = []
     var seenText = Set<String>()
+    var seenElements = Set<CFHashCode>()
     var nodesVisited = 0
     var remainingChars = max(0, maxChars)
     var truncated = false
 
     while let (element, depth) = stack.popLast(), nodesVisited < maxNodes, remainingChars > 0 {
+      guard seenElements.insert(CFHash(element)).inserted else { continue }
       nodesVisited += 1
       for value in textValues(element) {
         let normalized = normalize(value)
@@ -70,8 +72,10 @@ enum AccessibilityTextExtractor {
       }
 
       guard depth < maxDepth, remainingChars > 0 else { continue }
-      var children = childElements(element, attribute: kAXChildrenAttribute)
-      children += childElements(element, attribute: kAXVisibleChildrenAttribute)
+      let children = uniqueChildren(
+        childElements(element, attribute: kAXChildrenAttribute)
+          + childElements(element, attribute: kAXVisibleChildrenAttribute)
+      )
       for child in children.reversed() {
         stack.append((child, depth + 1))
       }
@@ -122,6 +126,13 @@ enum AccessibilityTextExtractor {
       guard CFGetTypeID(value) == AXUIElementGetTypeID() else { return nil }
       // swift-format-ignore
       return (value as! AXUIElement)
+    }
+  }
+
+  private static func uniqueChildren(_ children: [AXUIElement]) -> [AXUIElement] {
+    var seen = Set<CFHashCode>()
+    return children.filter { child in
+      seen.insert(CFHash(child)).inserted
     }
   }
 

--- a/Sources/agentd/CaptureHealthWatchdog.swift
+++ b/Sources/agentd/CaptureHealthWatchdog.swift
@@ -12,13 +12,6 @@ struct CaptureHealthStats: Sendable, Equatable {
   let lastRestartAt: Date?
   let lastRestartDisplayId: UInt32?
   let lastRestartReason: String?
-
-  static let empty = CaptureHealthStats(
-    restartCount: 0,
-    lastRestartAt: nil,
-    lastRestartDisplayId: nil,
-    lastRestartReason: nil
-  )
 }
 
 struct CaptureHealthWatchdog: Sendable {

--- a/Sources/agentd/DiagnosticCLI.swift
+++ b/Sources/agentd/DiagnosticCLI.swift
@@ -694,7 +694,7 @@ enum SelftestDiagnostics {
     )
     return SelftestOutput(
       generatedAt: Date(),
-      permissions: DiagnosticPermissionSnapshot.current(promptForAccessibility: false),
+      permissions: displaySnapshot.permissions,
       displayProbe: displaySnapshot.displayProbe,
       displayCount: displaySnapshot.displays.count,
       configPath: ConfigStore.path.path,

--- a/Sources/agentd/EvalOpsContextMetadata.swift
+++ b/Sources/agentd/EvalOpsContextMetadata.swift
@@ -5,25 +5,13 @@ import Foundation
 struct EvalOpsContextMetadata: Sendable, Equatable {
   static let contextVersionKey = "evalops_context_version"
   static let expectedContextVersion = "evalops.context.v1"
-  static let maestroSessionIdKey = "maestro_session_id"
-  static let agentRunIdKey = "agent_run_id"
-  static let toolExecutionIdKey = "tool_execution_id"
-  static let traceIdKey = "trace_id"
   static let traceparentKey = "traceparent"
-  static let taskIdKey = "task_id"
-  static let sourceIssueKey = "source_issue"
 
   private static let traceparentRegex =
     try! NSRegularExpression(
       pattern: #"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$"#,
       options: []
     )
-
-  let values: [String: String]
-
-  init(_ metadata: [String: String]) {
-    values = Self.clean(metadata)
-  }
 
   static func clean(_ metadata: [String: String]) -> [String: String] {
     var cleaned: [String: String] = [:]

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -810,7 +810,11 @@ actor FramePipeline {
       let textSource: FrameTextSource
       let axText = accessibilityText.map { AccessibilityTextExtractor.normalize($0.text) } ?? ""
       if !axText.isEmpty {
-        ocrResult = OCRResult(text: axText, confidence: 1, language: nil)
+        let visualRegions =
+          config.sparseFrameVisualRedactionEnabled && sparseFrameStore != nil
+          ? (try? await ocr.recognize(cgImage: frame.cgImage).regions) ?? []
+          : []
+        ocrResult = OCRResult(text: axText, confidence: 1, language: nil, regions: visualRegions)
         textSource = .accessibility
       } else {
         let ocrCacheKey = ImageContentHash.calculate(cgImage: frame.cgImage).map {

--- a/Sources/agentd/main.swift
+++ b/Sources/agentd/main.swift
@@ -395,6 +395,7 @@ final class AppController {
       scheduleFlushTimer()
     }
     if captureRunning, captureScopeChanged {
+      captureHealthWatchdog.observeCaptureStopped()
       await capture.stop()
       captureRunning = false
       idleMode = false

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -844,6 +844,44 @@ final class PipelineTests: XCTestCase {
     XCTAssertEqual(batch.frames.first?.ocrText, "accessibility visible text")
   }
 
+  func testAccessibilityTextCollectsVisionRegionsForSparseFrameRedaction() async throws {
+    let root = try Self.temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    var cfg = Self.config()
+    cfg.sparseFrameStorageRoot = root.path
+    cfg.sparseFrameVisualRedactionEnabled = true
+    let recorder = BatchRecorder()
+    let ocr = CountingOCR(
+      text: "vision text",
+      regions: [
+        OCRTextRegion(
+          normalizedBoundingBox: CGRect(x: 0.25, y: 0.25, width: 0.5, height: 0.5))
+      ]
+    )
+    let pipeline = FramePipeline(config: cfg, ocr: ocr) { batch in
+      await recorder.append(batch)
+    }
+
+    await pipeline.consume(
+      Self.frame(bits: 0xAAAA_AAAA_AAAA_AAAA),
+      context: Self.context(),
+      accessibilityText: AccessibilityTextResult(
+        text: "accessibility text",
+        nodesVisited: 3,
+        truncated: false
+      )
+    )
+    await pipeline.flush()
+
+    let callCount = await ocr.callCount()
+    XCTAssertEqual(callCount, 1)
+    let batches = await recorder.snapshot()
+    let batch = try XCTUnwrap(batches.first)
+    let frame = try XCTUnwrap(batch.frames.first)
+    XCTAssertEqual(frame.ocrText, "accessibility text")
+    XCTAssertEqual(frame.ocrTextRegions.count, 1)
+  }
+
   func testEmptyAccessibilityTextFallsBackToVisionOcr() async throws {
     let recorder = BatchRecorder()
     let ocr = CountingOCR(text: "vision fallback")
@@ -1071,15 +1109,17 @@ actor SequenceOCR: OCRRecognizing {
 
 actor CountingOCR: OCRRecognizing {
   private let text: String
+  private let regions: [OCRTextRegion]
   private var calls = 0
 
-  init(text: String) {
+  init(text: String, regions: [OCRTextRegion] = []) {
     self.text = text
+    self.regions = regions
   }
 
   func recognize(cgImage: CGImage) async throws -> OCRResult {
     calls += 1
-    return OCRResult(text: text, confidence: 0.9, language: "en")
+    return OCRResult(text: text, confidence: 0.9, language: "en", regions: regions)
   }
 
   func callCount() -> Int {


### PR DESCRIPTION
## Summary
- dedupe Accessibility tree traversal by AX element identity so visible/normal child overlap does not burn node budget
- keep AX-sourced text while collecting Vision text regions only when sparse-frame visual redaction needs masking geometry
- reuse the display diagnostics permission snapshot in selftest, clear watchdog state before capture scope stops, and remove dead metadata/watchdog declarations

## Review feedback addressed
- evalops/agentd#48: remove unused EvalOpsContextMetadata initializer, values property, and unused key constants
- evalops/agentd#72: avoid duplicate AX child traversal and preserve sparse-frame visual redaction regions on AX text frames
- evalops/agentd#73: avoid running the permission snapshot twice in selftest
- evalops/agentd#74: remove CaptureHealthStats.empty and clear watchdog state on scope-change stops

## Verification
- swift test --filter "PipelineTests|DiagnosticCLITests|CaptureHealthWatchdogTests"
- swift test
- xcrun swift-format lint --strict --recursive Sources Tests Package.swift
- git diff --check