### PR TITLE
fix: anchor Chronicle domain matching

### DIFF
--- a/Sources/agentd/ChronicleBehavior.swift
+++ b/Sources/agentd/ChronicleBehavior.swift
@@ -338,13 +338,33 @@ enum ChronicleBehavior {
 
   private static func globMatches(_ pattern: String, _ value: String) -> Bool {
     let pattern = pattern.lowercased()
-    let value = value.lowercased()
-    if pattern == value || value.contains(pattern) {
-      return true
+    let candidates = matchCandidates(for: value)
+    if !pattern.contains("*") {
+      if pattern.contains("/") {
+        return candidates.contains(pattern)
+      }
+      return candidates.contains { candidate in
+        candidate == pattern || candidate.hasSuffix(".\(pattern)")
+      }
     }
     let escaped = NSRegularExpression.escapedPattern(for: pattern)
       .replacingOccurrences(of: "\\*", with: ".*")
-    return value.range(of: ".*\(escaped).*", options: .regularExpression) != nil
+    let expression = "^\(escaped)$"
+    return candidates.contains { candidate in
+      candidate.range(of: expression, options: .regularExpression) != nil
+    }
+  }
+
+  private static func matchCandidates(for value: String) -> [String] {
+    let value = value.lowercased()
+    var candidates = [value]
+    if let components = URLComponents(string: value), let host = components.host?.lowercased() {
+      candidates.append(host)
+      if !components.path.isEmpty {
+        candidates.append("\(host)\(components.path)")
+      }
+    }
+    return Array(Set(candidates))
   }
 
   private static func specificity(_ pattern: String) -> Int {

--- a/Tests/agentdTests/ChronicleBehaviorTests.swift
+++ b/Tests/agentdTests/ChronicleBehaviorTests.swift
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import XCTest
+
+@testable import agentd
+
+final class ChronicleBehaviorTests: XCTestCase {
+  func testPlainDomainTierDoesNotMatchDomainSubstring() {
+    let tiers = [DomainTier(pattern: "x.com", tier: .audit)]
+
+    XCTAssertEqual(
+      ChronicleBehavior.captureTier(for: "https://dropbox.com/files", domainTiers: tiers),
+      .evidence
+    )
+    XCTAssertEqual(
+      ChronicleBehavior.captureTier(for: "https://box.com/files", domainTiers: tiers),
+      .evidence
+    )
+    XCTAssertEqual(
+      ChronicleBehavior.captureTier(for: "https://x.com/home", domainTiers: tiers),
+      .audit
+    )
+    XCTAssertEqual(
+      ChronicleBehavior.captureTier(for: "https://mobile.x.com/home", domainTiers: tiers),
+      .audit
+    )
+  }
+
+  func testUrlGlobMatchesHostPathWithoutSubstringFallback() {
+    let tiers = [
+      DomainTier(pattern: "github.com/*/pull/*", tier: .audit)
+    ]
+
+    XCTAssertEqual(
+      ChronicleBehavior.captureTier(
+        for: "https://github.com/evalops/agentd/pull/102",
+        domainTiers: tiers
+      ),
+      .audit
+    )
+    XCTAssertEqual(
+      ChronicleBehavior.captureTier(
+        for: "https://notgithub.com/evalops/agentd/pull/102",
+        domainTiers: tiers
+      ),
+      .evidence
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- replace substring fallback in Chronicle glob matching with anchored candidate matching
- match plain domains against exact hosts/subdomains so `x.com` no longer catches `dropbox.com`/`box.com`
- add ChronicleBehavior coverage for domain-tier and URL glob boundaries

## Verification
- `swift test --filter ChronicleBehaviorTests`
- `swift test`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `git diff --check`

Addresses post-merge review feedback from evalops/agentd#102.