### PR TITLE
fix: dispatch release PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: ci
 
 on:
   pull_request:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   issues: write
   pull-requests: write
@@ -31,6 +32,36 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
+
+      - name: Dispatch CI for Release Please PRs
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRS_JSON: ${{ steps.release.outputs.prs }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          branches_file="$RUNNER_TEMP/release-pr-branches.txt"
+          python3 - <<'PY' > "$branches_file"
+          import json
+          import os
+
+          prs = json.loads(os.environ.get("PRS_JSON") or "[]")
+          for pr in prs:
+              branch = pr.get("headBranchName")
+              if branch:
+                  print(branch)
+          PY
+
+          if [[ ! -s "$branches_file" ]]; then
+            echo "::error::Release Please reported PRs but did not expose any headBranchName values."
+            exit 1
+          fi
+
+          while IFS= read -r branch; do
+            echo "Dispatching ci.yml for $branch"
+            gh workflow run ci.yml --repo "$REPO" --ref "$branch"
+          done < "$branches_file"
 
   package-release:
     name: package release

--- a/docs/release-update-channel.md
+++ b/docs/release-update-channel.md
@@ -69,8 +69,10 @@ non-Conventional titles are invisible to Release Please. Use titles such as
 For bot-created release PR branches to trigger normal PR checks, configure the
 optional `AGENTD_RELEASE_TOKEN` secret with a fine-grained token that can push
 branches and open pull requests in this repository. Without it, Release Please
-falls back to `GITHUB_TOKEN`; that can still update GitHub state, but events
-created by `GITHUB_TOKEN` may not start follow-on workflows.
+falls back to `GITHUB_TOKEN`; in that mode `release-please` explicitly
+dispatches `ci.yml` for the generated release PR branch because
+`workflow_dispatch` is the GitHub-supported exception for workflows triggered
+with `GITHUB_TOKEN`.
 
 For local appcast fixture testing without notarization, set
 `AGENTD_SPARKLE_ALLOW_UNNOTARIZED=1`; do not use that override in release


### PR DESCRIPTION
## Summary
- allow `ci.yml` to be triggered with `workflow_dispatch`
- let the `release-please` workflow dispatch CI for generated release PR branches when it falls back to `GITHUB_TOKEN`
- document why this keeps Release Please PRs from getting stuck without normal pull_request events

## Test plan
- `actionlint`
- `python3 scripts/validate_release_metadata.py`
- `python3 scripts/validate_pr_title.py 'fix: dispatch release PR CI'`
- `git diff --check`
