### PR TITLE
Track exact dropped frame reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ local inspection of the shipped arm64 `codex_chronicle` helper bundled with
   changes, clicks, typing pauses, scroll stops, clipboard updates, and idle
   fallback ticks behind `eventCaptureEnabled`, with debounce/min-gap counters in
   diagnostics.
+- Drop accounting includes both broad `droppedCounts` and per-reason
+  `droppedReasonCounts` such as `privacy.browser_meeting_window`,
+  `privacy.denied_path`, `duplicate.phash`, `secret.ocrText:*`, `tier.deny`,
+  and `backpressure.buffer_full`, so downstream rollups can explain why evidence
+  is absent without exposing the dropped content.
 - Continuous capture has a local health watchdog that restarts ScreenCaptureKit
   streams when active displays stop producing frames, with restart counts in
   diagnostics.

--- a/Sources/agentd/Diagnostics.swift
+++ b/Sources/agentd/Diagnostics.swift
@@ -100,6 +100,19 @@ enum DiagnosticsReport {
       "- Sparse frame visual redaction: \(snapshot.config.sparseFrameVisualRedactionEnabled)"
     )
     lines.append("")
+    lines.append("## Drop Reason Guide")
+    lines.append("")
+    lines.append("| Prefix | Meaning |")
+    lines.append("| --- | --- |")
+    lines.append(
+      "| `privacy.*` | Window/app/path policy denied capture before OCR or persistence. |")
+    lines.append("| `tier.deny` | Domain tier policy explicitly denied this document surface. |")
+    lines.append("| `secret.*` | SecretScrubber found sensitive material and dropped the frame. |")
+    lines.append(
+      "| `duplicate.*` | Perceptual hash or OCR-diff sampling suppressed repeated content. |")
+    lines.append(
+      "| `backpressure.*` | In-memory dispatch pressure dropped frames before processing. |")
+    lines.append("")
     lines.append("## Event Capture")
     lines.append("")
     lines.append("| Trigger | Count |")

