### PR TITLE
release: bump agentd to v0.0.2

### DIFF
--- a/support/Info.plist
+++ b/support/Info.plist
@@ -13,9 +13,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleVersion</key>
-    <string>0.0.1</string>
+    <string>0.0.2</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.0.1</string>
+    <string>0.0.2</string>
     <key>LSUIElement</key>
     <true/>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary
- bump agentd bundle version to 0.0.2 so Sparkle can exercise an end-to-end update from v0.0.1

## Validation
- swift test
- python3 scripts/sparkle_appcast.py self-test
- git diff --check