### PR TITLE
Fix capture recovery and default allowlist

### DIFF
--- a/Sources/agentd/CaptureWorkerSupervisor.swift
+++ b/Sources/agentd/CaptureWorkerSupervisor.swift
@@ -3,6 +3,12 @@
 import Darwin
 import Foundation
 
+protocol CaptureWorkerRunningState: AnyObject {
+  var isRunning: Bool { get }
+}
+
+extension Process: CaptureWorkerRunningState {}
+
 struct CaptureWorkerProcessSpec {
   let executableURL: URL
   let arguments: [String]
@@ -216,7 +222,6 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
 
   private func reapExitedProcessIfNeededLocked() {
     guard let current = process, !current.isRunning else { return }
-    current.waitUntilExit()
     process = nil
     if terminatingProcess === current {
       terminatingProcess = nil
@@ -238,14 +243,21 @@ final class CaptureWorkerSupervisor: @unchecked Sendable {
     }
   }
 
-  private static func wait(for process: Process, timeoutSeconds: TimeInterval) -> Bool {
+  static func waitUntilNotRunning(
+    _ process: CaptureWorkerRunningState,
+    timeoutSeconds: TimeInterval,
+    sleep: (TimeInterval) -> Void = { Thread.sleep(forTimeInterval: $0) }
+  ) -> Bool {
     let deadline = Date().addingTimeInterval(max(0, timeoutSeconds))
     while process.isRunning {
       let remaining = deadline.timeIntervalSinceNow
       guard remaining > 0 else { return false }
-      Thread.sleep(forTimeInterval: min(0.01, remaining))
+      sleep(min(0.01, remaining))
     }
-    process.waitUntilExit()
     return true
+  }
+
+  private static func wait(for process: Process, timeoutSeconds: TimeInterval) -> Bool {
+    waitUntilNotRunning(process, timeoutSeconds: timeoutSeconds)
   }
 }

--- a/Sources/agentd/Config.swift
+++ b/Sources/agentd/Config.swift
@@ -506,6 +506,7 @@ struct AgentConfig: Codable, Sendable {
     "com.openai.codex",
     "com.openai.chat",
     "com.anthropic.claudefordesktop",
+    "com.apple.finder",
     "company.thebrowser.Browser",  // Arc
     "com.google.Chrome",
     "com.google.Chrome.beta",

--- a/Tests/agentdTests/CaptureWorkerSupervisorTests.swift
+++ b/Tests/agentdTests/CaptureWorkerSupervisorTests.swift
@@ -6,6 +6,32 @@ import XCTest
 @testable import agentd
 
 final class CaptureWorkerSupervisorTests: XCTestCase {
+  func testWaitUntilNotRunningReturnsWithoutReapingExitedProcess() {
+    let process = StubRunningState(isRunning: false)
+    var sleepCalls = 0
+
+    let exited = CaptureWorkerSupervisor.waitUntilNotRunning(
+      process,
+      timeoutSeconds: 10,
+      sleep: { _ in sleepCalls += 1 }
+    )
+
+    XCTAssertTrue(exited)
+    XCTAssertEqual(sleepCalls, 0)
+  }
+
+  func testWaitUntilNotRunningTimesOutWithoutBlocking() {
+    let process = StubRunningState(isRunning: true)
+
+    let exited = CaptureWorkerSupervisor.waitUntilNotRunning(
+      process,
+      timeoutSeconds: 0,
+      sleep: { _ in XCTFail("zero-timeout wait should not sleep") }
+    )
+
+    XCTAssertFalse(exited)
+  }
+
   func testTerminatesWorkerWithTermDuringGraceWindow() throws {
     let supervisor = CaptureWorkerSupervisor()
     let output = Pipe()
@@ -182,5 +208,13 @@ private final class ReadyLineBuffer: @unchecked Sendable {
       buffer.append(data)
       return String(data: buffer, encoding: .utf8)?.contains("ready\n") == true
     }
+  }
+}
+
+private final class StubRunningState: CaptureWorkerRunningState {
+  let isRunning: Bool
+
+  init(isRunning: Bool) {
+    self.isRunning = isRunning
   }
 }

--- a/Tests/agentdTests/SubmitterTests.swift
+++ b/Tests/agentdTests/SubmitterTests.swift
@@ -88,6 +88,7 @@ final class SubmitterTests: XCTestCase {
     XCTAssertTrue(cfg.allowedBundleIds.contains("com.openai.chat"))
     XCTAssertTrue(cfg.allowedBundleIds.contains("com.anthropic.claudefordesktop"))
     XCTAssertTrue(cfg.allowedBundleIds.contains("com.mitchellh.ghostty"))
+    XCTAssertTrue(cfg.allowedBundleIds.contains("com.apple.finder"))
     XCTAssertEqual(cfg.maxOcrTextChars, 4096)
     XCTAssertEqual(cfg.maxBatchBytes, 512 * 1024 * 1024)
 


### PR DESCRIPTION
## Summary
- add Finder to the global default capture allowlist alongside Codex and Ghostty
- remove unbounded Process.waitUntilExit() calls from capture-worker recovery bookkeeping
- add regression coverage for the default allowlist and nonblocking supervisor wait loop

## Verification
- swift test
- swift build -Xswiftc -warnings-as-errors
- swift-format lint --strict --recursive Sources Tests Package.swift
- python3 scripts/mock_chronicle.py --self-test Tests/Fixtures/chronicle
- scripts/package_app.sh
- installed patched app via scripts/permission_smoke.sh and verified selftest permissions + fresh local batch output