### PR TITLE
fix: restrict domain suffix matching to hosts

### DIFF
--- a/Sources/agentd/ChronicleBehavior.swift
+++ b/Sources/agentd/ChronicleBehavior.swift
@@ -343,9 +343,8 @@ enum ChronicleBehavior {
       if pattern.contains("/") {
         return candidates.contains(pattern)
       }
-      return candidates.contains { candidate in
-        candidate == pattern || candidate.hasSuffix(".\(pattern)")
-      }
+      guard let hostCandidate = hostMatchCandidate(for: value) else { return false }
+      return hostCandidate == pattern || hostCandidate.hasSuffix(".\(pattern)")
     }
     let escaped = NSRegularExpression.escapedPattern(for: pattern)
       .replacingOccurrences(of: "\\*", with: ".*")
@@ -365,6 +364,15 @@ enum ChronicleBehavior {
       }
     }
     return Array(Set(candidates))
+  }
+
+  private static func hostMatchCandidate(for value: String) -> String? {
+    let value = value.lowercased()
+    if let components = URLComponents(string: value), let host = components.host?.lowercased() {
+      return host
+    }
+    let host = value.split(separator: "/", maxSplits: 1).first.map(String.init) ?? value
+    return host.isEmpty ? nil : host
   }
 
   private static func specificity(_ pattern: String) -> Int {

--- a/Tests/agentdTests/ChronicleBehaviorTests.swift
+++ b/Tests/agentdTests/ChronicleBehaviorTests.swift
@@ -24,6 +24,10 @@ final class ChronicleBehaviorTests: XCTestCase {
       ChronicleBehavior.captureTier(for: "https://mobile.x.com/home", domainTiers: tiers),
       .audit
     )
+    XCTAssertEqual(
+      ChronicleBehavior.captureTier(for: "https://evil.com/config.x.com", domainTiers: tiers),
+      .evidence
+    )
   }
 
   func testUrlGlobMatchesHostPathWithoutSubstringFallback() {


### PR DESCRIPTION
## Summary

- restrict exact/subdomain domain-pattern suffix matching to the parsed host candidate
- keep path-aware glob patterns on the existing candidate set
- add coverage for URL paths that end with a configured domain but have a different host

## Verification

- swift test --filter ChronicleBehaviorTests
- swift test
- xcrun swift-format lint --strict --recursive Sources Tests Package.swift
- git diff --check

Addresses review feedback from evalops/agentd#105.