--- a/Sources/agentd/Pipeline.swift
+++ b/Sources/agentd/Pipeline.swift
@@ -176,6 +176,7 @@ struct Batch: Sendable, Codable {
   let captureWindow: CaptureWindow
   let frames: [ProcessedFrame]
   let droppedCounts: DropCounts
+  let droppedReasonCounts: [String: Int]
   let emittedCounts: EmittedCounts
 
   init(
@@ -192,6 +193,7 @@ struct Batch: Sendable, Codable {
     captureWindow: CaptureWindow? = nil,
     frames: [ProcessedFrame],
     droppedCounts: DropCounts,
+    droppedReasonCounts: [String: Int] = [:],
     emittedCounts: EmittedCounts = .empty
   ) {
     self.batchId = batchId
@@ -207,6 +209,7 @@ struct Batch: Sendable, Codable {
     self.captureWindow = captureWindow ?? CaptureWindow(startedAt: startedAt, endedAt: endedAt)
     self.frames = frames
     self.droppedCounts = droppedCounts
+    self.droppedReasonCounts = droppedReasonCounts
     self.emittedCounts = emittedCounts
   }
 
@@ -224,6 +227,7 @@ struct Batch: Sendable, Codable {
     case captureWindow
     case frames
     case droppedCounts
+    case droppedReasonCounts
     case emittedCounts
   }
 
@@ -245,6 +249,10 @@ struct Batch: Sendable, Codable {
       captureWindow: try container.decodeIfPresent(CaptureWindow.self, forKey: .captureWindow),
       frames: try container.decode([ProcessedFrame].self, forKey: .frames),
       droppedCounts: try container.decode(DropCounts.self, forKey: .droppedCounts),
+      droppedReasonCounts: try container.decodeIfPresent(
+        [String: Int].self,
+        forKey: .droppedReasonCounts
+      ) ?? [:],
       emittedCounts: try container.decodeIfPresent(EmittedCounts.self, forKey: .emittedCounts)
         ?? .empty
     )
@@ -720,6 +728,7 @@ actor FramePipeline {
   private var droppedDeniedApp = 0
   private var droppedDeniedPath = 0
   private var droppedBackpressure = 0
+  private var droppedReasonCounts: [String: Int] = [:]
 
   private let onBatch: @Sendable (Batch) async -> SubmitResult
 
@@ -746,7 +755,7 @@ actor FramePipeline {
   }
 
   func recordBackpressureDrop() {
-    droppedBackpressure += 1
+    recordDrop(reason: "backpressure.buffer_full", kind: nil)
   }
 
   func pendingStats() -> PendingFrameStats {
@@ -778,12 +787,7 @@ actor FramePipeline {
       )
     }
     guard privacyDecision.allowed else {
-      switch privacyDecision.dropKind {
-      case .deniedPath:
-        droppedDeniedPath += 1
-      case .deniedApp, nil:
-        droppedDeniedApp += 1
-      }
+      recordDrop(reason: "privacy.\(privacyDecision.reasonCode)", kind: privacyDecision.dropKind)
       return
     }
 
@@ -792,14 +796,14 @@ actor FramePipeline {
       domainTiers: config.domainTiers
     )
     if captureTier == .deny {
-      droppedDeniedPath += 1
+      recordDrop(reason: "tier.deny", kind: .deniedPath)
       return
     }
 
     guard let phash = PerceptualHash(cgImage: frame.cgImage) else { return }
     let duplicateByHash = dedupWindow.containsDuplicate(of: phash)
     if duplicateByHash, !config.ocrDiffSamplerEnabled {
-      droppedDup += 1
+      recordDrop(reason: "duplicate.phash", kind: nil)
       return
     }
 
@@ -841,7 +845,7 @@ actor FramePipeline {
 
     switch evaluateSecretSurfaces(context: ctx, ocrText: ocrResult.text) {
     case .dropped(let reason):
-      droppedSecret += 1
+      recordDrop(reason: "secret.\(reason)", kind: nil)
       Log.scrub.warning("frame dropped secret=\(reason, privacy: .public)")
       return
     case .clean:
@@ -858,7 +862,7 @@ actor FramePipeline {
       {
         Log.capture.info("ocr diff sampler emitted pHash duplicate frame")
       } else {
-        droppedDup += 1
+        recordDrop(reason: "duplicate.phash", kind: nil)
         return
       }
     }
@@ -942,6 +946,7 @@ actor FramePipeline {
         deniedPath: droppedDeniedPath,
         droppedBackpressure: droppedBackpressure
       ),
+      droppedReasonCounts: droppedReasonCounts,
       emittedCounts: ChronicleBehavior.emittedCounts(
         for: batchFrames,
         classification: config.behavioralClassification,
@@ -954,6 +959,7 @@ actor FramePipeline {
     droppedDeniedApp = 0
     droppedDeniedPath = 0
     droppedBackpressure = 0
+    droppedReasonCounts.removeAll(keepingCapacity: true)
     startedAt = Date()
     let result = await onBatch(batch)
     guard case .failed = result else { return }
@@ -963,11 +969,34 @@ actor FramePipeline {
     droppedDeniedApp += batch.droppedCounts.deniedApp
     droppedDeniedPath += batch.droppedCounts.deniedPath
     droppedBackpressure += batch.droppedCounts.droppedBackpressure
+    for (reason, count) in batch.droppedReasonCounts {
+      droppedReasonCounts[reason, default: 0] += count
+    }
     startedAt = min(startedAt, batch.startedAt)
   }
 
   private func hasDrops() -> Bool {
     droppedSecret + droppedDup + droppedDeniedApp + droppedDeniedPath + droppedBackpressure > 0
+  }
+
+  private func recordDrop(reason: String, kind: PrivacyDropKind?) {
+    switch kind {
+    case .deniedPath:
+      droppedDeniedPath += 1
+    case .deniedApp:
+      droppedDeniedApp += 1
+    case nil:
+      if reason.hasPrefix("secret.") {
+        droppedSecret += 1
+      } else if reason.hasPrefix("duplicate.") {
+        droppedDup += 1
+      } else if reason.hasPrefix("backpressure.") {
+        droppedBackpressure += 1
+      } else {
+        droppedDeniedApp += 1
+      }
+    }
+    droppedReasonCounts[reason, default: 0] += 1
   }
 
   private func evaluateSecretSurfaces(context: WindowContext, ocrText: String)

--- a/Tests/agentdTests/DiagnosticsTests.swift
+++ b/Tests/agentdTests/DiagnosticsTests.swift
@@ -113,6 +113,9 @@ final class DiagnosticsTests: XCTestCase {
     XCTAssertTrue(report.contains("Capture health restarts: 1"))
     XCTAssertTrue(report.contains("Last capture health restart display: 42"))
     XCTAssertTrue(report.contains("Last capture health restart reason: stale frame stream"))
+    XCTAssertTrue(report.contains("## Drop Reason Guide"))
+    XCTAssertTrue(report.contains("`privacy.*`"))
+    XCTAssertTrue(report.contains("`secret.*`"))
     XCTAssertTrue(report.contains("| focusedWindow | 2 |"))
     XCTAssertTrue(report.contains("| batch_1 |"))
     XCTAssertTrue(

--- a/Tests/agentdTests/PipelineTests.swift
+++ b/Tests/agentdTests/PipelineTests.swift
@@ -22,6 +22,7 @@ final class PipelineTests: XCTestCase {
     let batch = try XCTUnwrap(batches.first)
     XCTAssertEqual(batch.frames.count, 0)
     XCTAssertEqual(batch.droppedCounts.secret, 1)
+    XCTAssertEqual(batch.droppedReasonCounts["secret.windowTitle:aws_access_key"], 1)
   }
 
   func testDocumentPathSecretDropsFrame() async throws {
@@ -60,6 +61,7 @@ final class PipelineTests: XCTestCase {
     XCTAssertEqual(batch.frames.count, 0)
     XCTAssertEqual(batch.droppedCounts.deniedPath, 1)
     XCTAssertEqual(batch.droppedCounts.secret, 0)
+    XCTAssertEqual(batch.droppedReasonCounts["privacy.denied_path"], 1)
   }
 
   func testOcrTextIsCappedAfterFullTextSecretScan() async throws {
@@ -248,6 +250,7 @@ final class PipelineTests: XCTestCase {
     let batch = try XCTUnwrap(batches.first)
     XCTAssertEqual(batch.frames.count, 0)
     XCTAssertEqual(batch.droppedCounts.deniedApp, 1)
+    XCTAssertEqual(batch.droppedReasonCounts["privacy.denied_bundle"], 1)
   }
 
   func testPauseWindowTitleBeatsAllowedBundle() async throws {
@@ -363,6 +366,7 @@ final class PipelineTests: XCTestCase {
     let batch = try XCTUnwrap(batches.first)
     XCTAssertEqual(batch.frames.count, 1)
     XCTAssertEqual(batch.droppedCounts.duplicate, 1)
+    XCTAssertEqual(batch.droppedReasonCounts["duplicate.phash"], 1)
   }
 
   func testOcrDiffSamplerStaysDisabledByDefault() async throws {
@@ -647,6 +651,64 @@ final class PipelineTests: XCTestCase {
     XCTAssertTrue(second.allowed)
     XCTAssertTrue(second.cached)
     XCTAssertEqual(first.observationId, second.observationId)
+  }
+
+  func testBatchDroppedReasonCountsRoundTripAsOptionalWireField() throws {
+    let batch = Batch(
+      batchId: "batch_1",
+      deviceId: "device_1",
+      organizationId: "org_1",
+      workspaceId: nil,
+      userId: nil,
+      projectId: nil,
+      repository: nil,
+      startedAt: Date(timeIntervalSince1970: 1),
+      endedAt: Date(timeIntervalSince1970: 2),
+      frames: [],
+      droppedCounts: DropCounts(
+        secret: 1,
+        duplicate: 2,
+        deniedApp: 3,
+        deniedPath: 4,
+        droppedBackpressure: 5
+      ),
+      droppedReasonCounts: [
+        "secret.ocrText:openai_api_key": 1,
+        "privacy.browser_meeting_window": 3,
+      ]
+    )
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(batch)
+    let raw = String(data: data, encoding: .utf8) ?? ""
+    XCTAssertTrue(raw.contains("droppedReasonCounts"))
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let decoded = try decoder.decode(Batch.self, from: data)
+    XCTAssertEqual(decoded.droppedReasonCounts["privacy.browser_meeting_window"], 3)
+
+    let legacy = """
+      {
+        "batchId": "legacy",
+        "deviceId": "device_1",
+        "organizationId": "org_1",
+        "metadata": {},
+        "startedAt": "1970-01-01T00:00:01Z",
+        "endedAt": "1970-01-01T00:00:02Z",
+        "frames": [],
+        "droppedCounts": {
+          "secret": 0,
+          "duplicate": 0,
+          "deniedApp": 0,
+          "deniedPath": 0,
+          "droppedBackpressure": 0
+        }
+      }
+      """.data(using: .utf8)!
+    let legacyDecoded = try decoder.decode(Batch.self, from: legacy)
+    XCTAssertEqual(legacyDecoded.droppedReasonCounts, [:])
   }
 
   func testPrivacyDecisionCacheInvalidatesWhenTitleClassChanges() {


### PR DESCRIPTION
## Summary
- add `droppedReasonCounts` to local batch JSON while preserving legacy decode
- record exact drop reason codes for privacy, tier deny, secret scrub, duplicates, and backpressure
- document the reason-code prefixes in README and diagnostics output

## Validation
- `swift build -Xswiftc -warnings-as-errors`
- `swift test`
- `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
- `python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle`
- `git diff --check`

Related: #39