### PR TITLE
fix: avoid eager domain match candidate parsing

### DIFF
--- a/Sources/agentd/ChronicleBehavior.swift
+++ b/Sources/agentd/ChronicleBehavior.swift
@@ -338,14 +338,14 @@ enum ChronicleBehavior {
 
   private static func globMatches(_ pattern: String, _ value: String) -> Bool {
     let pattern = pattern.lowercased()
-    let candidates = matchCandidates(for: value)
     if !pattern.contains("*") {
       if pattern.contains("/") {
-        return candidates.contains(pattern)
+        return matchCandidates(for: value).contains(pattern)
       }
       guard let hostCandidate = hostMatchCandidate(for: value) else { return false }
       return hostCandidate == pattern || hostCandidate.hasSuffix(".\(pattern)")
     }
+    let candidates = matchCandidates(for: value)
     let escaped = NSRegularExpression.escapedPattern(for: pattern)
       .replacingOccurrences(of: "\\*", with: ".*")
     let expression = "^\(escaped)$"


### PR DESCRIPTION
## Summary

- avoid building URL/path match candidates for plain domain patterns
- keep candidate generation in the path and glob branches that actually use it

## Verification

- swift test --filter ChronicleBehaviorTests
- xcrun swift-format lint --strict --recursive Sources Tests Package.swift
- git diff --check

Addresses review feedback from evalops/agentd#107.