### PR TITLE
ci: set retention on uploaded workflow artifacts

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -232,6 +232,7 @@ jobs:
       - name: Upload notarized artifacts
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 14
           name: ${{ inputs.artifact_name }}-${{ github.sha }}
           path: |
             dist/EvalOps agentd.app


### PR DESCRIPTION
## Summary
- set explicit retention on GitHub Actions upload-artifact steps
- keep CI/release diagnostic artifacts from falling back to repo defaults

## Test plan
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' <changed workflows>
- git diff --check
